### PR TITLE
Extra setttings for MacOS PKG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         if: runner.os == 'macOS'
         run:
           for var in APPLEID APPLEIDPASS APPLETEAMID CSC_LINK CSC_KEY_PASSWORD; do test -n "${!var}" || unset $var; done;
-          npm run build:app -- -- -- dmg --publish never --${{ matrix.arch }}
+          npm run build:app -- -- -- dmg pkg --publish never --${{ matrix.arch }}
         env:
           APPLEID: ${{ secrets.APPLEID }}
           APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
@@ -151,6 +151,9 @@ jobs:
           rm -f *.blockmap
           find . -name '*.dmg' ! -name '*-arm64.dmg' ! -name '*-amd64.dmg' | while read -r f; do
             mv -f "$f" "${f%.dmg}-amd64.dmg"
+          done
+          find . -name '*.pkg' ! -name '*-arm64.pkg' ! -name '*-amd64.pkg' | while read -r f; do
+            mv -f "$f" "${f%.pkg}-amd64.pkg"
           done
           find . -name '*Setup*' | while read -r f; do
             mv -f "$f" "${f/ Setup /-}"

--- a/LICENSE
+++ b/LICENSE
@@ -4,11 +4,6 @@ Copyright (c) 2022 OpenLens Authors.
 
 Portions of this software are licensed as follows:
 
-* All content residing under the "docs/" directory of this repository, if that
-directory exists, is licensed under "Creative Commons: CC BY-SA 4.0 license".
-* Content outside of the above mentioned directories or restrictions above is
-available under the "MIT" license as defined below.
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/freelens/package.json
+++ b/freelens/package.json
@@ -144,6 +144,9 @@
         }
       ]
     },
+    "pkg": {
+      "license": "../LICENSE"
+    },
     "win": {
       "target": [
         "nsis"


### PR DESCRIPTION
It'll be used when `npm run build:app -- -- -- pkg` runs.