### PR TITLE
Fix integration tests on Ubuntu (chrome-sandbox)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -101,6 +101,8 @@ jobs:
           max_attempts: 3
           retry_on: timeout
           command: npm run test:integration
+        env:
+          DEBUG: pw:browser
 
       - name: Clean after tests
         run: npm run clean

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -86,7 +86,12 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           retry_on: timeout
-          command: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run test:integration
+          command: |
+            sudo chown root:root freelens/dist/linux-unpacked/chrome-sandbox
+            sudo chmod 4755 freelens/dist/linux-unpacked/chrome-sandbox
+            xvfb-run -a npm run test:integration
+        env:
+          DEBUG: pw:browser
 
       - name: Run integration tests (macOS, Windows)
         if: runner.os != 'Linux'

--- a/freelens/package.json
+++ b/freelens/package.json
@@ -37,7 +37,7 @@
     "dev-run": "nodemon --watch ./static/build/main.js --exec \"electron --remote-debugging-port=9223 --inspect .\"",
     "dev:main": "cross-env NODE_ENV=development webpack --config webpack/main.ts --progress --watch",
     "dev:renderer": "cross-env NODE_ENV=development ts-node ./webpack/dev-server.ts",
-    "test:integration": "jest -xyz --runInBand --modulePaths=[\"<rootDir>/integration/\"]",
+    "test:integration": "jest -xyz --runInBand --detectOpenHandles --modulePaths=[\"<rootDir>/integration/\"]",
     "build:tray-icons": "npm run --workspace @freelensapp/generate-tray-icons generate -- --output static/build/tray --input @freelensapp/icon/icons/logo-lens.svg --notice-icon @freelensapp/icon/icons/notice.svg --spinner-icon @freelensapp/icon/icons/arrow-spinner.svg",
     "download:binaries": "npm run --workspace @freelensapp/ensure-binaries ensure -- --package package.json --base-dir binaries/client",
     "postinstall": "electron-rebuild"


### PR DESCRIPTION
Without extra suid for `chrome-sandbox` integration tests break on Ubuntu with error:

> The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /home/runner/work/freelens/freelens/freelens/dist/linux-unpacked/chrome-sandbox is owned by root and has mode 4755.

It looks like regression introduced by some update in Github Actions ubuntu-latest.

TODO: The same fix for https://github.com/freelensapp/freelens-node-pod-menu