### PR TITLE
Less verbose About window

### DIFF
--- a/packages/core/src/features/application-menu/main/menu-items/special-menu-for-mac-application/show-about-application/show-about.injectable.ts
+++ b/packages/core/src/features/application-menu/main/menu-items/special-menu-for-mac-application/show-about-application/show-about.injectable.ts
@@ -31,6 +31,7 @@ const showAboutInjectable = getInjectable({
         `Electron: ${process.versions.electron}`,
         `Chrome: ${process.versions.chrome}`,
         `Node: ${process.versions.node}`,
+        `Platform: ${process.platform}`,
         `Architecture: ${process.arch}`,
         applicationCopyright,
       ];

--- a/packages/core/src/features/application-menu/main/menu-items/special-menu-for-mac-application/show-about-application/show-about.injectable.ts
+++ b/packages/core/src/features/application-menu/main/menu-items/special-menu-for-mac-application/show-about-application/show-about.injectable.ts
@@ -1,4 +1,5 @@
 /**
+ * Copyright (c) Freelens Authors. All rights reserved.
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
@@ -9,7 +10,6 @@ import appNameInjectable from "../../../../../../common/vars/app-name.injectable
 import productNameInjectable from "../../../../../../common/vars/product-name.injectable";
 import extensionApiVersionInjectable from "../../../../../../common/vars/extension-api-version.injectable";
 import applicationCopyrightInjectable from "../../../../../../common/vars/application-copyright.injectable";
-import specificVersionsInjectable from "./about-bundled-extensions.injectable";
 import { buildVersionInitializable } from "../../../../../vars/build-version/common/token";
 
 const showAboutInjectable = getInjectable({
@@ -23,7 +23,6 @@ const showAboutInjectable = getInjectable({
     const appName = di.inject(appNameInjectable);
     const productName = di.inject(productNameInjectable);
     const applicationCopyright = di.inject(applicationCopyrightInjectable);
-    const specificVersions = di.inject(specificVersionsInjectable);
 
     return () => {
       const appInfo = [
@@ -32,26 +31,14 @@ const showAboutInjectable = getInjectable({
         `Electron: ${process.versions.electron}`,
         `Chrome: ${process.versions.chrome}`,
         `Node: ${process.versions.node}`,
+        `Architecture: ${process.arch}`,
         applicationCopyright,
       ];
-
-      if (specificVersions.length > 0) {
-        appInfo.push(
-          "",
-          "",
-          ...specificVersions,
-        );
-      }
 
       showMessagePopup(
         `${isWindows ? " ".repeat(2) : ""}${appName}`,
         productName,
         appInfo.join("\r\n"),
-        {
-          textWidth: specificVersions.length > 0
-            ? 300
-            : undefined,
-        },
       );
     };
   },


### PR DESCRIPTION
Fixes #44 

<img width="276" alt="image" src="https://github.com/user-attachments/assets/486fbe09-aceb-42ef-aef3-f9e362212386">

The original listing of all modules was too verbose and causes that "Close" button was not visible on Linux (Ubuntu with Gnome).
