### PR TITLE
License document that should be detected correctly by Github

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,8 +4,6 @@ Copyright (c) 2024 Freelens Authors.
 
 Copyright (c) 2022 OpenLens Authors.
 
-Portions of this software are licensed as follows:
-
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to

--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,24 @@
+MIT License
+
 Copyright (c) 2024 Freelens Authors.
 
 Copyright (c) 2022 OpenLens Authors.
 
 Portions of this software are licensed as follows:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -60,4 +60,8 @@ Anyone is welcome to collaborate to advance the Freelens project.
 
 ## License
 
-This source code is available to everyone under the [MIT license](./LICENSE).
+Copyright (c) 2024 Freelens Authors.
+
+Copyright (c) 2022 OpenLens Authors.
+
+[MIT License](https://opensource.org/licenses/MIT)

--- a/license-header
+++ b/license-header
@@ -1,5 +1,0 @@
-/**
- * SPDX-License-Identifier: MIT
- * Copyright (c) Freelens Authors. All rights reserved.
- * See LICENSE in root directory for more information.
- */

--- a/license-header
+++ b/license-header
@@ -1,4 +1,4 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Licensed under MIT License. See LICENSE in root directory for more information.
+ * Licensed under MIT license. See LICENSE in root directory for more information.
  */

--- a/license-header
+++ b/license-header
@@ -1,4 +1,5 @@
 /**
+ * MIT License.
  * Copyright (c) Freelens Authors. All rights reserved.
- * Licensed under MIT license. See LICENSE in root directory for more information.
+ * See LICENSE in root directory for more information.
  */

--- a/license-header
+++ b/license-header
@@ -1,5 +1,5 @@
 /**
- * MIT License.
+ * SPDX-License-Identifier: MIT
  * Copyright (c) Freelens Authors. All rights reserved.
  * See LICENSE in root directory for more information.
  */


### PR DESCRIPTION
Currently Github shows that license is Unknown

Using https://github.com/licensee/licensee:

Before:

```
License:        NOASSERTION
Matched files:  LICENSE, license-header, README.md
LICENSE:
  Content hash:  176490e49c30fdcd4d93c0b15bc87cc239054307
  License:       NOASSERTION
  Closest non-matching licenses:
    MIT similarity:    93.47%
    MIT-0 similarity:  72.10%
    NCSA similarity:   59.66%
license-header:
  Content hash:  5419233269643fcfb748d1a4464de95798b9bc5f
  License:       NOASSERTION
  Closest non-matching licenses:
    WTFPL similarity:  3.85%
    0BSD similarity:   1.96%
    ISC similarity:    1.74%
README.md:
  Content hash:  132a12043d3270343cc41b39fa8bc2552e779c96
  Confidence:    90.00%
  Matcher:       Licensee::Matchers::Reference
  License:       MIT
  Closest non-matching licenses:
    WTFPL similarity:  11.11%
    0BSD similarity:   3.85%
    Zlib similarity:   3.72%
```

After:

```
License:        MIT
Matched files:  LICENSE, README.md
LICENSE:
  Content hash:  4c2c763d64bbc7ef2e58b0ec6d06d90cee9755c9
  Attribution:   Copyright (c) 2024 Freelens Authors.

Copyright (c) 2022 OpenLens Authors.
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT
README.md:
  Content hash:  da39a3ee5e6b4b0d3255bfef95601890afd80709
  Attribution:   Copyright (c) 2024 Freelens Authors.

Copyright (c) 2022 OpenLens Authors.
  Confidence:    90.00%
  Matcher:       Licensee::Matchers::Reference
  License:       MIT
  Closest non-matching licenses:
    Zlib similarity:   0.00%
    WTFPL similarity:  0.00%
    Vim similarity:    0.00%
```
