### PR TITLE
Push by github_actions won't trigger checks

### DIFF
--- a/.github/workflows/compute-versions.yaml
+++ b/.github/workflows/compute-versions.yaml
@@ -69,13 +69,8 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit: --cleanup=verbatim
           default_author: github_actions
-          message: |
-            Automated update of kubectl versions
-
-
-            request-checks: true
+          message: Automated update of kubectl versions
           new_branch: update/kubectl-compute-versions
           pull: --rebase --autostash
           push: origin update/kubectl-compute-versions --set-upstream --force


### PR DESCRIPTION
Some solution might be using a dedicated author of the commit.

Updates of kubectl versions are potentially safe, so maybe we can leave the PRs unchecked.