### PR TITLE
CI: notarytool must be now the default as altool has been decommissioned

### DIFF
--- a/freelens/build/notarize.js
+++ b/freelens/build/notarize.js
@@ -24,6 +24,6 @@ exports.default = async function notarizing(context) {
     appleIdPassword: process.env.APPLEIDPASS,
     ascProvider: process.env.ASCPROVIDER,
     teamId: process.env.APPLETEAMID,
-    tool: process.env.NOTARIZE_TOOL || "legacy",
+    tool: process.env.NOTARIZE_TOOL || "notarytool",
   });
 };


### PR DESCRIPTION
The default setting causes:

```
  • signing         file=dist/mac/Freelens.app identityName=Developer ID Application: *** (TFR6NT55MB) identityHash=83CA6BAC095C2A693F3AE78ED335D80C58CE2059 provisioningProfile=none
  ⨯ Failed to upload app to Apple's notarization servers

2024-11-03 20:33:41.632 *** Error: Unable to upload your app for notarization.
2024-11-03 20:33:41.633 *** Error: Notarization of MacOS applications using altool has been decommissioned. Please use notarytool. See: https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool (-1031)
  failedTask=build stackTrace=Error: Failed to upload app to Apple's notarization servers
```

It doesn't make sense to keep the current setting as the default as it is not possible to use it anymore.
