### PR TITLE
Separate license file for binaries

### DIFF
--- a/LICENSE-binaries
+++ b/LICENSE-binaries
@@ -1,0 +1,60 @@
+MIT License
+
+Copyright (c) 2024-2025 Freelens Authors.
+
+Copyright (c) 2022 OpenLens Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+The binary package includes:
+
+
+kubectl
+
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+
+Helm
+
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/freelens/package.json
+++ b/freelens/package.json
@@ -153,11 +153,11 @@
         "--ozone-platform-hint=auto",
         "--no-sandbox"
       ],
-      "license": "../LICENSE"
+      "license": "../LICENSE-binaries"
     },
     "flatpak": {
       "useWaylandFlags": true,
-      "license": "../LICENSE"
+      "license": "../LICENSE-binaries"
     },
     "snap": {
       "allowNativeWayland": true,
@@ -187,7 +187,7 @@
       ]
     },
     "pkg": {
-      "license": "../LICENSE"
+      "license": "../LICENSE-binaries"
     },
     "win": {
       "appId": "app.freelens.Freelens",
@@ -215,7 +215,7 @@
       "allowElevation": true,
       "createStartMenuShortcut": true,
       "allowToChangeInstallationDirectory": true,
-      "license": "../LICENSE"
+      "license": "../LICENSE-binaries"
     },
     "protocols": {
       "name": "Lens Protocol Handler",


### PR DESCRIPTION
Now Github again does not recognize our license so the extra file is just for binaries.