### PR TITLE
Fixes for apparmor profile

### DIFF
--- a/freelens/build/apparmor-profile.aa
+++ b/freelens/build/apparmor-profile.aa
@@ -1,7 +1,10 @@
+# This profile allows everything and only exists to give the
+# application a name instead of having the label "unconfined"
+
 abi <abi/4.0>,
 include <tunables/global>
 
-profile freelens "/opt/Freelens/freelens" flags=(unconfined) {
+profile freelens /opt/Freelens/freelens flags=(unconfined) {
   userns,
 
   # Site-specific additions and overrides. See local/README for details.


### PR DESCRIPTION
This is based on the other profiles on Ubuntu 24.04 (ie. chromium).

It is still not to run as enforced hovewer the application should be detected with a separate profile.
