### PR TITLE
Fix for incorrect launchable tag in metainfo file

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ flatpak install flathub app.freelens.Freelens
 flatpak run app.freelens.Freelens
 ```
 
+The application is sandboxed. It includes bundled `kubectl` and `helm`
+commands and uses the `~/.kube/config` file by default. The `~/.freelens`
+directory is stored in the sandbox.
+
+Flatpak adds wrappers for the `aws`, `gke-gcloud-auth-plugin`, and
+`kubelogin` tools, running them as commands from the host system.
+
+The terminal uses `/bin/sh` by default, but it can be switched in the
+settings to, for example, `/bin/bash` for a sandboxed environment or
+`/app/bin/host-spawn` for a host environment.
+
 #### APT repository
 
 Run the following commands:

--- a/freelens/build/metainfo.xml
+++ b/freelens/build/metainfo.xml
@@ -32,7 +32,7 @@ intuitive and user-friendly interface.</p>
   <requires>
     <display_length compare="ge">768</display_length>
   </requires>
-  <launchable type="desktop-id">app.freelens.Freelens</launchable>
+  <launchable type="desktop-id">app.freelens.Freelens.desktop</launchable>
   <content_rating type="oars-1.1"></content_rating>
   <releases>
     <release version="0.1.3" date="2025-01-28">


### PR DESCRIPTION
FIxes incorrect `<launchable>` tag as it was discovered in https://buildbot.flathub.org/#/builders/6/builds/177149:

```json
{
    "errors": [
        "metainfo-launchable-tag-wrong-value"
    ],
    "info": [
        "metainfo-launchable-tag-wrong-value: The value of launchable tag in Metainfo is wrong: app.freelens.Freelens"
    ],
    "message": "Please consult the documentation at https://docs.flathub.org/docs/for-app-authors/linter"
}
```
