### PR TITLE
Use annotation rather than label for marking manual edits

### DIFF
--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
@@ -7140,7 +7140,7 @@ metadata:
   somePropertyToBeChanged: some-old-value
   selfLink: /api/some-api-version/namespaces/some-uid
   annotations:
-    edit.freelens.app/version: some-api-version
+    freelens.app/resource-version: some-api-version
 
               </textarea>
             </div>

--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
@@ -7140,7 +7140,7 @@ metadata:
   somePropertyToBeChanged: some-old-value
   selfLink: /api/some-api-version/namespaces/some-uid
   annotations:
-    edit.resource.freelens.app/version: some-api-version
+    edit.freelens.app/version: some-api-version
 
               </textarea>
             </div>

--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
@@ -7139,8 +7139,8 @@ metadata:
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
   selfLink: /api/some-api-version/namespaces/some-uid
-  labels:
-    k8slens-edit-resource-version: some-api-version
+  annotations:
+    edit.resource.freelens.app/version: some-api-version
 
               </textarea>
             </div>

--- a/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
+++ b/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
@@ -232,7 +232,7 @@ metadata:
                       op: "add",
                       path: "/metadata/annotations",
                       value: {
-                        "edit.resource.freelens.app/version": "some-api-version",
+                        "edit.freelens.app/version": "some-api-version",
                       },
                     }],
                   },
@@ -598,7 +598,7 @@ metadata:
                           op: "add",
                           path: "/metadata/annotations",
                           value: {
-                            "edit.resource.freelens.app/version": "some-api-version",
+                            "edit.freelens.app/version": "some-api-version",
                           },
                         },
                         {
@@ -852,7 +852,7 @@ metadata:
                         op: "add",
                         path: "/metadata/annotations",
                         value: {
-                          "edit.resource.freelens.app/version": "some-api-version",
+                          "edit.freelens.app/version": "some-api-version",
                         },
                       }],
                     },
@@ -932,7 +932,7 @@ metadata:
                           op: "add",
                           path: "/metadata/annotation",
                           value: {
-                            "edit.resource.freelens.app/version": "some-api-version",
+                            "edit.freelens.app/version": "some-api-version",
                           },
                         }],
                       },

--- a/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
+++ b/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
@@ -224,15 +224,15 @@ metadata:
                 expect(rendered.baseElement).toMatchSnapshot();
               });
 
-              it("calls for save with just the adding version label", () => {
+              it("calls for save with just the adding version annotation", () => {
                 expect(apiKubePatchMock).toHaveBeenCalledWith(
                   "/api/some-api-version/namespaces/some-uid",
                   {
                     data: [{
                       op: "add",
-                      path: "/metadata/labels",
+                      path: "/metadata/annotations",
                       value: {
-                        "k8slens-edit-resource-version": "some-api-version",
+                        "edit.resource.freelens.app/version": "some-api-version",
                       },
                     }],
                   },
@@ -596,9 +596,9 @@ metadata:
                         },
                         {
                           op: "add",
-                          path: "/metadata/labels",
+                          path: "/metadata/annotations",
                           value: {
-                            "k8slens-edit-resource-version": "some-api-version",
+                            "edit.resource.freelens.app/version": "some-api-version",
                           },
                         },
                         {
@@ -836,7 +836,7 @@ metadata:
 `);
                 });
 
-                it("when selecting to save, calls for save of second namespace with just the add edit version label", () => {
+                it("when selecting to save, calls for save of second namespace with just the add edit version annotation", () => {
                   apiKubePatchMock.mockClear();
 
                   const saveButton = rendered.getByTestId(
@@ -850,9 +850,9 @@ metadata:
                     {
                       data: [{
                         op: "add",
-                        path: "/metadata/labels",
+                        path: "/metadata/annotations",
                         value: {
-                          "k8slens-edit-resource-version": "some-api-version",
+                          "edit.resource.freelens.app/version": "some-api-version",
                         },
                       }],
                     },
@@ -916,7 +916,7 @@ metadata:
 `);
                   });
 
-                  it("when selecting to save, calls for save of first namespace with just the new edit version label", () => {
+                  it("when selecting to save, calls for save of first namespace with just the new edit version annotation", () => {
                     apiKubePatchMock.mockClear();
 
                     const saveButton = rendered.getByTestId(
@@ -930,9 +930,9 @@ metadata:
                       {
                         data: [{
                           op: "add",
-                          path: "/metadata/labels",
+                          path: "/metadata/annotation",
                           value: {
-                            "k8slens-edit-resource-version": "some-api-version",
+                            "edit.resource.freelens.app/version": "some-api-version",
                           },
                         }],
                       },

--- a/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
+++ b/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
@@ -930,7 +930,7 @@ metadata:
                       {
                         data: [{
                           op: "add",
-                          path: "/metadata/annotation",
+                          path: "/metadata/annotations",
                           value: {
                             "edit.freelens.app/version": "some-api-version",
                           },

--- a/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
+++ b/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
@@ -232,7 +232,7 @@ metadata:
                       op: "add",
                       path: "/metadata/annotations",
                       value: {
-                        "edit.freelens.app/version": "some-api-version",
+                        "freelens.app/resource-version": "some-api-version",
                       },
                     }],
                   },
@@ -598,7 +598,7 @@ metadata:
                           op: "add",
                           path: "/metadata/annotations",
                           value: {
-                            "edit.freelens.app/version": "some-api-version",
+                            "freelens.app/resource-version": "some-api-version",
                           },
                         },
                         {
@@ -852,7 +852,7 @@ metadata:
                         op: "add",
                         path: "/metadata/annotations",
                         value: {
-                          "edit.freelens.app/version": "some-api-version",
+                          "freelens.app/resource-version": "some-api-version",
                         },
                       }],
                     },
@@ -932,7 +932,7 @@ metadata:
                           op: "add",
                           path: "/metadata/annotations",
                           value: {
-                            "edit.freelens.app/version": "some-api-version",
+                            "freelens.app/resource-version": "some-api-version",
                           },
                         }],
                       },

--- a/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
@@ -59,7 +59,7 @@ interface Dependencies {
 }
 
 function getEditSelfLinkFor(object: RawKubeObject): string | undefined {
-  const lensVersionLabel = object.metadata.labels?.[EditResourceLabelName];
+  const lensVersionLabel = object.metadata.labels?.[EditResourceAnnotationName];
 
   if (lensVersionLabel) {
     const parsedKubeApi = parseKubeApi(object.metadata.selfLink);
@@ -82,7 +82,7 @@ function getEditSelfLinkFor(object: RawKubeObject): string | undefined {
 /**
  * The label name that Lens uses to receive the desired api version
  */
-export const EditResourceLabelName = "k8slens-edit-resource-version";
+export const EditResourceAnnotationName = "edit.resource.freelens.app/version";
 
 export class EditResourceModel {
   constructor(protected readonly dependencies: Dependencies) {}
@@ -139,14 +139,14 @@ export class EditResourceModel {
       return void this.dependencies.showErrorNotification(`Loading resource failed: ${result.error}`);
     }
 
-    if (result?.response?.metadata.labels?.[EditResourceLabelName]) {
+    if (result?.response?.metadata.annotations?.[EditResourceAnnotationName]) {
       const parsed = parseKubeApi(this.selfLink);
 
       if (!parsed) {
         return void this.dependencies.showErrorNotification(`Object's selfLink is invalid: "${this.selfLink}"`);
       }
 
-      parsed.apiVersion = result.response.metadata.labels[EditResourceLabelName];
+      parsed.apiVersion = result.response.metadata.annotations[EditResourceAnnotationName];
 
       result = await this.dependencies.requestKubeResource(createKubeApiURL(parsed));
     }
@@ -188,8 +188,8 @@ export class EditResourceModel {
     const firstVersion = yaml.load(this.editingResource.firstDraft ?? currentValue);
 
     // Make sure we save this label so that we can use it in the future
-    currentVersion.metadata.labels ??= {};
-    currentVersion.metadata.labels[EditResourceLabelName] = currentVersion.apiVersion.split("/").pop();
+    currentVersion.metadata.annotations ??= {};
+    currentVersion.metadata.annotations[EditResourceAnnotationName] = currentVersion.apiVersion.split("/").pop();
 
     const patches = createPatch(firstVersion, currentVersion);
     const selfLink = getEditSelfLinkFor(currentVersion);

--- a/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
@@ -59,9 +59,9 @@ interface Dependencies {
 }
 
 function getEditSelfLinkFor(object: RawKubeObject): string | undefined {
-  const lensVersionLabel = object.metadata.labels?.[EditResourceAnnotationName];
+  const lensVersionAnnotation = object.metadata.annotations?.[EditResourceAnnotationName];
 
-  if (lensVersionLabel) {
+  if (lensVersionAnnotation) {
     const parsedKubeApi = parseKubeApi(object.metadata.selfLink);
 
     if (!parsedKubeApi) {
@@ -72,7 +72,7 @@ function getEditSelfLinkFor(object: RawKubeObject): string | undefined {
 
     return createKubeApiURL({
       ...parsedApi,
-      apiVersion: lensVersionLabel,
+      apiVersion: lensVersionAnnotation,
     });
   }
 
@@ -80,7 +80,7 @@ function getEditSelfLinkFor(object: RawKubeObject): string | undefined {
 }
 
 /**
- * The label name that Lens uses to receive the desired api version
+ * The annotation name that Lens uses to receive the desired api version
  */
 export const EditResourceAnnotationName = "edit.freelens.app/version";
 
@@ -187,7 +187,7 @@ export class EditResourceModel {
     const currentVersion = yaml.load(currentValue) as RawKubeObject;
     const firstVersion = yaml.load(this.editingResource.firstDraft ?? currentValue);
 
-    // Make sure we save this label so that we can use it in the future
+    // Make sure we save this annotation so that we can use it in the future
     currentVersion.metadata.annotations ??= {};
     currentVersion.metadata.annotations[EditResourceAnnotationName] = currentVersion.apiVersion.split("/").pop();
 

--- a/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
@@ -82,7 +82,7 @@ function getEditSelfLinkFor(object: RawKubeObject): string | undefined {
 /**
  * The annotation name that Lens uses to receive the desired api version
  */
-export const EditResourceAnnotationName = "edit.freelens.app/version";
+export const EditResourceAnnotationName = "freelens.app/resource-version";
 
 export class EditResourceModel {
   constructor(protected readonly dependencies: Dependencies) {}

--- a/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
@@ -82,7 +82,7 @@ function getEditSelfLinkFor(object: RawKubeObject): string | undefined {
 /**
  * The label name that Lens uses to receive the desired api version
  */
-export const EditResourceAnnotationName = "edit.resource.freelens.app/version";
+export const EditResourceAnnotationName = "edit.freelens.app/version";
 
 export class EditResourceModel {
   constructor(protected readonly dependencies: Dependencies) {}


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #141

**Description of changes:**

- Replaces label with annotation
- Renamed to keep convention `foo.domain.name/something`
