### PR TITLE
Allows to run node shell on Bootlerocket and Windows nodes

### DIFF
--- a/packages/core/src/common/cluster-types.ts
+++ b/packages/core/src/common/cluster-types.ts
@@ -108,6 +108,7 @@ export interface ClusterPreferences extends ClusterPrometheusPreferences {
   httpsProxy?: string;
   hiddenMetrics?: string[];
   nodeShellImage?: string;
+  nodeShellWindowsImage?: string;
   imagePullSecret?: string;
   defaultNamespace?: string;
 }
@@ -177,7 +178,12 @@ export enum ClusterMetricsResourceType {
 /**
  * The default node shell image
  */
-export const initialNodeShellImage = "docker.io/alpine:3.13";
+export const initialNodeShellImage = "docker.io/library/alpine";
+
+/**
+ * The default node shell image for Windows
+ */
+export const initialNodeShellWindowsImage = "mcr.microsoft.com/powershell";
 
 /**
  * The data representing a cluster's state, for passing between main and renderer

--- a/packages/core/src/main/shell-session/node-shell-session/node-shell-session.ts
+++ b/packages/core/src/main/shell-session/node-shell-session/node-shell-session.ts
@@ -99,7 +99,6 @@ export class NodeShellSession extends ShellSession {
 
     const nodeOs = node.getOperatingSystem();
     const nodeOsImage = node.getOperatingSystemImage();
-    const nodeKernelVersion = node.getKernelVersion();
 
     let image: string;
     let command: string[]; 
@@ -125,11 +124,7 @@ export class NodeShellSession extends ShellSession {
         };
         break;
       case "windows":
-        if (nodeKernelVersion) {
-          image = nodeShellImage || initialNodeShellWindowsImage;
-        } else {
-          throw new Error(`No status with kernel version for node ${this.nodeName} found`);
-        }
+        image = nodeShellImage || initialNodeShellWindowsImage;
         command = ["cmd.exe"];
         args = ["/c", "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\PowerShell\\latest\\pwsh.exe", "-nol", "-wd", "C:\\"];
         securityContext = {

--- a/packages/core/src/main/shell-session/node-shell-session/node-shell-session.ts
+++ b/packages/core/src/main/shell-session/node-shell-session/node-shell-session.ts
@@ -13,7 +13,7 @@ import { NodeApi } from "@freelensapp/kube-api";
 import { TerminalChannels } from "../../../common/terminal/channels";
 import type { CreateKubeJsonApiForCluster } from "../../../common/k8s-api/create-kube-json-api-for-cluster.injectable";
 import type { CreateKubeApi } from "../../../common/k8s-api/create-kube-api.injectable";
-import { initialNodeShellImage } from "../../../common/cluster-types";
+import { initialNodeShellImage, initialNodeShellWindowsImage } from "../../../common/cluster-types";
 import type { LoadProxyKubeconfig } from "../../cluster/load-proxy-kubeconfig.injectable";
 import type { Pod } from "@freelensapp/kube-object";
 
@@ -71,34 +71,12 @@ export class NodeShellSession extends ShellSession {
     }
 
     const env = await this.getCachedShellEnv();
-    const args = ["exec", "-i", "-t", "-n", "kube-system", this.podName, "--"];
-    const nodeApi = this.dependencies.createKubeApi(NodeApi, {
-      request: this.dependencies.createKubeJsonApiForCluster(this.cluster.id),
-    });
-    const node = await nodeApi.get({ name: this.nodeName });
-
-    if (!node) {
-      throw new Error(`No node with name=${this.nodeName} found`);
-    }
-
-    const nodeOs = node.getOperatingSystem();
-
-    switch (nodeOs) {
-      default:
-        this.dependencies.logger.warn(`[NODE-SHELL-SESSION]: could not determine node OS, falling back with assumption of linux`);
-        // fallthrough
-      case "linux":
-        args.push("sh", "-c", "((clear && bash) || (clear && ash) || (clear && sh))");
-        break;
-      case "windows":
-        args.push("powershell");
-        break;
-    }
+    const args = ["attach", "-q", "-i", "-t", "-n", "kube-system", this.podName];
 
     await this.openShellProcess(await this.kubectl.getPath(), args, env);
   }
 
-  protected createNodeShellPod(coreApi: CoreV1Api) {
+  protected async createNodeShellPod(coreApi: CoreV1Api) {
     const {
       imagePullSecret,
       nodeShellImage,
@@ -109,6 +87,60 @@ export class NodeShellSession extends ShellSession {
         name: imagePullSecret,
       }]
       : undefined;
+
+    const nodeApi = this.dependencies.createKubeApi(NodeApi, {
+      request: this.dependencies.createKubeJsonApiForCluster(this.cluster.id),
+    });
+    const node = await nodeApi.get({ name: this.nodeName });
+
+    if (!node) {
+      throw new Error(`No node with name=${this.nodeName} found`);
+    }
+
+    const nodeOs = node.getOperatingSystem();
+    const nodeOsImage = node.getOperatingSystemImage();
+    const nodeKernelVersion = node.getKernelVersion();
+
+    let image: string;
+    let command: string[]; 
+    let args: string[];
+    let securityContext: any;
+
+    switch (nodeOs) {
+      default:
+        this.dependencies.logger.warn(`[NODE-SHELL-SESSION]: could not determine node OS, falling back with assumption of linux`);
+        // fallthrough
+      case "linux":
+        image = nodeShellImage || initialNodeShellImage;
+        command = ["nsenter"];
+
+        if (nodeOsImage && nodeOsImage.startsWith("Bottlerocket OS")) {
+          args = ["-t", "1", "-m", "-u", "-i", "-n", "-p", "--", "apiclient", "exec", "admin", "bash", "-l"];
+        } else {
+          args = ["-t", "1", "-m", "-u", "-i", "-n", "-p", "--", "bash", "-l"];
+        }
+
+        securityContext = {
+          privileged: true,
+        };
+        break;
+      case "windows":
+        if (nodeKernelVersion) {
+          image = nodeShellImage || initialNodeShellWindowsImage;
+        } else {
+          throw new Error(`No status with kernel version for node ${this.nodeName} found`);
+        }
+        command = ["cmd.exe"];
+        args = ["/c", "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\PowerShell\\latest\\pwsh.exe", "-nol", "-wd", "C:\\"];
+        securityContext = {
+          privileged: true,
+          windowsOptions: {
+            hostProcess: true,
+            runAsUserName: "NT AUTHORITY\\SYSTEM",
+          },
+        };
+        break;
+    }
 
     return coreApi
       .createNamespacedPod("kube-system", {
@@ -129,12 +161,13 @@ export class NodeShellSession extends ShellSession {
           priorityClassName: "system-node-critical",
           containers: [{
             name: "shell",
-            image: nodeShellImage || initialNodeShellImage,
-            securityContext: {
-              privileged: true,
-            },
-            command: ["nsenter"],
-            args: ["-t", "1", "-m", "-u", "-i", "-n", "sleep", "14000"],
+            image,
+            securityContext,
+            command,
+            args,
+            stdin: true,
+            stdinOnce: true,
+            tty: true,
           }],
           imagePullSecrets,
         },

--- a/packages/core/src/renderer/components/cluster-settings/node-shell-setting.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/node-shell-setting.tsx
@@ -10,7 +10,7 @@ import React from "react";
 import { Input } from "../input/input";
 import { observer } from "mobx-react";
 import { Icon } from "@freelensapp/icon";
-import { initialNodeShellImage } from "../../../common/cluster-types";
+import { initialNodeShellImage, initialNodeShellWindowsImage } from "../../../common/cluster-types";
 import Gutter from "../gutter/gutter";
 
 export interface ClusterNodeShellSettingProps {
@@ -20,6 +20,7 @@ export interface ClusterNodeShellSettingProps {
 @observer
 export class ClusterNodeShellSetting extends React.Component<ClusterNodeShellSettingProps> {
   @observable nodeShellImage = this.props.cluster.preferences?.nodeShellImage || "";
+  @observable nodeShellWindowsImage = this.props.cluster.preferences?.nodeShellWindowsImage || "";
   @observable imagePullSecret = this.props.cluster.preferences?.imagePullSecret || "";
 
   constructor(props: ClusterNodeShellSettingProps) {
@@ -30,6 +31,7 @@ export class ClusterNodeShellSetting extends React.Component<ClusterNodeShellSet
   componentWillUnmount() {
     runInAction(() => {
       this.props.cluster.preferences.nodeShellImage = this.nodeShellImage || undefined;
+      this.props.cluster.preferences.nodeShellWindowsImage = this.nodeShellWindowsImage || undefined;
       this.props.cluster.preferences.imagePullSecret = this.imagePullSecret || undefined;
     });
   }
@@ -38,7 +40,7 @@ export class ClusterNodeShellSetting extends React.Component<ClusterNodeShellSet
     return (
       <>
         <section>
-          <SubTitle title="Node shell image" id="node-shell-image"/>
+          <SubTitle title="Node shell image for Linux" id="node-shell-image"/>
           <Input
             theme="round-black"
             placeholder={`Default image: ${initialNodeShellImage}`}
@@ -58,7 +60,32 @@ export class ClusterNodeShellSetting extends React.Component<ClusterNodeShellSet
             }
           />
           <small className="hint">
-            Node shell image. Used for creating node shell pod.
+            Node shell image. Used for creating node shell pod on Linux nodes.
+          </small>
+        </section>
+        <Gutter />
+        <section>
+          <SubTitle title="Node shell image for Windows" id="node-shell-windows-image"/>
+          <Input
+            theme="round-black"
+            placeholder={`Default image: ${initialNodeShellWindowsImage}`}
+            value={this.nodeShellWindowsImage}
+            onChange={value => this.nodeShellWindowsImage = value}
+            iconRight={
+              this.nodeShellWindowsImage
+                ? (
+                  <Icon
+                    smallest
+                    material="close"
+                    onClick={() => this.nodeShellWindowsImage = ""}
+                    tooltip="Reset"
+                  />
+                )
+                : undefined
+            }
+          />
+          <small className="hint">
+            Node shell image. Used for creating node shell pod on Windows nodes.
           </small>
         </section>
         <Gutter />

--- a/packages/kube-object/src/specifics/node.ts
+++ b/packages/kube-object/src/specifics/node.ts
@@ -247,6 +247,14 @@ export class Node extends KubeObject<ClusterScopedMetadata, NodeStatus, NodeSpec
     );
   }
 
+  getOperatingSystemImage(): string | undefined {
+    return this.status?.nodeInfo?.osImage;
+  }
+
+  getKernelVersion(): string | undefined {
+    return this.status?.nodeInfo?.kernelVersion;
+  }
+
   isUnschedulable() {
     return this.spec.unschedulable;
   }

--- a/packages/kube-object/src/specifics/node.ts
+++ b/packages/kube-object/src/specifics/node.ts
@@ -251,10 +251,6 @@ export class Node extends KubeObject<ClusterScopedMetadata, NodeStatus, NodeSpec
     return this.status?.nodeInfo?.osImage;
   }
 
-  getKernelVersion(): string | undefined {
-    return this.status?.nodeInfo?.kernelVersion;
-  }
-
   isUnschedulable() {
     return this.spec.unschedulable;
   }


### PR DESCRIPTION
This is a reworked node-shell feature. It allows to run it on Bottlerocket OS and Windows nodes where there is no `sh` nor `bash` command.

Unfortunately, node-shell pods cannot be autoremoved anymore with `sleep` command. It is because now single pod is created and then `kubectl attach` is run. It is because `kubectl exec` with `nsenter` command won't work: Bottlerocket OS is SELinux hardened then `nsenter` won't have privileges to run in `kubectl exec` context.

Bottlerocket OS:

<img width="854" alt="image" src="https://github.com/user-attachments/assets/6d7262c9-e489-4e39-87c8-8a0d0876c11c" />

Windows 2022:

<img width="765" alt="image" src="https://github.com/user-attachments/assets/19d267a7-57a1-4a11-b533-042d5c4b0b02" />

