### PR TITLE
Updated apiVersion for CronJobs from batch/v1beta1 to batch/v1

### DIFF
--- a/packages/core/src/renderer/components/__tests__/cronjob.store.test.ts
+++ b/packages/core/src/renderer/components/__tests__/cronjob.store.test.ts
@@ -20,7 +20,7 @@ const scheduledCronJob = new CronJob({
     resourceVersion: "scheduledCronJob",
     uid: "scheduledCronJob",
     namespace: "default",
-    selfLink: "/apis/batch/v1beta1/cronjobs/default/scheduledCronJob",
+    selfLink: "/apis/batch/v1/cronjobs/default/scheduledCronJob",
   },
   spec: {
     schedule: "test",
@@ -55,7 +55,7 @@ const suspendedCronJob = new CronJob({
     resourceVersion: "suspendedCronJob",
     uid: "suspendedCronJob",
     namespace: "default",
-    selfLink: "/apis/batch/v1beta1/cronjobs/default/suspendedCronJob",
+    selfLink: "/apis/batch/v1/cronjobs/default/suspendedCronJob",
   },
   spec: {
     schedule: "test",
@@ -90,7 +90,7 @@ const otherSuspendedCronJob = new CronJob({
     resourceVersion: "otherSuspendedCronJob",
     uid: "otherSuspendedCronJob",
     namespace: "default",
-    selfLink: "/apis/batch/v1beta1/cronjobs/default/otherSuspendedCronJob",
+    selfLink: "/apis/batch/v1/cronjobs/default/otherSuspendedCronJob",
   },
   spec: {
     schedule: "test",

--- a/packages/core/src/renderer/components/kube-object-details/kube-object-detail-items/implementations/cron-job-detail-item.injectable.ts
+++ b/packages/core/src/renderer/components/kube-object-details/kube-object-detail-items/implementations/cron-job-detail-item.injectable.ts
@@ -28,5 +28,5 @@ const cronJobDetailItemInjectable = getInjectable({
 export default cronJobDetailItemInjectable;
 
 export const isCronJob = kubeObjectMatchesToKindAndApiVersion("CronJob", [
-  "batch/v1beta1",
+  "batch/v1",
 ]);

--- a/packages/resource-templates/templates/create-resource/CronJob.yaml
+++ b/packages/resource-templates/templates/create-resource/CronJob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello


### PR DESCRIPTION
PR taken from https://github.com/tanoggy/lens/tree/change-apiversion-cronjob by @tanoggy
