### PR TITLE
Fix for problem that paste operation doesn't work in an editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "postdev": "npx -y lerna watch -- npx -y lerna run build --stream --include-dependents --scope \\$LERNA_PACKAGE_NAME",
     "prestart-dev": "cd freelens && npm run build:tray-icons && npm run download:binaries",
     "start-dev": "npx -y lerna run start",
-    "postinstall": "linkable",
+    "postinstall": "linkable && npx -y patch-package@8",
     "lint": "npx -y lerna run lint --stream --no-bail",
     "lint:fix": "npx -y lerna run lint:fix --stream",
     "test:unit": "npx -y lerna run --stream test:unit --no-bail",

--- a/packages/core/src/renderer/components/cluster-manager/cluster-frame-handler.ts
+++ b/packages/core/src/renderer/components/cluster-manager/cluster-frame-handler.ts
@@ -58,6 +58,7 @@ export class ClusterFrameHandler {
     iframe.id = `cluster-frame-${cluster.id}`;
     iframe.name = cluster.contextName.get();
     iframe.setAttribute("src", getClusterFrameUrl(clusterId));
+    iframe.setAttribute("allow", "clipboard-read; clipboard-write");
     iframe.addEventListener("load", action(() => {
       this.dependencies.logger.info(`[LENS-VIEW]: frame for clusterId=${clusterId} has loaded`);
       const view = this.views.get(clusterId);

--- a/patches/monaco-editor+0.52.2.patch
+++ b/patches/monaco-editor+0.52.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard.js b/node_modules/monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard.js
+index a1deb14..5598b9b 100644
+--- a/node_modules/monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard.js
++++ b/node_modules/monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard.js
+@@ -201,7 +201,7 @@ if (PasteAction) {
+             if (result) {
+                 return CopyPasteController.get(focusedEditor)?.finishedPaste() ?? Promise.resolve();
+             }
+-            else if (platform.isWeb) {
++            else /*if (platform.isWeb)*/ {
+                 // Use the clipboard service if document.execCommand('paste') was not successful
+                 return (async () => {
+                     const clipboardText = await clipboardService.readText();


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #445, #434

**Description of changes:**

- Added security context for iframe that enabled read-write operations on clipboard
- Patch for VS Code (monaco-editor) which enables alternative clipboard handler on newer Chrome
