### PR TITLE
Remove text selection style causing readability issues in light theme

### DIFF
--- a/packages/core/src/renderer/components/app.scss
+++ b/packages/core/src/renderer/components/app.scss
@@ -55,11 +55,6 @@
   background-color: transparent;
 }
 
-::selection {
-  background: var(--primary);
-  color: white;
-}
-
 *:target {
   color: var(--textColorAccent);
 }


### PR DESCRIPTION
Removed custom text selection styling that was causing readability issues in the light theme, where selected text would become invisible (white text on white background). This change follows the behavior already implemented in the Lens application.