### PR TITLE
Upgrade @testing-library dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5211,31 +5211,31 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
-      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
+        "aria-query": "5.3.0",
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "deep-equal": "^2.0.5"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -9250,6 +9250,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -26482,7 +26491,7 @@
         "@freelensapp/test-utils": "^1.1.0",
         "@ogre-tools/linkable": "^17.11.1",
         "@side/jest-runtime": "^1.1.0",
-        "@testing-library/dom": "^9.3.4",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^13.5.0",
@@ -28362,7 +28371,7 @@
       "license": "MIT",
       "peerDependencies": {
         "@freelensapp/webpack": "^1.1.0",
-        "@testing-library/dom": "^9.3.4",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^12.1.5"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -930,6 +930,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
       "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
@@ -5239,26 +5240,30 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
-      "integrity": "sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
       "license": "MIT",
       "dependencies": {
-        "@adobe/css-tools": "^4.0.1",
-        "@babel/runtime": "^7.9.2",
-        "@types/testing-library__jest-dom": "^5.9.1",
+        "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.5.6",
-        "lodash": "^4.17.15",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
         "redent": "^3.0.0"
       },
       "engines": {
-        "node": ">=8",
+        "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
       }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/@adobe/css-tools": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.2.tgz",
+      "integrity": "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==",
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom/node_modules/chalk": {
       "version": "3.0.0",
@@ -5272,6 +5277,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "12.1.5",
@@ -6162,14 +6173,6 @@
       "integrity": "sha512-0vQ4fz9TTM4bCdllYWEJ2JHBUXR9xqPtc70dJ7BMRDVfvZyYdrgey3nP5RRcVj+qAgnHJM8r9fvgrfnPMxdnhA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/testing-library__jest-dom": {
-      "version": "5.14.5",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
-      "integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
-      "dependencies": {
-        "@types/jest": "*"
-      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
@@ -26492,7 +26495,7 @@
         "@ogre-tools/linkable": "^17.11.1",
         "@side/jest-runtime": "^1.1.0",
         "@testing-library/dom": "^10.4.0",
-        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/jest-dom": "^6.4.3",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^13.5.0",
         "@types/byline": "^4.2.36",
@@ -27470,7 +27473,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/jest-dom": "^6.4.3",
         "@testing-library/react": "^12.1.5",
         "@types/jest": "^29.5.14",
         "identity-obj-proxy": "^3.0.0",
@@ -28372,7 +28375,7 @@
       "peerDependencies": {
         "@freelensapp/webpack": "^1.1.0",
         "@testing-library/dom": "^10.4.0",
-        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/jest-dom": "^6.4.3",
         "@testing-library/react": "^12.1.5"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27815,8 +27815,7 @@
         "@freelensapp/eslint-config": "^1.1.0",
         "@freelensapp/react-testing-library-discovery": "^1.1.0",
         "@freelensapp/webpack": "^1.1.0",
-        "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/react": "^12.1.5"
       },
       "peerDependencies": {
         "@freelensapp/feature-core": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5330,15 +5330,13 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {
@@ -26438,7 +26436,8 @@
         "@async-fn/jest": "^1.6.4",
         "@freelensapp/eslint-config": "^1.1.0",
         "@freelensapp/react-testing-library-discovery": "^1.1.0",
-        "@freelensapp/webpack": "^1.1.0"
+        "@freelensapp/webpack": "^1.1.0",
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "@freelensapp/feature-core": "^1.1.0",
@@ -26497,7 +26496,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.4.3",
         "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^13.5.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/byline": "^4.2.36",
         "@types/chart.js": "^2.9.41",
         "@types/circular-dependency-plugin": "5.0.8",
@@ -27817,7 +27816,7 @@
         "@freelensapp/react-testing-library-discovery": "^1.1.0",
         "@freelensapp/webpack": "^1.1.0",
         "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^13.5.0"
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "@freelensapp/feature-core": "^1.1.0",
@@ -28088,8 +28087,7 @@
         "@freelensapp/eslint-config": "^1.1.0",
         "@freelensapp/react-testing-library-discovery": "^1.1.0",
         "@freelensapp/webpack": "^1.1.0",
-        "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^13.5.0"
+        "@testing-library/react": "^12.1.5"
       },
       "peerDependencies": {
         "@freelensapp/tooltip": "^1.1.0",
@@ -28102,22 +28100,6 @@
         "react-dom": "^17.0.2"
       }
     },
-    "packages/ui-components/button/node_modules/@testing-library/user-event": {
-      "version": "12.8.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
-      "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
-      }
-    },
     "packages/ui-components/error-boundary": {
       "name": "@freelensapp/error-boundary",
       "version": "1.1.0",
@@ -28127,8 +28109,7 @@
         "@freelensapp/eslint-config": "^1.1.0",
         "@freelensapp/react-testing-library-discovery": "^1.1.0",
         "@freelensapp/webpack": "^1.1.0",
-        "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^13.5.0"
+        "@testing-library/react": "^12.1.5"
       },
       "peerDependencies": {
         "@freelensapp/button": "^1.1.0",
@@ -28155,8 +28136,7 @@
         "@freelensapp/eslint-config": "^1.1.0",
         "@freelensapp/react-testing-library-discovery": "^1.1.0",
         "@freelensapp/webpack": "^1.1.0",
-        "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^13.5.0"
+        "@testing-library/react": "^12.1.5"
       },
       "peerDependencies": {
         "@freelensapp/button": "^1.1.0",
@@ -28264,7 +28244,7 @@
         "@freelensapp/react-testing-library-discovery": "^1.1.0",
         "@freelensapp/webpack": "^1.1.0",
         "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^13.5.0"
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "@freelensapp/utilities": "^1.1.0",
@@ -28274,22 +28254,6 @@
         "mobx-react": "^7.6.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
-      }
-    },
-    "packages/ui-components/tooltip/node_modules/@testing-library/user-event": {
-      "version": "12.8.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
-      "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
       }
     },
     "packages/utility-features/event-emitter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5211,9 +5211,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
-      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -5226,7 +5226,7 @@
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@testing-library/dom/node_modules/aria-query": {
@@ -5288,6 +5288,34 @@
       "peerDependencies": {
         "react": "<18.0.0",
         "react-dom": "<18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
+      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -26454,7 +26482,7 @@
         "@freelensapp/test-utils": "^1.1.0",
         "@ogre-tools/linkable": "^17.11.1",
         "@side/jest-runtime": "^1.1.0",
-        "@testing-library/dom": "^8.20.1",
+        "@testing-library/dom": "^9.3.4",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^13.5.0",
@@ -28334,7 +28362,7 @@
       "license": "MIT",
       "peerDependencies": {
         "@freelensapp/webpack": "^1.1.0",
-        "@testing-library/dom": "^8.20.1",
+        "@testing-library/dom": "^9.3.4",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^12.1.5"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28089,7 +28089,7 @@
         "@freelensapp/react-testing-library-discovery": "^1.1.0",
         "@freelensapp/webpack": "^1.1.0",
         "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^12.8.3"
+        "@testing-library/user-event": "^13.5.0"
       },
       "peerDependencies": {
         "@freelensapp/tooltip": "^1.1.0",
@@ -28264,7 +28264,7 @@
         "@freelensapp/react-testing-library-discovery": "^1.1.0",
         "@freelensapp/webpack": "^1.1.0",
         "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^12.8.3"
+        "@testing-library/user-event": "^13.5.0"
       },
       "peerDependencies": {
         "@freelensapp/utilities": "^1.1.0",

--- a/packages/business-features/keyboard-shortcuts/package.json
+++ b/packages/business-features/keyboard-shortcuts/package.json
@@ -2,7 +2,7 @@
   "name": "@freelensapp/keyboard-shortcuts",
   "private": false,
   "version": "1.1.0",
-  "description": "Keyboard shortcuts for Freeens",
+  "description": "Keyboard shortcuts for Freelens",
   "type": "commonjs",
   "files": [
     "dist"
@@ -44,6 +44,7 @@
     "@async-fn/jest": "^1.6.4",
     "@freelensapp/eslint-config": "^1.1.0",
     "@freelensapp/react-testing-library-discovery": "^1.1.0",
-    "@freelensapp/webpack": "^1.1.0"
+    "@freelensapp/webpack": "^1.1.0",
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/business-features/keyboard-shortcuts/src/keyboard-shortcuts.test.tsx
+++ b/packages/business-features/keyboard-shortcuts/src/keyboard-shortcuts.test.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import userEvent, { UserEvent } from "@testing-library/user-event";
 import type { RenderResult } from "@testing-library/react";
 import { render } from "@testing-library/react";
 import { createContainer, DiContainer, getInjectable } from "@ogre-tools/injectable";
@@ -20,6 +20,7 @@ describe("keyboard-shortcuts", () => {
   let di: DiContainer;
   let invokeMock: jest.Mock;
   let rendered: RenderResult;
+  let user: UserEvent;
 
   beforeEach(() => {
     di = createContainer("irrelevant");
@@ -97,6 +98,8 @@ describe("keyboard-shortcuts", () => {
     di.override(renderInjectionToken, () => (application) => {
       rendered = render(application);
     });
+
+    user = userEvent.setup();
   });
 
   describe("when application is started", () => {
@@ -114,25 +117,25 @@ describe("keyboard-shortcuts", () => {
       expect(rendered.baseElement).toMatchSnapshot();
     });
 
-    it("given focus is in the body, when pressing the shortcut, calls shortcut in global scope", () => {
-      userEvent.keyboard("{Escape}");
+    it("given focus is in the body, when pressing the shortcut, calls shortcut in global scope", async () => {
+      await user.keyboard("{Escape}");
 
       expect(invokeMock.mock.calls).toEqual([["esc-in-root"]]);
     });
 
-    it("given focus inside a nested scope, when pressing the shortcut, calls only the callback for the scope", () => {
+    it("given focus inside a nested scope, when pressing the shortcut, calls only the callback for the scope", async () => {
       const result = discover.getSingleElement("keyboard-shortcut-scope", "some-scope");
 
       const discoveredHtml = result.discovered as HTMLDivElement;
 
       discoveredHtml.focus();
 
-      userEvent.keyboard("{Escape}");
+      await user.keyboard("{Escape}");
 
       expect(invokeMock.mock.calls).toEqual([["esc-in-scope"]]);
     });
 
-    it("given conflicting shortcut, when pressing the shortcut, calls both callbacks", () => {
+    it("given conflicting shortcut, when pressing the shortcut, calls both callbacks", async () => {
       const conflictingShortcutInjectable = getInjectable({
         id: "some-conflicting-keyboard-shortcut",
 
@@ -148,7 +151,7 @@ describe("keyboard-shortcuts", () => {
         di.register(conflictingShortcutInjectable);
       });
 
-      userEvent.keyboard("{Escape}");
+      await user.keyboard("{Escape}");
 
       expect(invokeMock.mock.calls).toEqual([["esc-in-root"], ["conflicting-esc-in-root"]]);
     });
@@ -201,7 +204,7 @@ describe("keyboard-shortcuts", () => {
         shouldCallCallback: true,
       },
     ].forEach(({ binding, keyboard, scenario, shouldCallCallback }) => {
-      it(scenario, () => {
+      it(scenario, async () => {
         const invokeMock = jest.fn();
 
         const shortcutInjectable = getInjectable({
@@ -219,7 +222,7 @@ describe("keyboard-shortcuts", () => {
           di.register(shortcutInjectable);
         });
 
-        userEvent.keyboard(keyboard);
+        await user.keyboard(keyboard);
 
         if (shouldCallCallback) {
           expect(invokeMock).toHaveBeenCalled();
@@ -256,14 +259,14 @@ describe("keyboard-shortcuts", () => {
       await startApplication();
     });
 
-    it("when pressing the keyboard shortcut with command, calls the callback", () => {
-      userEvent.keyboard("{Meta>}[KeyK]");
+    it("when pressing the keyboard shortcut with command, calls the callback", async () => {
+      await user.keyboard("{Meta>}[KeyK]");
 
       expect(invokeMock).toHaveBeenCalled();
     });
 
-    it("when pressing the keyboard shortcut with ctrl, does not call the callback", () => {
-      userEvent.keyboard("{Control>}[KeyK]");
+    it("when pressing the keyboard shortcut with ctrl, does not call the callback", async () => {
+      await user.keyboard("{Control>}[KeyK]");
 
       expect(invokeMock).not.toHaveBeenCalled();
     });
@@ -295,14 +298,14 @@ describe("keyboard-shortcuts", () => {
       await startApplication();
     });
 
-    it("when pressing the keyboard shortcut with windows, does not call the callback", () => {
-      userEvent.keyboard("{Meta>}[KeyK]");
+    it("when pressing the keyboard shortcut with windows, does not call the callback", async () => {
+      await user.keyboard("{Meta>}[KeyK]");
 
       expect(invokeMock).not.toHaveBeenCalled();
     });
 
-    it("when pressing the keyboard shortcut with ctrl, calls the callback", () => {
-      userEvent.keyboard("{Control>}[KeyK]");
+    it("when pressing the keyboard shortcut with ctrl, calls the callback", async () => {
+      await user.keyboard("{Control>}[KeyK]");
 
       expect(invokeMock).toHaveBeenCalled();
     });
@@ -334,14 +337,14 @@ describe("keyboard-shortcuts", () => {
       await startApplication();
     });
 
-    it("when pressing the keyboard shortcut with meta, does not call the callback", () => {
-      userEvent.keyboard("{Meta>}[KeyK]");
+    it("when pressing the keyboard shortcut with meta, does not call the callback", async () => {
+      await user.keyboard("{Meta>}[KeyK]");
 
       expect(invokeMock).not.toHaveBeenCalled();
     });
 
-    it("when pressing the keyboard shortcut with ctrl, calls the callback", () => {
-      userEvent.keyboard("{Control>}[KeyK]");
+    it("when pressing the keyboard shortcut with ctrl, calls the callback", async () => {
+      await user.keyboard("{Control>}[KeyK]");
 
       expect(invokeMock).toHaveBeenCalled();
     });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "clean": "rimraf dist static/build",
     "test:unit": "jest --testPathIgnorePatterns integration",
     "test:watch": "func() { jest ${1} --watch --testPathIgnorePatterns integration; }; func",
-    "lint": "PROD=true eslint --ext js,ts,tsx --max-warnings=0 .",
+    "lint": "eslint --ext js,ts,tsx --max-warnings=0 .",
     "lint:fix": "npm run lint -- --fix"
   },
   "config": {
@@ -80,7 +80,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.4.3",
     "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/byline": "^4.2.36",
     "@types/chart.js": "^2.9.41",
     "@types/circular-dependency-plugin": "5.0.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,7 +77,7 @@
     "@freelensapp/test-utils": "^1.1.0",
     "@ogre-tools/linkable": "^17.11.1",
     "@side/jest-runtime": "^1.1.0",
-    "@testing-library/dom": "^9.3.4",
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "clean": "rimraf dist static/build",
     "test:unit": "jest --testPathIgnorePatterns integration",
     "test:watch": "func() { jest ${1} --watch --testPathIgnorePatterns integration; }; func",
-    "lint": "eslint --ext js,ts,tsx --max-warnings=0 .",
+    "lint": "PROD=true eslint --ext js,ts,tsx --max-warnings=0 .",
     "lint:fix": "npm run lint -- --fix"
   },
   "config": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,7 +77,7 @@
     "@freelensapp/test-utils": "^1.1.0",
     "@ogre-tools/linkable": "^17.11.1",
     "@side/jest-runtime": "^1.1.0",
-    "@testing-library/dom": "^8.20.1",
+    "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,7 +78,7 @@
     "@ogre-tools/linkable": "^17.11.1",
     "@side/jest-runtime": "^1.1.0",
     "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/jest-dom": "^6.4.3",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.5.0",
     "@types/byline": "^4.2.36",

--- a/packages/core/src/features/cluster/delete-dialog/delete-cluster-dialog.test.tsx
+++ b/packages/core/src/features/cluster/delete-dialog/delete-cluster-dialog.test.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { KubeConfig } from "@freelensapp/kubernetes-client-node";
 import type { RenderResult } from "@testing-library/react";
 import normalizedPlatformInjectable from "../../../common/vars/normalized-platform.injectable";

--- a/packages/core/src/features/command-pallet/keyboard-shortcuts.test.tsx
+++ b/packages/core/src/features/command-pallet/keyboard-shortcuts.test.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { RenderResult } from "@testing-library/react";
+import type {UserEvent} from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import platformInjectable from "../../common/vars/platform.injectable";
 import { type ApplicationBuilder, getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
@@ -11,9 +12,11 @@ import { type ApplicationBuilder, getApplicationBuilder } from "../../renderer/c
 describe("Command Pallet: keyboard shortcut tests", () => {
   let builder: ApplicationBuilder;
   let rendered: RenderResult;
+  let user: UserEvent;
 
   beforeEach(async () => {
     builder = getApplicationBuilder();
+    user = userEvent.setup({delay: null});
   });
 
   describe("when on macOS", () => {
@@ -36,8 +39,8 @@ describe("Command Pallet: keyboard shortcut tests", () => {
     });
 
     describe("when pressing ESC", () => {
-      beforeEach(() => {
-        userEvent.keyboard("{Escape}");
+      beforeEach(async () => {
+        await user.keyboard("{Escape}");
       });
 
       it("renders", () => {
@@ -52,8 +55,8 @@ describe("Command Pallet: keyboard shortcut tests", () => {
     });
 
     describe("when pressing SHIFT+CMD+P", () => {
-      beforeEach(() => {
-        userEvent.keyboard("{Shift>}{Meta>}P{/Meta}{/Shift}");
+      beforeEach(async () => {
+        await user.keyboard("{Shift>}{Meta>}P{/Meta}{/Shift}");
       });
 
       it("renders", () => {
@@ -67,8 +70,8 @@ describe("Command Pallet: keyboard shortcut tests", () => {
       });
 
       describe("when pressing ESC", () => {
-        beforeEach(() => {
-          userEvent.keyboard("{Escape}");
+        beforeEach(async () => {
+          await user.keyboard("{Escape}");
         });
 
         it("renders", () => {
@@ -104,8 +107,8 @@ describe("Command Pallet: keyboard shortcut tests", () => {
     });
 
     describe("when pressing ESC", () => {
-      beforeEach(() => {
-        userEvent.keyboard("{Escape}");
+      beforeEach(async () => {
+        await user.keyboard("{Escape}");
       });
 
       it("renders", () => {
@@ -120,8 +123,8 @@ describe("Command Pallet: keyboard shortcut tests", () => {
     });
 
     describe("when pressing SHIFT+CTRL+P", () => {
-      beforeEach(() => {
-        userEvent.keyboard("{Shift>}{Control>}P{/Control}{/Shift}");
+      beforeEach(async () => {
+        await user.keyboard("{Shift>}{Control>}P{/Control}{/Shift}");
       });
 
       it("renders", () => {
@@ -135,8 +138,8 @@ describe("Command Pallet: keyboard shortcut tests", () => {
       });
 
       describe("when pressing ESC", () => {
-        beforeEach(() => {
-          userEvent.keyboard("{Escape}");
+        beforeEach(async () => {
+          await user.keyboard("{Escape}");
         });
 
         it("renders", () => {

--- a/packages/core/src/features/helm-charts/add-helm-repository-from-list-in-preferences.test.ts
+++ b/packages/core/src/features/helm-charts/add-helm-repository-from-list-in-preferences.test.ts
@@ -15,6 +15,7 @@ import type { HelmRepo } from "../../common/helm/helm-repo";
 import requestPublicHelmRepositoriesInjectable from "./child-features/preferences/renderer/adding-of-public-helm-repository/public-helm-repositories/request-public-helm-repositories.injectable";
 import { showSuccessNotificationInjectable, showErrorNotificationInjectable } from "@freelensapp/notifications";
 import type { AsyncResult } from "@freelensapp/utilities";
+import userEvent from "@testing-library/user-event";
 
 describe("add helm repository from list in preferences", () => {
   let builder: ApplicationBuilder;
@@ -26,7 +27,7 @@ describe("add helm repository from list in preferences", () => {
   let callForPublicHelmRepositoriesMock: AsyncFnMock<() => Promise<HelmRepo[]>>;
 
   beforeEach(async () => {
-    builder = getApplicationBuilder();
+    builder = getApplicationBuilder(userEvent.setup({delay: null}));
 
     execFileMock = asyncFn();
     getActiveHelmRepositoriesMock = asyncFn();
@@ -113,7 +114,7 @@ describe("add helm repository from list in preferences", () => {
           beforeEach(async () => {
             getActiveHelmRepositoriesMock.mockClear();
 
-            builder.select.selectOption(
+            await builder.select.selectOption(
               "selection-of-active-public-helm-repository",
               "Some to be added repository",
             );

--- a/packages/core/src/features/helm-charts/installing-chart/installing-helm-chart-from-new-tab.test.ts
+++ b/packages/core/src/features/helm-charts/installing-chart/installing-helm-chart-from-new-tab.test.ts
@@ -31,6 +31,7 @@ import requestDetailedHelmReleaseInjectable from "../../../renderer/components/h
 import { flushPromises } from "@freelensapp/test-utils";
 import type { ListClusterHelmReleases } from "../../../main/helm/helm-service/list-helm-releases.injectable";
 import listClusterHelmReleasesInjectable from "../../../main/helm/helm-service/list-helm-releases.injectable";
+import userEvent from "@testing-library/user-event";
 
 describe("installing helm chart from new tab", () => {
   let builder: ApplicationBuilder;
@@ -43,7 +44,7 @@ describe("installing helm chart from new tab", () => {
   let listClusterHelmReleasesMock: AsyncFnMock<ListClusterHelmReleases>;
 
   beforeEach(() => {
-    builder = getApplicationBuilder();
+    builder = getApplicationBuilder(userEvent.setup({delay: null}));
 
     builder.setEnvironmentToClusterFrame();
 
@@ -647,7 +648,7 @@ describe("installing helm chart from new tab", () => {
           });
 
           describe("given changing version to be installed", () => {
-            let menu: { selectOption: (labelText: string) => void };
+            let menu: { selectOption: (labelText: string) => Promise<void> };
 
             beforeEach(() => {
               requestHelmChartVersionsMock.mockClear();
@@ -666,12 +667,12 @@ describe("installing helm chart from new tab", () => {
             describe("when version is selected", () => {
               let installButton: HTMLButtonElement;
 
-              beforeEach(() => {
+              beforeEach(async () => {
                 installButton = rendered.getByTestId(
                   "install-chart-from-tab-for-some-first-tab-id",
                 ) as HTMLButtonElement;
 
-                menu.selectOption("some-other-version");
+                await menu.selectOption("some-other-version");
               });
 
               it("renders", () => {
@@ -760,7 +761,7 @@ describe("installing helm chart from new tab", () => {
           });
 
           describe("given namespace selection is opened", () => {
-            let menu: { selectOption: (labelText: string) => void };
+            let menu: { selectOption: (labelText: string) => Promise<void> };
 
             beforeEach(() => {
               const menuId =
@@ -774,8 +775,8 @@ describe("installing helm chart from new tab", () => {
             });
 
             describe("when namespace is selected", () => {
-              beforeEach(() => {
-                menu.selectOption("some-other-namespace");
+              beforeEach(async () => {
+                await menu.selectOption("some-other-namespace");
               });
 
               it("renders", () => {
@@ -858,7 +859,7 @@ describe("installing helm chart from new tab", () => {
             });
 
             it("given change in version, when default configuration resolves, install button is enabled", async () => {
-              builder.select
+              await builder.select
                 .openMenu(
                   "install-chart-version-select-for-some-first-tab-id",
                 )
@@ -932,7 +933,7 @@ describe("installing helm chart from new tab", () => {
             });
 
             it("given version is changed, when default configuration resolves, defaults back to default configuration", async () => {
-              builder.select
+              await builder.select
                 .openMenu(
                   "install-chart-version-select-for-some-first-tab-id",
                 )

--- a/packages/core/src/features/helm-charts/installing-chart/opening-dock-tab-for-installing-helm-chart.test.ts
+++ b/packages/core/src/features/helm-charts/installing-chart/opening-dock-tab-for-installing-helm-chart.test.ts
@@ -22,6 +22,7 @@ import requestHelmChartsInjectable from "../../../common/k8s-api/endpoints/helm-
 import requestHelmChartVersionsInjectable from "../../../common/k8s-api/endpoints/helm-charts.api/request-versions.injectable";
 import requestHelmChartReadmeInjectable from "../../../common/k8s-api/endpoints/helm-charts.api/request-readme.injectable";
 import requestHelmChartValuesInjectable from "../../../common/k8s-api/endpoints/helm-charts.api/request-values.injectable";
+import userEvent from "@testing-library/user-event";
 
 describe("opening dock tab for installing helm chart", () => {
   let builder: ApplicationBuilder;
@@ -31,7 +32,7 @@ describe("opening dock tab for installing helm chart", () => {
   let requestHelmChartValuesMock: jest.Mock;
 
   beforeEach(() => {
-    builder = getApplicationBuilder();
+    builder = getApplicationBuilder(userEvent.setup({delay: null}));
 
     requestHelmChartsMock = asyncFn();
     requestHelmChartVersionsMock = asyncFn();
@@ -247,10 +248,10 @@ describe("opening dock tab for installing helm chart", () => {
             });
 
             describe("when selecting different version", () => {
-              beforeEach(() => {
+              beforeEach(async () => {
                 requestHelmChartReadmeMock.mockClear();
 
-                builder.select
+                await builder.select
                   .openMenu(
                     "helm-chart-version-selector-some-repository-some-name",
                   )

--- a/packages/core/src/features/hotbar/hovering-hotbar-menu.test.ts
+++ b/packages/core/src/features/hotbar/hovering-hotbar-menu.test.ts
@@ -4,6 +4,7 @@
  */
 
 import type { RenderResult } from "@testing-library/react";
+import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
@@ -11,11 +12,14 @@ import { getApplicationBuilder } from "../../renderer/components/test-utils/get-
 describe("hovering hotbar menu tests", () => {
   let builder: ApplicationBuilder;
   let result: RenderResult;
+  let user: UserEvent;
 
   beforeEach(async () => {
     builder = getApplicationBuilder();
 
     result = await builder.render();
+
+    user = userEvent.setup({delay: null});
   });
 
   it("renders", () => {
@@ -27,8 +31,8 @@ describe("hovering hotbar menu tests", () => {
   });
 
   describe("when hovering over the hotbar menu", () => {
-    beforeEach(() => {
-      userEvent.hover(result.getByTestId("hotbar-menu-badge-for-Default"));
+    beforeEach(async () => {
+      await user.hover(result.getByTestId("hotbar-menu-badge-for-Default"));
     });
 
     it("renders", () => {

--- a/packages/core/src/features/preferences/navigation-to-extension-specific-preferences.test.tsx
+++ b/packages/core/src/features/preferences/navigation-to-extension-specific-preferences.test.tsx
@@ -6,7 +6,7 @@ import type { RenderResult } from "@testing-library/react";
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import type { FakeExtensionOptions } from "../../renderer/components/test-utils/get-extension-fake";
 import type { Discover } from "@freelensapp/react-testing-library-discovery";
 import { discoverFor } from "@freelensapp/react-testing-library-discovery";

--- a/packages/core/src/renderer/components/avatar/__tests__/avatar.test.tsx
+++ b/packages/core/src/renderer/components/avatar/__tests__/avatar.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { Avatar } from "../avatar";
 import { Icon } from "@freelensapp/icon";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";

--- a/packages/core/src/renderer/components/catalog/__tests__/catalog-add-button.test.tsx
+++ b/packages/core/src/renderer/components/catalog/__tests__/catalog-add-button.test.tsx
@@ -4,6 +4,7 @@
  */
 import React from "react";
 import { screen } from "@testing-library/react";
+import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import type { CatalogCategorySpec } from "../../../../common/catalog";
 import { CatalogCategory } from "../../../../common/catalog";
@@ -29,11 +30,14 @@ class TestCatalogCategory extends CatalogCategory {
 
 describe("CatalogAddButton", () => {
   let render: DiRender;
+  let user: UserEvent;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
 
     render = renderFor(di);
+
+    user = userEvent.setup();
   });
 
   it("opens Add menu", async () => {
@@ -51,7 +55,7 @@ describe("CatalogAddButton", () => {
 
     render(<CatalogAddButton category={category}/>);
 
-    userEvent.hover(screen.getByLabelText("SpeedDial CatalogAddButton"));
+    await user.hover(screen.getByLabelText("SpeedDial CatalogAddButton"));
     await screen.findByTitle("Add from kubeconfig");
   });
 
@@ -79,7 +83,7 @@ describe("CatalogAddButton", () => {
 
     render(<CatalogAddButton category={category}/>);
 
-    userEvent.hover(screen.getByLabelText("SpeedDial CatalogAddButton"));
+    await user.hover(screen.getByLabelText("SpeedDial CatalogAddButton"));
 
     await expect(screen.findByTitle("Add from kubeconfig"))
       .rejects

--- a/packages/core/src/renderer/components/catalog/__tests__/catalog-category-label.test.tsx
+++ b/packages/core/src/renderer/components/catalog/__tests__/catalog-category-label.test.tsx
@@ -5,7 +5,7 @@
 
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import type { CatalogCategorySpec } from "../../../../common/catalog";
 import { CatalogCategory } from "../../../../common/catalog";
 import { CatalogCategoryLabel } from "../catalog-category-label";

--- a/packages/core/src/renderer/components/cluster-settings/__tests__/cluster-local-terminal-settings.test.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/__tests__/cluster-local-terminal-settings.test.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 import { waitFor } from "@testing-library/react";
 import { ClusterLocalTerminalSetting } from "../local-terminal-settings";
+import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import type { Stats } from "fs";
 import { Cluster } from "../../../../common/cluster/cluster";
@@ -21,6 +22,7 @@ describe("ClusterLocalTerminalSettings", () => {
   let showErrorNotificationMock: jest.Mock;
   let statMock: jest.Mock;
   let loadKubeconfigMock: jest.Mock;
+  let user: UserEvent;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -40,6 +42,8 @@ describe("ClusterLocalTerminalSettings", () => {
     di.override(loadKubeconfigInjectable, () => loadKubeconfigMock);
 
     render = renderFor(di);
+
+    user = userEvent.setup();
   });
 
   it("should render the current settings", async () => {
@@ -99,9 +103,9 @@ describe("ClusterLocalTerminalSettings", () => {
     const dom = render(<ClusterLocalTerminalSetting cluster={cluster}/>);
     const dn = await dom.findByTestId("default-namespace");
 
-    userEvent.click(dn);
-    userEvent.type(dn, "kube-system");
-    userEvent.click(dom.baseElement);
+    await user.click(dn);
+    await user.type(dn, "kube-system");
+    await user.click(dom.baseElement);
 
     await waitFor(() => expect(cluster.preferences.defaultNamespace).toBe("kube-system"));
   });
@@ -128,9 +132,9 @@ describe("ClusterLocalTerminalSettings", () => {
     const dom = render(<ClusterLocalTerminalSetting cluster={cluster}/>);
     const dn = await dom.findByTestId("working-directory");
 
-    userEvent.click(dn);
-    userEvent.type(dn, "/foobar");
-    userEvent.click(dom.baseElement);
+    await user.click(dn);
+    await user.type(dn, "/foobar");
+    await user.click(dom.baseElement);
 
     await waitFor(() => expect(cluster.preferences?.terminalCWD).toBe("/foobar"));
   });
@@ -158,9 +162,9 @@ describe("ClusterLocalTerminalSettings", () => {
     const dom = render(<ClusterLocalTerminalSetting cluster={cluster}/>);
     const dn = await dom.findByTestId("working-directory");
 
-    userEvent.click(dn);
-    userEvent.type(dn, "/foobar");
-    userEvent.click(dom.baseElement);
+    await user.click(dn);
+    await user.type(dn, "/foobar");
+    await user.click(dom.baseElement);
 
     await waitFor(() => expect(showErrorNotificationMock).toHaveBeenCalled());
   });

--- a/packages/core/src/renderer/components/cluster-settings/__tests__/icon-settings.test.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/__tests__/icon-settings.test.tsx
@@ -11,6 +11,7 @@ import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import { renderFor } from "../../test-utils/renderFor";
 import { ClusterIconSetting } from "../icon-settings";
 import { screen } from "@testing-library/react";
+import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import type { ClusterIconSettingComponentProps } from "@freelensapp/cluster-settings";
 import { clusterIconSettingsComponentInjectionToken, clusterIconSettingsMenuInjectionToken } from "@freelensapp/cluster-settings";
@@ -57,6 +58,7 @@ const newSettingsReactComponent = getInjectable({
 describe("Icon settings", () => {
   let rendered: RenderResult;
   let di: DiContainer;
+  let user: UserEvent;
 
   beforeEach(() => {
     di = getDiForUnitTesting();
@@ -89,6 +91,8 @@ describe("Icon settings", () => {
     rendered = render(
       <ClusterIconSetting cluster={cluster} entity={clusterEntity} />,
     );
+
+    user = userEvent.setup();
   });
 
   describe("given no external registrations for cluster settings menu injection token", () => {
@@ -97,13 +101,13 @@ describe("Icon settings", () => {
     });
 
     it("has predefined menu item", async () => {
-      userEvent.click(await screen.findByTestId("icon-for-menu-actions-for-cluster-icon-settings-for-some-entity-id"));
+      await user.click(await screen.findByTestId("icon-for-menu-actions-for-cluster-icon-settings-for-some-entity-id"));
 
       expect(rendered.getByText("Upload Icon")).toBeInTheDocument();
     });
 
     it("has menu item from build-in registration", async () => {
-      userEvent.click(await screen.findByTestId("icon-for-menu-actions-for-cluster-icon-settings-for-some-entity-id"));
+      await user.click(await screen.findByTestId("icon-for-menu-actions-for-cluster-icon-settings-for-some-entity-id"));
 
       expect(rendered.getByText("Clear")).toBeInTheDocument();
     });
@@ -117,7 +121,7 @@ describe("Icon settings", () => {
     });
 
     it("has menu item from external registration", async () => {
-      userEvent.click(await screen.findByTestId("icon-for-menu-actions-for-cluster-icon-settings-for-some-entity-id"));
+      await user.click(await screen.findByTestId("icon-for-menu-actions-for-cluster-icon-settings-for-some-entity-id"));
 
       expect(rendered.getByText("Hello World")).toBeInTheDocument();
     });

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
@@ -16,6 +16,7 @@ import callForLogsInjectable from "../call-for-logs.injectable";
 import type { LogTabViewModelDependencies } from "../logs-view-model";
 import { LogTabViewModel } from "../logs-view-model";
 import type { TabId } from "../../dock/store";
+import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import { SearchStore } from "../../../../search-store/search-store";
 import assert from "assert";
@@ -105,6 +106,7 @@ const getFewPodsTabData = (tabId: TabId, deps: Partial<LogTabViewModelDependenci
 
 describe("<LogResourceSelector />", () => {
   let render: DiRender;
+  let user: UserEvent;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -117,6 +119,8 @@ describe("<LogResourceSelector />", () => {
     render = renderFor(di);
 
     ensureDirSync("/tmp");
+
+    user = userEvent.setup();
   });
 
   describe("with one pod", () => {
@@ -195,7 +199,7 @@ describe("<LogResourceSelector />", () => {
       assert(selector);
 
       selectEvent.openMenu(selector);
-      userEvent.click(await findByText("deploymentPod2", { selector: ".pod-selector-menu .Select__option" }));
+      await user.click(await findByText("deploymentPod2", { selector: ".pod-selector-menu .Select__option" }));
       expect(renameTab).toBeCalledWith("foobar", "Pod deploymentPod2");
     });
   });

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import * as selectEvent from "react-select-event";
 import { LogResourceSelector } from "../resource-selector";
 import { dockerPod, deploymentPod1, deploymentPod2 } from "./pod.mock";

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
@@ -13,6 +13,7 @@ import type { LogTabViewModelDependencies } from "../logs-view-model";
 import { LogTabViewModel } from "../logs-view-model";
 import type { TabId } from "../../dock/store";
 import { LogSearch } from "../search";
+import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import { SearchStore } from "../../../../search-store/search-store";
 
@@ -61,11 +62,14 @@ const getOnePodViewModel = (tabId: TabId, deps: Partial<LogTabViewModelDependenc
 
 describe("LogSearch tests", () => {
   let render: DiRender;
+  let user: UserEvent;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
 
     render = renderFor(di);
+
+    user = userEvent.setup();
   });
 
   it("renders w/o errors", () => {
@@ -96,9 +100,9 @@ describe("LogSearch tests", () => {
       />,
     );
 
-    userEvent.click(await screen.findByPlaceholderText("Search..."));
-    userEvent.keyboard("o");
-    userEvent.click(await screen.findByText("keyboard_arrow_up"));
+    await user.click(await screen.findByPlaceholderText("Search..."));
+    await user.keyboard("o");
+    await user.click(await screen.findByText("keyboard_arrow_up"));
     expect(scrollToOverlay).toBeCalled();
   });
 
@@ -118,9 +122,9 @@ describe("LogSearch tests", () => {
       />,
     );
 
-    userEvent.click(await screen.findByPlaceholderText("Search..."));
-    userEvent.keyboard("o");
-    userEvent.click(await screen.findByText("keyboard_arrow_down"));
+    await user.click(await screen.findByPlaceholderText("Search..."));
+    await user.keyboard("o");
+    await user.click(await screen.findByText("keyboard_arrow_down"));
     expect(scrollToOverlay).toBeCalled();
   });
 
@@ -140,8 +144,8 @@ describe("LogSearch tests", () => {
       />,
     );
 
-    userEvent.click(await screen.findByText("keyboard_arrow_down"));
-    userEvent.click(await screen.findByText("keyboard_arrow_up"));
+    await user.click(await screen.findByText("keyboard_arrow_down"));
+    await user.click(await screen.findByText("keyboard_arrow_up"));
     expect(scrollToOverlay).not.toBeCalled();
   });
 });

--- a/packages/core/src/renderer/components/dock/logs/__test__/to-bottom.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/to-bottom.test.tsx
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { fireEvent } from "@testing-library/react";
 import { ToBottom } from "../to-bottom";
 import { noop } from "@freelensapp/utilities";

--- a/packages/core/src/renderer/components/extensions/__tests__/extensions.test.tsx
+++ b/packages/core/src/renderer/components/extensions/__tests__/extensions.test.tsx
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import type { ExtensionDiscovery } from "../../../../extensions/extension-discovery/extension-discovery";

--- a/packages/core/src/renderer/components/hotbar/__tests__/hotbar-remove-command.test.tsx
+++ b/packages/core/src/renderer/components/hotbar/__tests__/hotbar-remove-command.test.tsx
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { HotbarRemoveCommand } from "../hotbar-remove-command";
 import type { RenderResult } from "@testing-library/react";
 import { fireEvent } from "@testing-library/react";

--- a/packages/core/src/renderer/components/kube-object-list-layout/kube-object-list-layout.test.tsx
+++ b/packages/core/src/renderer/components/kube-object-list-layout/kube-object-list-layout.test.tsx
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import type { DiContainer } from "@ogre-tools/injectable";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import type { RenderResult } from "@testing-library/react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";

--- a/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
+++ b/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
@@ -7,6 +7,7 @@ import type { RenderResult } from "@testing-library/react";
 import { screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { KubeObject } from "@freelensapp/kube-object";
+import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import { getInjectable } from "@ogre-tools/injectable";
 import type { DiContainer } from "@ogre-tools/injectable";
@@ -35,6 +36,7 @@ import activeEntityIdInjectable from "../../api/catalog/entity/active-entity-id.
 describe("kube-object-menu", () => {
   let di: DiContainer;
   let render: DiRender;
+  let user: UserEvent;
 
   beforeEach(() => {
     di = getDiForUnitTesting();
@@ -71,6 +73,8 @@ describe("kube-object-menu", () => {
     di.override(hideDetailsInjectable, () => () => {});
 
     di.override(createEditResourceTabInjectable, () => () => "irrelevant");
+
+    user = userEvent.setup();
   });
 
   it("given no cluster, does not crash", () => {
@@ -165,7 +169,7 @@ describe("kube-object-menu", () => {
 
       describe("when removing new kube object", () => {
         beforeEach(async () => {
-          userEvent.click(await screen.findByTestId("menu-action-delete-for-/some-other-api-version/some-other-kind/some-other-namespace/some-other-name"));
+          await user.click(await screen.findByTestId("menu-action-delete-for-/some-other-api-version/some-other-kind/some-other-namespace/some-other-name"));
         });
 
         it("renders", async () => {
@@ -177,7 +181,7 @@ describe("kube-object-menu", () => {
 
     describe("when removing kube object", () => {
       beforeEach(async () => {
-        userEvent.click(await screen.findByTestId("menu-action-delete-for-/foo"));
+        await user.click(await screen.findByTestId("menu-action-delete-for-/foo"));
       });
 
       it("renders", async () => {
@@ -189,7 +193,7 @@ describe("kube-object-menu", () => {
         beforeEach(async () => {
           const confirmRemovalButton = await screen.findByTestId("confirm");
 
-          userEvent.click(confirmRemovalButton);
+          await user.click(confirmRemovalButton);
         });
 
         it("calls for removal of the kube object", () => {
@@ -242,7 +246,7 @@ describe("kube-object-menu", () => {
     it("when removing kube object, renders confirmation dialog with namespace", async () => {
       const menuItem = await screen.findByTestId("menu-action-delete-for-/foo");
 
-      userEvent.click(menuItem);
+      await user.click(menuItem);
 
       expect(baseElement).toMatchSnapshot();
     });
@@ -280,7 +284,7 @@ describe("kube-object-menu", () => {
     it("when removing kube object, renders confirmation dialog without namespace", async () => {
       const menuItem = await screen.findByTestId("menu-action-delete-for-/foo");
 
-      userEvent.click(menuItem);
+      await user.click(menuItem);
 
       expect(baseElement).toMatchSnapshot();
     });

--- a/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
+++ b/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import type { RenderResult } from "@testing-library/react";
 import { screen, waitFor } from "@testing-library/react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { KubeObject } from "@freelensapp/kube-object";
 import userEvent from "@testing-library/user-event";
 import { getInjectable } from "@ogre-tools/injectable";

--- a/packages/core/src/renderer/components/layout/__tests__/sidebar-cluster.test.tsx
+++ b/packages/core/src/renderer/components/layout/__tests__/sidebar-cluster.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import type { RenderResult } from "@testing-library/react";
 import { fireEvent } from "@testing-library/react";
 import { SidebarCluster } from "../sidebar-cluster";

--- a/packages/core/src/renderer/components/layout/top-bar/top-bar.test.tsx
+++ b/packages/core/src/renderer/components/layout/top-bar/top-bar.test.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { fireEvent } from "@testing-library/react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { TopBar } from "./top-bar";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import type { DiContainer } from "@ogre-tools/injectable";

--- a/packages/core/src/renderer/components/select/select.test.tsx
+++ b/packages/core/src/renderer/components/select/select.test.tsx
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import type { SelectOption } from "./select";
 import { Select } from "./select";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";

--- a/packages/core/src/renderer/components/switch/__tests__/switch.test.tsx
+++ b/packages/core/src/renderer/components/switch/__tests__/switch.test.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { fireEvent, render } from "@testing-library/react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { Switch } from "../switch";
 
 describe("<Switch/>", () => {

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/__tests__/dialog.test.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/__tests__/dialog.test.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 import { ClusterRoleBindingDialog } from "../dialog/view";
 import { ClusterRole } from "@freelensapp/kube-object";
+import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import type { DiRender } from "../../../test-utils/renderFor";
@@ -25,6 +26,7 @@ describe("ClusterRoleBindingDialog tests", () => {
   let render: DiRender;
   let closeClusterRoleBindingDialog: CloseClusterRoleBindingDialog;
   let openClusterRoleBindingDialog: OpenClusterRoleBindingDialog;
+  let user: UserEvent;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -58,6 +60,8 @@ describe("ClusterRoleBindingDialog tests", () => {
         },
       }),
     ]);
+
+    user = userEvent.setup();
   });
 
   afterEach(() => {
@@ -75,7 +79,7 @@ describe("ClusterRoleBindingDialog tests", () => {
     openClusterRoleBindingDialog();
     const res = render(<ClusterRoleBindingDialog />);
 
-    userEvent.keyboard("a");
+    await user.keyboard("a");
     await res.findAllByText("foobar");
   });
 });

--- a/packages/core/src/renderer/components/user-management/role-bindings/__tests__/dialog.test.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/__tests__/dialog.test.tsx
@@ -3,6 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { ClusterRole } from "@freelensapp/kube-object";
@@ -22,6 +23,7 @@ import { Cluster } from "../../../../../common/cluster/cluster";
 describe("RoleBindingDialog tests", () => {
   let render: DiRender;
   let openRoleBindingDialog: OpenRoleBindingDialog;
+  let user: UserEvent;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -54,6 +56,8 @@ describe("RoleBindingDialog tests", () => {
         },
       }),
     ]);
+
+    user = userEvent.setup();
   });
 
   it("should render without any errors", () => {
@@ -66,7 +70,7 @@ describe("RoleBindingDialog tests", () => {
     openRoleBindingDialog();
     const res = render(<RoleBindingDialog />);
 
-    userEvent.click(await res.findByText("Select role", { exact: false }));
+    await user.click(await res.findByText("Select role", { exact: false }));
 
     await res.findAllByText("foobar", {
       exact: false,

--- a/packages/core/src/renderer/components/workloads-pods/__tests__/pod-tolerations.test.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/__tests__/pod-tolerations.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { fireEvent } from "@testing-library/react";
 import type { Toleration } from "@freelensapp/kube-object";
 import { PodTolerations } from "../pod-tolerations";

--- a/packages/infrastructure/jest/package.json
+++ b/packages/infrastructure/jest/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "homepage": "https://freelens.app",
   "dependencies": {
-    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/jest-dom": "^6.4.3",
     "@testing-library/react": "^12.1.5",
     "@types/jest": "^29.5.14",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -50,6 +50,6 @@
     "@freelensapp/react-testing-library-discovery": "^1.1.0",
     "@freelensapp/webpack": "^1.1.0",
     "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^13.5.0"
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -49,7 +49,6 @@
     "@freelensapp/eslint-config": "^1.1.0",
     "@freelensapp/react-testing-library-discovery": "^1.1.0",
     "@freelensapp/webpack": "^1.1.0",
-    "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/react": "^12.1.5"
   }
 }

--- a/packages/ui-components/button/package.json
+++ b/packages/ui-components/button/package.json
@@ -47,7 +47,6 @@
     "@freelensapp/eslint-config": "^1.1.0",
     "@freelensapp/react-testing-library-discovery": "^1.1.0",
     "@freelensapp/webpack": "^1.1.0",
-    "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^13.5.0"
+    "@testing-library/react": "^12.1.5"
   }
 }

--- a/packages/ui-components/button/package.json
+++ b/packages/ui-components/button/package.json
@@ -48,6 +48,6 @@
     "@freelensapp/react-testing-library-discovery": "^1.1.0",
     "@freelensapp/webpack": "^1.1.0",
     "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^12.8.3"
+    "@testing-library/user-event": "^13.5.0"
   }
 }

--- a/packages/ui-components/error-boundary/package.json
+++ b/packages/ui-components/error-boundary/package.json
@@ -52,7 +52,6 @@
     "@freelensapp/eslint-config": "^1.1.0",
     "@freelensapp/react-testing-library-discovery": "^1.1.0",
     "@freelensapp/webpack": "^1.1.0",
-    "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^13.5.0"
+    "@testing-library/react": "^12.1.5"
   }
 }

--- a/packages/ui-components/icon/package.json
+++ b/packages/ui-components/icon/package.json
@@ -60,7 +60,6 @@
     "@freelensapp/eslint-config": "^1.1.0",
     "@freelensapp/react-testing-library-discovery": "^1.1.0",
     "@freelensapp/webpack": "^1.1.0",
-    "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^13.5.0"
+    "@testing-library/react": "^12.1.5"
   }
 }

--- a/packages/ui-components/tooltip/package.json
+++ b/packages/ui-components/tooltip/package.json
@@ -48,6 +48,6 @@
     "@freelensapp/react-testing-library-discovery": "^1.1.0",
     "@freelensapp/webpack": "^1.1.0",
     "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^13.5.0"
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/ui-components/tooltip/package.json
+++ b/packages/ui-components/tooltip/package.json
@@ -48,6 +48,6 @@
     "@freelensapp/react-testing-library-discovery": "^1.1.0",
     "@freelensapp/webpack": "^1.1.0",
     "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^12.8.3"
+    "@testing-library/user-event": "^13.5.0"
   }
 }

--- a/packages/ui-components/tooltip/src/tooltip.test.tsx
+++ b/packages/ui-components/tooltip/src/tooltip.test.tsx
@@ -5,11 +5,12 @@
 
 import { render } from "@testing-library/react";
 import type { RenderResult } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import userEvent, { UserEvent } from "@testing-library/user-event";
 import assert from "assert";
 import React from "react";
 import { computeNextPosition, RectangleDimensions } from "./helpers";
 import { Tooltip, TooltipPosition } from "./tooltip";
+import "@testing-library/jest-dom";
 
 const getRectangle = (parts: Omit<RectangleDimensions, "width" | "height">): RectangleDimensions => {
   assert(parts.right >= parts.left);
@@ -24,6 +25,7 @@ const getRectangle = (parts: Omit<RectangleDimensions, "width" | "height">): Rec
 
 describe("<Tooltip />", () => {
   let requestAnimationFrameSpy: jest.SpyInstance<number, [callback: FrameRequestCallback]>;
+  let user: UserEvent;
 
   beforeEach(() => {
     requestAnimationFrameSpy = jest.spyOn(window, "requestAnimationFrame");
@@ -33,6 +35,7 @@ describe("<Tooltip />", () => {
 
       return 0;
     });
+    user = userEvent.setup();
   });
 
   afterEach(() => {
@@ -52,7 +55,7 @@ describe("<Tooltip />", () => {
     expect(result.baseElement).toMatchSnapshot();
   });
 
-  it("renders to DOM when hovering over target", () => {
+  it("renders to DOM when hovering over target", async () => {
     const result = render(
       <>
         <Tooltip targetId="my-target" data-testid="tooltip" usePortal={false}>
@@ -66,7 +69,7 @@ describe("<Tooltip />", () => {
 
     assert(target);
 
-    userEvent.hover(target);
+    await user.hover(target);
     expect(result.baseElement).toMatchSnapshot();
   });
 
@@ -121,8 +124,8 @@ describe("<Tooltip />", () => {
     });
 
     describe("when hovering over the target element", () => {
-      beforeEach(() => {
-        userEvent.hover(result.getByTestId("target"));
+      beforeEach(async () => {
+        await user.hover(result.getByTestId("target"));
       });
 
       it("renders", () => {
@@ -134,8 +137,8 @@ describe("<Tooltip />", () => {
       });
 
       describe("when no longer hovering the target", () => {
-        beforeEach(() => {
-          userEvent.unhover(result.getByTestId("target"));
+        beforeEach(async () => {
+          await user.unhover(result.getByTestId("target"));
         });
 
         it("renders", () => {
@@ -176,8 +179,8 @@ describe("<Tooltip />", () => {
     });
 
     describe("when hovering over the target element", () => {
-      beforeEach(() => {
-        userEvent.hover(result.getByTestId("target"));
+      beforeEach(async () => {
+        await user.hover(result.getByTestId("target"));
       });
 
       it("renders", () => {
@@ -189,8 +192,8 @@ describe("<Tooltip />", () => {
       });
 
       describe("when no longer hovering the target", () => {
-        beforeEach(() => {
-          userEvent.unhover(result.getByTestId("target"));
+        beforeEach(async () => {
+          await user.unhover(result.getByTestId("target"));
         });
 
         it("renders", () => {
@@ -204,8 +207,8 @@ describe("<Tooltip />", () => {
     });
 
     describe("when hovering over the target's parent element", () => {
-      beforeEach(() => {
-        userEvent.hover(result.getByTestId("target-parent"));
+      beforeEach(async () => {
+        await user.hover(result.getByTestId("target-parent"));
       });
 
       it("renders", () => {
@@ -217,8 +220,8 @@ describe("<Tooltip />", () => {
       });
 
       describe("when no longer hovering the target's parent", () => {
-        beforeEach(() => {
-          userEvent.unhover(result.getByTestId("target-parent"));
+        beforeEach(async () => {
+          await user.unhover(result.getByTestId("target-parent"));
         });
 
         it("renders", () => {

--- a/packages/ui-components/tooltip/src/withTooltip.test.tsx
+++ b/packages/ui-components/tooltip/src/withTooltip.test.tsx
@@ -5,9 +5,10 @@
 
 import type { StrictReactNode } from "@freelensapp/utilities";
 import { render, RenderResult } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import userEvent, { UserEvent } from "@testing-library/user-event";
 import React from "react";
 import { withTooltip } from "./withTooltip";
+import "@testing-library/jest-dom";
 
 type MyComponentProps = {
   text: string;
@@ -24,6 +25,12 @@ const MyComponent = withTooltip(({ text, "data-testid": testId, id, children }: 
 ));
 
 describe("withTooltip tests", () => {
+  let user: UserEvent;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
   it("does not render a tooltip when not specified", () => {
     const result = render(<MyComponent text="foobar" />);
 
@@ -48,8 +55,8 @@ describe("withTooltip tests", () => {
     });
 
     describe("when hovering the component", () => {
-      beforeEach(() => {
-        userEvent.hover(result.getByTestId("my-test-id"));
+      beforeEach(async () => {
+        await user.hover(result.getByTestId("my-test-id"));
       });
 
       it("renders", () => {
@@ -76,8 +83,8 @@ describe("withTooltip tests", () => {
     });
 
     describe("when hovering the component", () => {
-      beforeEach(() => {
-        userEvent.hover(result.getByTestId("my-test-id"));
+      beforeEach(async () => {
+        await user.hover(result.getByTestId("my-test-id"));
       });
 
       it("renders", () => {

--- a/packages/utility-features/react-testing-library-discovery/package.json
+++ b/packages/utility-features/react-testing-library-discovery/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@freelensapp/webpack": "^1.1.0",
     "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/jest-dom": "^6.4.3",
     "@testing-library/react": "^12.1.5"
   }
 }

--- a/packages/utility-features/react-testing-library-discovery/package.json
+++ b/packages/utility-features/react-testing-library-discovery/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@freelensapp/webpack": "^1.1.0",
-    "@testing-library/dom": "^8.20.1",
+    "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^12.1.5"
   }

--- a/packages/utility-features/react-testing-library-discovery/package.json
+++ b/packages/utility-features/react-testing-library-discovery/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@freelensapp/webpack": "^1.1.0",
-    "@testing-library/dom": "^9.3.4",
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^12.1.5"
   }


### PR DESCRIPTION
Replaces most of #236, does not upgrade [@testing-library/react](https://redirect.github.com/testing-library/react-testing-library) yet, as React needs to be upgraded first.

Happy to see someone carrying on Lens/OpenLens.