### PR TITLE
Fix spacing issue in error boundary

### DIFF
--- a/packages/ui-components/error-boundary/src/error-boundary.tsx
+++ b/packages/ui-components/error-boundary/src/error-boundary.tsx
@@ -57,11 +57,11 @@ class NonInjectedErrorBoundary extends React.Component<
             <span className="contrast">{window.location.pathname}</span>
           </h5>
           <p>
-            {"To help us improve the product please report bugs on"}
+            {"To help us improve the product please report bugs on "}
             <a href={forumsUrl} rel="noreferrer" target="_blank">
               Lens Forums
             </a>
-            {" or on our"}
+            {" or on our "}
             <a href={issuesTrackerUrl} rel="noreferrer" target="_blank">
               Github
             </a>


### PR DESCRIPTION
There was no space between these words and the link.

Didn't see any tests for this file, but it fixed it locally.