### PR TITLE
Replaced deprecated navigation-related APIs in Electron

### DIFF
--- a/packages/core/src/features/application-menu/main/menu-items/view/go-back/go-back-menu-item.injectable.ts
+++ b/packages/core/src/features/application-menu/main/menu-items/view/go-back/go-back-menu-item.injectable.ts
@@ -21,7 +21,7 @@ const goBackMenuItemInjectable = getInjectable({
       webContents
         .getAllWebContents()
         .filter((wc) => wc.getType() === "window")
-        .forEach((wc) => wc.goBack());
+        .forEach((wc) => wc.navigationHistory.goBack());
     },
   }),
 

--- a/packages/core/src/features/application-menu/main/menu-items/view/go-forward/go-forward-menu-item.injectable.ts
+++ b/packages/core/src/features/application-menu/main/menu-items/view/go-forward/go-forward-menu-item.injectable.ts
@@ -21,7 +21,7 @@ const goForwardMenuItemInjectable = getInjectable({
       webContents
         .getAllWebContents()
         .filter((wc) => wc.getType() === "window")
-        .forEach((wc) => wc.goForward());
+        .forEach((wc) => wc.navigationHistory.goForward());
     },
   }),
 

--- a/packages/core/src/main/ipc/window.ts
+++ b/packages/core/src/main/ipc/window.ts
@@ -14,12 +14,12 @@ export function handleWindowAction(action: WindowAction) {
 
   switch (action) {
     case WindowAction.GO_BACK: {
-      window.webContents.goBack();
+      window.webContents.navigationHistory.goBack();
       break;
     }
 
     case WindowAction.GO_FORWARD: {
-      window.webContents.goForward();
+      window.webContents.navigationHistory.goForward();
       break;
     }
 
@@ -52,7 +52,7 @@ export function onLocationChange(): void {
 
   const canGoBack = getAllWebContents.some((webContent) => {
     if (webContent.getType() === "window") {
-      return webContent.canGoBack();
+      return webContent.navigationHistory.canGoBack();
     }
 
     return false;
@@ -60,7 +60,7 @@ export function onLocationChange(): void {
 
   const canGoForward = getAllWebContents.some((webContent) => {
     if (webContent.getType() === "window") {
-      return webContent.canGoForward();
+      return webContent.navigationHistory.canGoForward();
     }
 
     return false;

--- a/packages/core/src/main/start-main-application/lens-window/application-window/create-electron-window.injectable.ts
+++ b/packages/core/src/main/start-main-application/lens-window/application-window/create-electron-window.injectable.ts
@@ -185,7 +185,7 @@ const createElectronWindowInjectable = getInjectable({
           const wc = browserWindow.webContents;
 
           wc.reload();
-          wc.clearHistory();
+          wc.navigationHistory.clear();
         },
       };
     };


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #490

**Description of changes:**

- These APIs have been moved to the navigationHistory property of WebContents to provide a more structured and intuitive interface for managing navigation history.
