### PR TITLE
Less verbose warning about no Prometheus service found

### DIFF
--- a/packages/core/src/main/routes/metrics/add-metrics-route.injectable.ts
+++ b/packages/core/src/main/routes/metrics/add-metrics-route.injectable.ts
@@ -115,7 +115,7 @@ const addMetricsRouteInjectable = getRouteInjectable({
       } catch (error) {
         prometheusMetadata.success = false;
 
-        logger.warn(`[METRICS-ROUTE]: failed to get metrics for clusterId=${cluster.id}:`, error);
+        logger.warn(`[METRICS-ROUTE]: failed to get metrics for clusterId=${cluster.id}: ${error}`);
 
         return { response: {}};
       } finally {


### PR DESCRIPTION
Full stack trace kills the output.