### PR TITLE
Disable publishing and updating

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -164,7 +164,7 @@ jobs:
         run: npm run build
 
       - name: Build Electron app
-        run: npm run build:app -- -- -- dir ${{ matrix.targets }} --publish=never --${{ matrix.arch }}
+        run: npm run build:app -- -- -- dir ${{ matrix.targets }} --${{ matrix.arch }}
 
       - name: Run integration tests (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -193,7 +193,6 @@ jobs:
             done
             npm run build:app -- -- -- \
               dmg pkg \
-              --publish never \
               --${{ matrix.arch }}
         env:
           APPLEID: ${{ secrets.APPLEID }}
@@ -234,7 +233,6 @@ jobs:
         run: |
           npm run build:app -- -- -- \
             AppImage deb rpm \
-            --publish never \
             --${{ matrix.arch }}
 
       - name: Build Electron app (Windows x64)
@@ -243,7 +241,6 @@ jobs:
         run: |
           npm run build:app -- -- -- \
             msi nsis \
-            --publish never \
             --${{ matrix.arch }}
 
       - name: Azure Trusted Signing (Windows x64)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,9 +70,9 @@ Finally, generate binary packages:
 
 ```sh
 # Debian/Ubuntu
-npm run build:app -- -- -- AppImage deb --publish never --arm64
+npm run build:app -- -- -- AppImage deb --arm64
 # MacOS
-npm run build:app -- -- -- dmg pkg --publish never --x86
+npm run build:app -- -- -- dmg pkg --x86
 ```
 
 ### Run app

--- a/freelens/package.json
+++ b/freelens/package.json
@@ -57,6 +57,7 @@
     "detectUpdateChannel": false,
     "electronVersion": "35.1.2",
     "generateUpdatesFilesForAllChannels": true,
+    "publish": [],
     "files": [
       "static/**/*",
       "!node_modules/@freelensapp/core/node_modules/**/*",

--- a/freelens/src/common/application-information.injectable.ts
+++ b/freelens/src/common/application-information.injectable.ts
@@ -26,6 +26,8 @@ const applicationInformationInjectable = getInjectable({
       dependencies,
     } = packageJson;
 
+    const publish = (build as any)?.publish;
+
     return {
       version,
       productName,
@@ -37,7 +39,7 @@ const applicationInformationInjectable = getInjectable({
       bundledHelmVersion,
       contentSecurityPolicy,
       welcomeRoute,
-      updatingIsEnabled: (build as any)?.publish?.length > 0,
+      updatingIsEnabled: publish instanceof Array ? publish?.length > 0 : false,
       dependencies,
     };
   },


### PR DESCRIPTION
Fix for errors in the workflow for integration tests.

On Windows electron-build tries to publish the package. 