### PR TITLE
Readme: Scoop package for Windows [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ winget install Freelensapp.Freelens
 
 The `--silent` option is supported to suppress all UI.
 
+#### Scoop
+
+Run the following command:
+
+```powershell
+scoop install freelens
+```
+
 ## Development
 
 Read [DEVELOPMENT.md](DEVELOPMENT.md) to see how to build the application

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The `--silent` option is supported to suppress all UI.
 Run the following command:
 
 ```powershell
+scoop bucket add extras
 scoop install freelens
 ```
 


### PR DESCRIPTION
This enables us to install the Freelens app using the `scoop` command. See [#15193](https://github.com/ScoopInstaller/Extras/pull/15193)