### PR TITLE
CI: replace nick-fields/retry@v3 with retry task

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -40,22 +40,16 @@ jobs:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/playwright
 
     steps:
-      - name: Add coreutils to PATH
-        if: runner.os == 'macOS'
-        run: echo "/usr/local/opt/coreutils/libexec/gnubin" >> $GITHUB_PATH
-
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install dependencies (macOS)
-        id: install-deps-macos
         if: runner.os == 'macOS'
-        run: timeout 300 brew install python-setuptools
-        continue-on-error: true
+        run: brew install coreutils python-setuptools
 
-      - name: Install dependencies (macOS) (retry)
-        if: runner.os == 'macOS' && steps.install-deps-macos.outcome == 'failure'
-        run: timeout 300 brew install python-setuptools
+      - name: Add coreutils to PATH (macOS)
+        if: runner.os == 'macOS'
+        run: echo "/usr/local/opt/coreutils/libexec/gnubin" >> $GITHUB_PATH
 
       - name: Install dependencies (Windows)
         id: install-deps-windows

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -44,22 +44,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies (macOS)
+        id: install-deps-macos
         if: runner.os == 'macOS'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: brew install python-setuptools
+        run: timeout 300 brew install python-setuptools
+        continue-on-error: true
+
+      - name: Install dependencies (macOS) (retry)
+        if: runner.os == 'macOS' && steps.install-deps-macos.outcome == 'failure'
+        run: timeout 300 brew install python-setuptools
 
       - name: Install dependencies (Windows)
+        id: install-deps-windows
         if: runner.os == 'Windows'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: choco install yq --yes --no-progress
+        run: timeout 300 choco install yq --yes --no-progress
+        continue-on-error: true
+
+      - name: Install dependencies (Windows) (retry)
+        if: runner.os == 'Windows' && steps.install-deps-windows.outcome == 'failure'
+        run: timeout 300 choco install yq --yes --no-progress
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -132,12 +134,15 @@ jobs:
           driver: docker
 
       - name: Install pnpm dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: pnpm install --color=always --prefer-offline --frozen-lockfile
+        id: install-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
 
@@ -167,26 +172,35 @@ jobs:
         run: pnpm --color=always build:app dir --${{ matrix.arch }}
 
       - name: Run integration tests (Linux)
+        id: integration-tests-linux
         if: runner.os == 'Linux'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_on: timeout
-          command: |
-            sudo chown root:root freelens/dist/linux-unpacked/chrome-sandbox
-            sudo chmod 4755 freelens/dist/linux-unpacked/chrome-sandbox
-            xvfb-run -a pnpm --color=always test:integration
+        run: |
+          sudo chown root:root freelens/dist/linux-unpacked/chrome-sandbox
+          sudo chmod 4755 freelens/dist/linux-unpacked/chrome-sandbox
+          timeout 600 xvfb-run -a pnpm --color=always test:integration
+        env:
+          DEBUG: pw:browser
+        continue-on-error: true
+
+      - name: Run integration tests (Linux) (retry)
+        if: runner.os == 'Linux' && steps.integration-tests-linux.outcome == 'failure'
+        run: |
+          sudo chown root:root freelens/dist/linux-unpacked/chrome-sandbox
+          sudo chmod 4755 freelens/dist/linux-unpacked/chrome-sandbox
+          timeout 600 xvfb-run -a pnpm --color=always test:integration
         env:
           DEBUG: pw:browser
 
       - name: Run integration tests (macOS, Windows)
+        id: integration-tests-macos-windows
         if: runner.os != 'Linux'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_on: timeout
-          command: pnpm --color=always test:integration
+        run: timeout 600 pnpm --color=always test:integration
+        env:
+          DEBUG: pw:browser
+        continue-on-error: true
+
+      - name: Run integration tests (macOS, Windows) (retry)
+        if: runner.os != 'Linux' && steps.integration-tests-macos-windows.outcome == 'failure'
+        run: timeout 600 pnpm --color=always test:integration
         env:
           DEBUG: pw:browser

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -38,9 +38,12 @@ jobs:
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/playwright
-      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
 
     steps:
+      - name: Add coreutils to PATH
+        if: runner.os == 'macOS'
+        run: echo "/usr/local/opt/coreutils/libexec/gnubin" >> $GITHUB_PATH
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -135,6 +135,7 @@ jobs:
 
       - name: Install pnpm dependencies
         id: install-pnpm
+        shell: bash
         run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
@@ -142,6 +143,7 @@ jobs:
 
       - name: Install pnpm dependencies (retry)
         if: steps.install-pnpm.outcome == 'failure'
+        shell: bash
         run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
@@ -201,6 +203,7 @@ jobs:
 
       - name: Run integration tests (macOS, Windows) (retry)
         if: runner.os != 'Linux' && steps.integration-tests-macos-windows.outcome == 'failure'
+        shell: bash
         run: timeout 600 pnpm --color=always test:integration
         env:
           DEBUG: pw:browser

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install coreutils python-setuptools
+        run: brew install bash coreutils python-setuptools
 
       - name: Add coreutils to PATH (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -38,6 +38,7 @@ jobs:
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/playwright
+      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
 
     steps:
       - name: Checkout
@@ -56,11 +57,13 @@ jobs:
       - name: Install dependencies (Windows)
         id: install-deps-windows
         if: runner.os == 'Windows'
+        shell: bash
         run: timeout 300 choco install yq --yes --no-progress
         continue-on-error: true
 
       - name: Install dependencies (Windows) (retry)
         if: runner.os == 'Windows' && steps.install-deps-windows.outcome == 'failure'
+        shell: bash
         run: timeout 300 choco install yq --yes --no-progress
 
       - name: Setup node

--- a/.github/workflows/kubectl-versions.yaml
+++ b/.github/workflows/kubectl-versions.yaml
@@ -60,12 +60,13 @@ jobs:
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
       - name: Install pnpm dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: pnpm --color=always install --prefer-offline --frozen-lockfile
+        id: install-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: kubectl versions
         run: pnpm --color=always compute-versions

--- a/.github/workflows/kubectl-versions.yaml
+++ b/.github/workflows/kubectl-versions.yaml
@@ -32,6 +32,9 @@ jobs:
       github.event_name != 'issue_comment' ||
       (startsWith(github.event.issue.title, 'Automated update of kubectl versions') && contains(github.event.comment.body, '/rerun'))
 
+    env:
+      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/kubectl-versions.yaml
+++ b/.github/workflows/kubectl-versions.yaml
@@ -32,9 +32,6 @@ jobs:
       github.event_name != 'issue_comment' ||
       (startsWith(github.event.issue.title, 'Automated update of kubectl versions') && contains(github.event.comment.body, '/rerun'))
 
-    env:
-      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -52,12 +52,13 @@ jobs:
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
       - name: Install pnpm dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: pnpm --color=always install --prefer-offline --frozen-lockfile
+        id: install-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Lint
         run: pnpm --color=always --stream lint

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -27,9 +27,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 
-    env:
-      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 
+    env:
+      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/npm-audit.yaml
+++ b/.github/workflows/npm-audit.yaml
@@ -60,12 +60,13 @@ jobs:
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
       - name: Install pnpm dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: pnpm --color=always install --prefer-offline --frozen-lockfile
+        id: install-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Run npm audit
         run: |

--- a/.github/workflows/npm-audit.yaml
+++ b/.github/workflows/npm-audit.yaml
@@ -32,6 +32,9 @@ jobs:
       github.event_name != 'issue_comment' ||
       (startsWith(github.event.issue.title, 'Automated npm audit') && contains(github.event.comment.body, '/rerun'))
 
+    env:
+      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/npm-audit.yaml
+++ b/.github/workflows/npm-audit.yaml
@@ -32,9 +32,6 @@ jobs:
       github.event_name != 'issue_comment' ||
       (startsWith(github.event.issue.title, 'Automated npm audit') && contains(github.event.comment.body, '/rerun'))
 
-    env:
-      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/npm-dedupe.yaml
+++ b/.github/workflows/npm-dedupe.yaml
@@ -60,12 +60,13 @@ jobs:
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
       - name: Install pnpm dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: pnpm --color=always install --prefer-offline --frozen-lockfile
+        id: install-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Run pnpm dedupe
         run: |

--- a/.github/workflows/npm-dedupe.yaml
+++ b/.github/workflows/npm-dedupe.yaml
@@ -32,6 +32,9 @@ jobs:
       github.event_name != 'issue_comment' ||
       (startsWith(github.event.issue.title, 'Automated npm dedupe') && contains(github.event.comment.body, '/rerun'))
 
+    env:
+      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/npm-dedupe.yaml
+++ b/.github/workflows/npm-dedupe.yaml
@@ -32,9 +32,6 @@ jobs:
       github.event_name != 'issue_comment' ||
       (startsWith(github.event.issue.title, 'Automated npm dedupe') && contains(github.event.comment.body, '/rerun'))
 
-    env:
-      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/npm-version.yaml
+++ b/.github/workflows/npm-version.yaml
@@ -54,12 +54,13 @@ jobs:
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
       - name: Install pnpm dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: pnpm --color=always install --prefer-offline --frozen-lockfile
+        id: install-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Set version
         run: |
@@ -74,12 +75,13 @@ jobs:
           newversion: ${{ github.event.inputs.newversion }}
 
       - name: Update pnpm dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_on: error
-          command: pnpm --color=always install --prefer-offline
+        id: update-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline
+        continue-on-error: true
+
+      - name: Update pnpm dependencies (retry)
+        if: steps.update-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline
 
       - name: Check for changes
         run: |

--- a/.github/workflows/npm-version.yaml
+++ b/.github/workflows/npm-version.yaml
@@ -27,6 +27,9 @@ jobs:
     environment: automated
     timeout-minutes: 10
 
+    env:
+      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/npm-version.yaml
+++ b/.github/workflows/npm-version.yaml
@@ -27,9 +27,6 @@ jobs:
     environment: automated
     timeout-minutes: 10
 
-    env:
-      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,33 +81,23 @@ jobs:
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: |
-            sudo apt-get -q update
-            sudo apt-get -q install -y --no-install-recommends \
-              gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        run: |
+          sudo apt-get -q update
+          sudo apt-get -q install -y --no-install-recommends \
+            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: brew install bash python-setuptools
+        run: brew install bash coreutils python-setuptools
+
+      - name: Add coreutils to PATH (macOS)
+        if: runner.os == 'macOS'
+        run: echo "/usr/local/opt/coreutils/libexec/gnubin" >> $GITHUB_PATH
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: choco install yq --yes --no-progress
+        shell: bash
+        run: choco install yq --yes --no-progress
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -154,12 +144,15 @@ jobs:
             ${{ matrix.os }}-${{ matrix.arch }}-electron-builder-
 
       - name: Install pnpm dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: pnpm --color=always install --prefer-offline --frozen-lockfile
+        id: install-pnpm
+        shell: bash
+        run: pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        shell: bash
+        run: pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Enable downloading for all architectures (macOS x64, Linux arm64)
         if: runner.os == 'macOS' && matrix.arch == 'x64' || runner.os == 'Linux' && matrix.arch == 'arm64'
@@ -181,19 +174,13 @@ jobs:
 
       - name: Build Electron app (macOS)
         if: runner.os == 'macOS'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          retry_wait_seconds: 600
-          command: |
-            for var in APPLEID APPLEIDPASS APPLETEAMID CSC_LINK CSC_KEY_PASSWORD CSC_INSTALLER_LINK CSC_INSTALLER_KEY_PASSWORD; do
-              test -n "${!var}" || unset $var
-            done
-            pnpm --color=always build:app \
-              dmg pkg \
-              --${{ matrix.arch }}
+        run: |
+          for var in APPLEID APPLEIDPASS APPLETEAMID CSC_LINK CSC_KEY_PASSWORD CSC_INSTALLER_LINK CSC_INSTALLER_KEY_PASSWORD; do
+            test -n "${!var}" || unset $var
+          done
+          pnpm --color=always build:app \
+            dmg pkg \
+            --${{ matrix.arch }}
         env:
           APPLEID: ${{ secrets.APPLEID }}
           APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
@@ -204,25 +191,63 @@ jobs:
           CSC_INSTALLER_KEY_PASSWORD: ${{ secrets.CSC_INSTALLER_KEY_PASSWORD }}
 
       - name: Notarize PKG (macOS)
+        id: notarize-pkg
         if: runner.os == 'macOS'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          retry_wait_seconds: 600
-          command: |
-            if [[ -n $APPLEID && -n $APPLEIDPASS && -n $APPLETEAMID ]]; then
-              pkgname=$(ls -1 freelens/dist/Freelens*.pkg | head -n1)
-              auth="--apple-id $APPLEID --password $APPLEIDPASS --team-id $APPLETEAMID"
-              xcrun notarytool submit $pkgname $auth --wait 2>&1 | tee freelens/dist/notarytool.log
-              uuid=$(awk '/id: / { print $2; exit; }' freelens/dist/notarytool.log)
-              sleep 60
-              if [[ -n $uuid ]]; then
-                xcrun notarytool log $uuid $auth
-                xcrun stapler staple $pkgname
-              fi
+        run: |
+          if [[ -n $APPLEID && -n $APPLEIDPASS && -n $APPLETEAMID ]]; then
+            pkgname=$(ls -1 freelens/dist/Freelens*.pkg | head -n1)
+            auth="--apple-id $APPLEID --password $APPLEIDPASS --team-id $APPLETEAMID"
+            xcrun notarytool submit $pkgname $auth --wait 2>&1 | tee freelens/dist/notarytool.log
+            uuid=$(awk '/id: / { print $2; exit; }' freelens/dist/notarytool.log)
+            sleep 60
+            if [[ -n $uuid ]]; then
+              xcrun notarytool log $uuid $auth
+              xcrun stapler staple $pkgname
             fi
+          fi
+        env:
+          APPLEID: ${{ secrets.APPLEID }}
+          APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
+          APPLETEAMID: ${{ secrets.APPLETEAMID }}
+        continue-on-error: true
+
+      - name: Notarize PKG (macOS) (retry)
+        id: notarize-pkg-2
+        if: runner.os == 'macOS' && steps.notarize-pkg.outcome == 'failure'
+        run: |
+          if [[ -n $APPLEID && -n $APPLEIDPASS && -n $APPLETEAMID ]]; then
+            sleep 600
+            pkgname=$(ls -1 freelens/dist/Freelens*.pkg | head -n1)
+            auth="--apple-id $APPLEID --password $APPLEIDPASS --team-id $APPLETEAMID"
+            xcrun notarytool submit $pkgname $auth --wait 2>&1 | tee freelens/dist/notarytool.log
+            uuid=$(awk '/id: / { print $2; exit; }' freelens/dist/notarytool.log)
+            sleep 60
+            if [[ -n $uuid ]]; then
+              xcrun notarytool log $uuid $auth
+              xcrun stapler staple $pkgname
+            fi
+          fi
+        env:
+          APPLEID: ${{ secrets.APPLEID }}
+          APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
+          APPLETEAMID: ${{ secrets.APPLETEAMID }}
+        continue-on-error: true
+
+      - name: Notarize PKG (macOS) (retry 2)
+        if: runner.os == 'macOS' && steps.notarize-pkg-2.outcome == 'failure'
+        run: |
+          if [[ -n $APPLEID && -n $APPLEIDPASS && -n $APPLETEAMID ]]; then
+            sleep 600
+            pkgname=$(ls -1 freelens/dist/Freelens*.pkg | head -n1)
+            auth="--apple-id $APPLEID --password $APPLEIDPASS --team-id $APPLETEAMID"
+            xcrun notarytool submit $pkgname $auth --wait 2>&1 | tee freelens/dist/notarytool.log
+            uuid=$(awk '/id: / { print $2; exit; }' freelens/dist/notarytool.log)
+            sleep 60
+            if [[ -n $uuid ]]; then
+              xcrun notarytool log $uuid $auth
+              xcrun stapler staple $pkgname
+            fi
+          fi
         env:
           APPLEID: ${{ secrets.APPLEID }}
           APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
@@ -383,30 +408,58 @@ jobs:
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
       - name: Install pnpm dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: pnpm --color=always install --prefer-offline --frozen-lockfile
+        id: install-pnpm
+        shell: bash
+        run: pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        shell: bash
+        run: pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Build packages
         run: pnpm --color=always --stream build
 
       - name: Publish npm packages
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: |
-            case "${GITHUB_REF_NAME}" in
-              *-*) dist_tag=next;;
-              *) dist_tag=latest;;
-            esac
-            pnpm --color=always publish -r \
-              --no-git-checks \
-              --tag ${dist_tag}
+        id: publish-npm
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            *-*) dist_tag=next;;
+            *) dist_tag=latest;;
+          esac
+          pnpm --color=always publish -r \
+            --no-git-checks \
+            --tag ${dist_tag}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        continue-on-error: true
+
+      - name: Publish npm packages (retry)
+        id: publish-npm-2
+        if: steps.publish-npm.outcome == 'failure'
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            *-*) dist_tag=next;;
+            *) dist_tag=latest;;
+          esac
+          pnpm --color=always publish -r \
+            --no-git-checks \
+            --tag ${dist_tag}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        continue-on-error: true
+
+      - name: Publish npm packages (retry 2)
+        if: steps.publish-npm-2.outcome == 'failure'
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            *-*) dist_tag=next;;
+            *) dist_tag=latest;;
+          esac
+          pnpm --color=always publish -r \
+            --no-git-checks \
+            --tag ${dist_tag}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -62,13 +62,14 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
-      - name: Install dependencies for plugin
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_on: error
-          command: pnpm --color=always install --prefer-offline --frozen-lockfile
+      - name: Install pnpm dependencies
+        id: install-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Set up Trunk
         run: curl https://get.trunk.io -fsSL | bash -s -- -y

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -36,9 +36,6 @@ jobs:
       github.event_name != 'issue_comment' ||
       (startsWith(github.event.issue.title, 'Automated trunk upgrade') && contains(github.event.comment.body, '/rerun'))
 
-    env:
-      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -36,6 +36,9 @@ jobs:
       github.event_name != 'issue_comment' ||
       (startsWith(github.event.issue.title, 'Automated trunk upgrade') && contains(github.event.comment.body, '/rerun'))
 
+    env:
+      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
+    env:
+      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -27,10 +27,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
-    env:
-      PATH: /usr/local/opt/coreutils/libexec/gnubin:{{ env.PATH}}
-
     steps:
+      - name: Add coreutils to PATH
+        if: runner.os == 'macOS'
+        run: echo "/usr/local/opt/coreutils/libexec/gnubin" >> $GITHUB_PATH
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -52,21 +52,23 @@ jobs:
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
       - name: Install dependencies (macOS)
+        id: install-deps-macos
         if: runner.os == 'macOS'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: brew install python-setuptools
+        run: timeout 300 brew install python-setuptools
+        continue-on-error: true
+
+      - name: Install dependencies (macOS) (retry)
+        if: runner.os == 'macOS' && steps.install-deps-macos.outcome == 'failure'
+        run: timeout 300 brew install python-setuptools
 
       - name: Install pnpm dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: pnpm --color=always install --prefer-offline --frozen-lockfile
+        id: install-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Build packages
         run: pnpm --color=always --stream build


### PR DESCRIPTION
Replaces action for retries with native syntax because messages from nick-fields/retry are folded and native syntax is more friendly to browse.
