### PR TITLE
fix: update `notarize.js` to use dynamic import for `@electron/notarize` module

### DIFF
--- a/freelens/build/notarize.js
+++ b/freelens/build/notarize.js
@@ -3,9 +3,9 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-const { notarize } = require("@electron/notarize");
 
 exports.default = async function notarizing(context) {
+  const { notarize } = await import('@electron/notarize');
   const { electronPlatformName, appOutDir } = context;
 
   if (electronPlatformName !== "darwin") {


### PR DESCRIPTION
Replace CommonJS `require()` with ES Module dynamic import to resolve `require() of ES Module not supported` error during build process. The `@electron/notarize` package is now an ES Module and requires this approach for compatibility with electron-builder.