### PR TITLE
Remove electron from ASAR explicitely

### DIFF
--- a/freelens/electron-builder.yml
+++ b/freelens/electron-builder.yml
@@ -14,6 +14,8 @@ publish: []
 files:
   - static
   - "!node_modules/@freelensapp/*/src"
+  - "!node_modules/@freelensapp/core/build"
+  - "!node_modules/@freelensapp/core/static"
   - "!node_modules/electron"
   - "!node_modules/win-ca/pem"
 

--- a/freelens/electron-builder.yml
+++ b/freelens/electron-builder.yml
@@ -15,7 +15,7 @@ files:
   - static
   - "!node_modules/@freelensapp/*/src"
   - "!node_modules/@freelensapp/core/build"
-  - "!node_modules/@freelensapp/core/static"
+  - "!node_modules/@freelensapp/core/static/build/library/fonts"
   - "!node_modules/electron"
   - "!node_modules/win-ca/pem"
 

--- a/freelens/electron-builder.yml
+++ b/freelens/electron-builder.yml
@@ -12,10 +12,10 @@ publish: []
 
 ## Files in app.asar
 files:
-  - static/**/*
-  - "!node_modules/@freelensapp/core/node_modules/**/*"
-  - "!node_modules/@freelensapp/core/src"
-  - "!node_modules/win-ca/pem/*"
+  - static
+  - "!node_modules/@freelensapp/*/src"
+  - "!node_modules/electron"
+  - "!node_modules/win-ca/pem"
 
 ## Extra files added to unpacked resources
 extraResources:


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes https://github.com/freelensapp/freelens-nightly-builds/actions/runs/14850771633/job/41693805278

**Description of changes:**

- electron is added to ASAR even if it is in devDependencies but we can exclude it explicitely
- more tweaks for files in ASAR
