### PR TITLE
Modify light theme for primary and sub menu active state colors

### DIFF
--- a/packages/core/src/common/catalog-entities/general-catalog-entities/implementations/catalog-catalog-entity.injectable.ts
+++ b/packages/core/src/common/catalog-entities/general-catalog-entities/implementations/catalog-catalog-entity.injectable.ts
@@ -28,7 +28,7 @@ const catalogCatalogEntityInjectable = getInjectable({
         path: url,
         icon: {
           material: "view_list",
-          background: "#00a7a0",
+          background: "var(--primary)",
         },
       },
       status: {

--- a/packages/core/src/common/catalog-entities/general-catalog-entities/implementations/welcome-catalog-entity.injectable.ts
+++ b/packages/core/src/common/catalog-entities/general-catalog-entities/implementations/welcome-catalog-entity.injectable.ts
@@ -28,7 +28,7 @@ const welcomeCatalogEntityInjectable = getInjectable({
         path: url,
         icon: {
           material: "home",
-          background: "#00a7a0",
+          background: "var(--primary)",
         },
       },
       status: {

--- a/packages/core/src/features/preferences/common/preferences-catalog-entity.injectable.ts
+++ b/packages/core/src/features/preferences/common/preferences-catalog-entity.injectable.ts
@@ -28,7 +28,7 @@ const preferencesCatalogEntityInjectable = getInjectable({
         path: url,
         icon: {
           material: "settings",
-          background: "#00a7a0",
+          background: "var(--primary)",
         },
       },
       status: {

--- a/packages/core/src/renderer/components/layout/sidebar-items.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar-items.module.scss
@@ -13,8 +13,12 @@
     cursor: pointer;
 
     &:global(.active), &:hover {
-      background: var(--blue);
+      background: var(--primary);
       color: var(--sidebarActiveColor);
+
+      + .subMenu {
+        border-color: var(--primary);
+      }
     }
 
     span {
@@ -29,14 +33,10 @@
   .subMenu {
     border-left: 4px solid transparent;
 
-    &.active {
-      border-color: var(--blue);
-    }
-  
     .SidebarItem {
       color: var(--textColorPrimary);
       padding-left: 25px;
-  
+
       .navItem {
         padding-top: 4px;
         padding-bottom: 4px;
@@ -60,4 +60,3 @@
     }
   }
 }
-

--- a/packages/core/src/renderer/themes/lens-light.injectable.ts
+++ b/packages/core/src/renderer/themes/lens-light.injectable.ts
@@ -22,7 +22,7 @@ const lensLightThemeInjectable = getInjectable({
         magenta: "#c93dce",
         golden: "#ffc63d",
         halfGray: "#87909c80",
-        primary: "#800a7a0",
+        primary: "#00a7a0",
         textColorPrimary: "#555555",
         textColorSecondary: "#51575d",
         textColorTertiary: "#555555",


### PR DESCRIPTION
Hi! A few UI fixes for `Light` theme:
* primary color hex
* sidebar subMenu active state
* use primary for global icons