### PR TITLE
Add pnpm as a dependency for root workspace

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -4,6 +4,12 @@
   "project": [],
 
   "workspaces": {
+    ".": {
+      "ignoreDependencies": [
+        // used to run pnpm in monorepo workspaces from the root
+        "pnpm"
+      ]
+    },
     "freelens": {
       "entry": [
         "build/notarize.js",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "packageManager": "pnpm@10.11.0"
+  "packageManager": "pnpm@10.11.0",
+  "devDependencies": {
+    "pnpm": "10.11.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,11 @@ patchedDependencies:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      pnpm:
+        specifier: 10.11.0
+        version: 10.11.0
 
   freelens:
     dependencies:


### PR DESCRIPTION
If pnpm is used as alias `corepack pnpm` then running another pnpm from the package.json causes error like "command not found".

We have already pnpm in runtime dependencies then it is not a problem to add them into root as devDependencies.
