### PR TITLE
Icon property is optional in extensions

### DIFF
--- a/freelens/.npmignore
+++ b/freelens/.npmignore
@@ -1,5 +1,3 @@
 static/build
 binaries/
 dist/
-*.mjs
-*.mjs.map

--- a/packages/core/src/renderer/components/layout/cluster-page-menu.ts
+++ b/packages/core/src/renderer/components/layout/cluster-page-menu.ts
@@ -21,5 +21,5 @@ export interface ClusterPageMenuRegistration {
 }
 
 export interface ClusterPageMenuComponents {
-  Icon?: React.ComponentType<IconProps>;
+  Icon?: React.ComponentType<IconProps> | null | undefined;
 }


### PR DESCRIPTION
It allows to skip `as any` in extensions when Icon is skipped.