### PR TITLE
Align memory and CPU usage in pods table

### DIFF
--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-memory-usage-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-memory-usage-column.injectable.tsx
@@ -14,7 +14,10 @@ import { COLUMN_PRIORITY } from "./column-priority";
 const columnId = "memoryUsage";
 
 function bytesToUnitsAligned(bytes: number): string {
-  return bytesToUnits(bytes, { precision: 1 }).replace(/iB$/, "");
+  if (bytes < 1024) {
+    return `${(bytes / 1024).toFixed(1)}Ki`;
+  }
+  return bytesToUnits(bytes, { precision: 1 }).replace(/B$/, "");
 }
 
 export const podsUsedMemoryColumnInjectable = getInjectable({

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-memory-usage-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-memory-usage-column.injectable.tsx
@@ -13,6 +13,10 @@ import { COLUMN_PRIORITY } from "./column-priority";
 
 const columnId = "memoryUsage";
 
+function bytesToUnitsAligned(bytes: number): string {
+  return bytesToUnits(bytes, { precision: 1 }).replace(/iB$/, "");
+}
+
 export const podsUsedMemoryColumnInjectable = getInjectable({
   id: "pods-memory-usage-column",
   instantiate: (di) => ({
@@ -24,7 +28,7 @@ export const podsUsedMemoryColumnInjectable = getInjectable({
       const podStore = di.inject(podStoreInjectable);
       const metrics = podStore.getPodKubeMetrics(pod);
 
-      return <span>{bytesToUnits(metrics.memory)}</span>;
+      return <span>{bytesToUnitsAligned(metrics.memory)}</span>;
     },
     header: { title: "Memory", className: "memory", sortBy: columnId, id: columnId },
     sortingCallBack: (pod) => {

--- a/packages/core/src/renderer/components/workloads-pods/pods.scss
+++ b/packages/core/src/renderer/components/workloads-pods/pods.scss
@@ -23,10 +23,12 @@
 
     &.cpu {
       flex-grow: 0.5;
+      text-align: right;
     }
 
     &.memory {
       flex-grow: 0.8;
+      text-align: right;
     }
 
     &.restarts {

--- a/packages/core/src/renderer/components/workloads-pods/pods.scss
+++ b/packages/core/src/renderer/components/workloads-pods/pods.scss
@@ -23,12 +23,20 @@
 
     &.cpu {
       flex-grow: 0.5;
-      text-align: right;
+      justify-content: right;
+
+      &.sorting {
+        justify-content: left;
+      }
     }
 
     &.memory {
       flex-grow: 0.8;
-      text-align: right;
+      justify-content: right;
+
+      &.sorting {
+        justify-content: left;
+      }
     }
 
     &.restarts {

--- a/packages/utility-features/utilities/src/convert-memory.test.ts
+++ b/packages/utility-features/utilities/src/convert-memory.test.ts
@@ -55,6 +55,10 @@ describe("unitsToBytes", () => {
     expect(unitsToBytes("1234Pi")).toBe(unitsToBytes("1234PiB"));
   });
 
+  it("should parse with Ei suffix as the same as EiB", () => {
+    expect(unitsToBytes("1234Ei")).toBe(unitsToBytes("1234EiB"));
+  });
+
   it("given unrelated data, return NaN", () => {
     expect(unitsToBytes("I am not a number")).toBeNaN();
   });
@@ -108,6 +112,13 @@ describe("bytesToUnits", () => {
     expect(bytesToUnits(2048 ** 5)).toBe("32.0PiB");
     expect(bytesToUnits(1900 * 1024 ** 4)).toBe("1.9PiB");
     expect(bytesToUnits(50 * 1024 ** 5 + 1)).toBe("50.0PiB");
+  });
+
+  it("given a number within the magnitude of 1024^6..1024^7, format with EiB", () => {
+    expect(bytesToUnits(1024 ** 6)).toBe("1.0EiB");
+    expect(bytesToUnits(2048 ** 6)).toBe("64.0EiB");
+    expect(bytesToUnits(1900 * 1024 ** 5)).toBe("1.9EiB");
+    expect(bytesToUnits(50 * 1024 ** 6 + 1)).toBe("50.0EiB");
   });
 });
 

--- a/packages/utility-features/utilities/src/convertMemory.ts
+++ b/packages/utility-features/utilities/src/convertMemory.ts
@@ -7,19 +7,20 @@
 import assert from "assert";
 import { iter } from "./iter";
 
-// Helper to convert memory from units Ki, Mi, Gi, Ti, Pi to bytes and vise versa
+// Helper to convert memory from units Ki, Mi, Gi, Ti, Pi, Ei to bytes and vise versa
 
 const baseMagnitude = 1024;
-const maxMagnitude = ["PiB", baseMagnitude ** 5] as const;
+const maxMagnitude = ["EiB", baseMagnitude ** 6] as const;
 const magnitudes = new Map([
   ["B", 1] as const,
   ["KiB", baseMagnitude ** 1] as const,
   ["MiB", baseMagnitude ** 2] as const,
   ["GiB", baseMagnitude ** 3] as const,
   ["TiB", baseMagnitude ** 4] as const,
+  ["PiB", baseMagnitude ** 5] as const,
   maxMagnitude,
 ]);
-const unitRegex = /(?<value>[0-9]+(\.[0-9]*)?)(?<suffix>(B|[KMGTP]iB?))?/;
+const unitRegex = /(?<value>[0-9]+(\.[0-9]*)?)(?<suffix>(B|[KMGTPE]iB?))?/;
 
 type BinaryUnit = typeof magnitudes extends Map<infer Key, any> ? Key : never;
 


### PR DESCRIPTION
Also strips "B" and the end so all numbers are aligned. It saves also space and shows more important value in smaller screens.

<img width="1219" alt="image" src="https://github.com/user-attachments/assets/15a9d7aa-77d3-4cfb-8260-8c8e56c49de4" />


Follow up #776

FYI @HanCheo 