### PR TITLE
Provide KubeObjectAge in Extensions API

### DIFF
--- a/packages/core/src/extensions/renderer-api/components.ts
+++ b/packages/core/src/extensions/renderer-api/components.ts
@@ -124,6 +124,7 @@ export const getDetailsUrl = asLegacyGlobalFunctionForExtensionApi(getDetailsUrl
 export const showDetails = asLegacyGlobalFunctionForExtensionApi(showDetailsInjectable);
 
 // kube helpers
+export * from "../../renderer/components/kube-object";
 export * from "../../renderer/components/kube-object-details";
 export * from "../../renderer/components/kube-object-list-layout";
 export * from "../../renderer/components/kube-object-menu";

--- a/packages/core/src/renderer/components/kube-object/index.ts
+++ b/packages/core/src/renderer/components/kube-object/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+export * from "./age";


### PR DESCRIPTION
KubeObjectAge is missing in API and adding it in extensions takes a lot of unecessary code.