### PR TITLE
Restart proxy if port is not found

### DIFF
--- a/packages/core/src/main/kube-auth-proxy/create-kube-auth-proxy.injectable.ts
+++ b/packages/core/src/main/kube-auth-proxy/create-kube-auth-proxy.injectable.ts
@@ -141,14 +141,25 @@ const createKubeAuthProxyInjectable = getInjectable({
           }
         });
 
-        port = await getPortFromStream(proxyProcess.stdout, {
-          lineRegex: startingServeRegex,
-          onFind: () =>
-            broadcastConnectionUpdate({
-              level: "info",
-              message: "Authentication proxy started",
-            }),
-        });
+        try {
+          port = await getPortFromStream(proxyProcess.stdout, {
+            lineRegex: startingServeRegex,
+            onFind: () =>
+              broadcastConnectionUpdate({
+                level: "info",
+                message: "Authentication proxy started",
+              }),
+          });
+        } catch (error) {
+          logger.warn("[KUBE-AUTH-PROXY]: getPortFromStream failed", error);
+          broadcastConnectionUpdate({
+            level: "error",
+            message: "Proxy port can't be found, restarting...",
+          });
+          exit();
+
+          return run();
+        }
 
         logger.info(`[KUBE-AUTH-PROXY]: found port=${port}`);
 


### PR DESCRIPTION
Fixes:

```
warn:    ┏ [getPortFrom]: failed to retrieve port via starting to serve on (?<address>.+) +467ms
warn:    ┃ [1] {
warn:    ┃ [2]   '0': "~~ Freelens K8s Proxy, '1.3.2-SNAPSHOT-fb71c44' ~~\n" +
warn:    ┃ [3]     'kubeconfig: /Users/dex4er/.kube/config\n' +
warn:    ┃ [4]     'api prefix: /6595b4740c230fa2/\n' +
warn:    ┃ [5]     'kubeconfig context: kind-test\n' +
warn:    ┃ [6]   timestamp: '08/06/2025 22:28:09'
warn:    ┗ [7] }
(node:67302) UnhandledPromiseRejectionWarning: Error: failed to retrieve port from stream
    at Timeout._onTimeout (/Users/dex4er/Sources/freelens/freelens/freelens/dist/mac-arm64/Freelens.app/Contents/Resources/app.asar/node_modules/@freelensapp/core/static/build/library/main.js:42459:28)
    at listOnTimeout (node:internal/timers:588:17)
    at process.processTimers (node:internal/timers:523:7)
    at emitUnhandledRejectionWarning (node:internal/process/promises:301:15)
    at warnWithErrorCodeUnhandledRejectionsMode (node:internal/process/promises:409:5)
    at processPromiseRejections (node:internal/process/promises:475:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:106:32)
(node:67302) Error: failed to retrieve port from stream
    at Timeout._onTimeout (/Users/dex4er/Sources/freelens/freelens/freelens/dist/mac-arm64/Freelens.app/Contents/Resources/app.asar/node_modules/@freelensapp/core/static/build/library/main.js:42459:28)
    at listOnTimeout (node:internal/timers:588:17)
    at process.processTimers (node:internal/timers:523:7)
```
