### PR TITLE
Refactoring for loading CA certificates from Windows's store

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -229,6 +229,7 @@
     "@types/uuid": "^10.0.0",
     "@types/webpack-env": "^1.18.8",
     "@types/webpack-node-externals": "^3.0.4",
+    "@types/win-ca": "^3.5.4",
     "@types/ws": "^8.18.1",
     "circular-dependency-plugin": "^5.2.2",
     "css-loader": "^6.11.0",

--- a/packages/core/src/common/fetch/fetch.injectable.ts
+++ b/packages/core/src/common/fetch/fetch.injectable.ts
@@ -11,7 +11,9 @@ export type Fetch = typeof fetch;
 
 const fetchInjectable: Injectable<typeof fetch, unknown, void> = getInjectable({
   id: "fetch",
-  instantiate: () => fetch,
+  instantiate: (di) => {
+    return fetch;
+  },
   causesSideEffects: true,
 });
 

--- a/packages/core/src/features/certificate-authorities/main/darwin-request-system-cas.injectable.ts
+++ b/packages/core/src/features/certificate-authorities/main/darwin-request-system-cas.injectable.ts
@@ -49,6 +49,8 @@ const darwinRequestSystemCAsInjectable = getInjectable({
         } else if (!rootCAResult.callWasSuccessful) {
           logger.warn(`[INJECT-CAS]: Error retrieving root CAs: ${rootCAResult.error}`);
         } else {
+          const certs = [...new Set([...trustedResult.response, ...rootCAResult.response])];
+          logger.info(`[INJECT-CAS]: ${certs.length} CAs retrieved from system.`);
           return [...new Set([...trustedResult.response, ...rootCAResult.response])];
         }
 

--- a/packages/core/src/features/certificate-authorities/main/win32-request-system-cas.injectable.ts
+++ b/packages/core/src/features/certificate-authorities/main/win32-request-system-cas.injectable.ts
@@ -4,49 +4,24 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { loggerInjectionToken } from "@freelensapp/logger";
+import { loggerInjectionToken } from "@freelensapp/logger/dist";
 import { getInjectable } from "@ogre-tools/injectable";
-import execFileInjectable from "../../../common/fs/exec-file.injectable";
+import winCa from "win-ca/api";
 import { platformSpecificRequestSystemCAsInjectionToken } from "../common/request-system-cas-token";
-
-const pemEncoding = (hexEncodedCert: string) => {
-  const certData = Buffer.from(hexEncodedCert, "hex").toString("base64");
-  const lines = ["-----BEGIN CERTIFICATE-----"];
-
-  for (let i = 0; i < certData.length; i += 64) {
-    lines.push(certData.substring(i, i + 64));
-  }
-
-  lines.push("-----END CERTIFICATE-----", "");
-
-  return lines.join("\r\n");
-};
 
 const win32RequestSystemCAsInjectable = getInjectable({
   id: "win32-request-system-cas",
   instantiate: (di) => ({
     platform: "win32" as const,
     instantiate: () => {
-      const winCARootsExePath: string = __non_webpack_require__.resolve("win-ca/lib/roots.exe");
-      const execFile = di.inject(execFileInjectable);
       const logger = di.inject(loggerInjectionToken);
-
       return async () => {
-        /**
-         * This needs to be done manually because for some reason calling the api from "win-ca"
-         * directly fails to load "child_process" correctly on renderer
-         */
-        const result = await execFile(winCARootsExePath, {
-          maxBuffer: 128 * 1024 * 1024, // 128 MiB
-        });
-
-        if (!result.callWasSuccessful) {
-          logger.warn(`[INJECT-CAS]: Error retrieving CAs`, result.error);
-
-          return [];
+        const certs = [] as string[];
+        for await (let cert of winCa({ format: winCa.der2.pem, generator: true, async: true })) {
+          certs.push(cert.toString());
         }
-
-        return result.response.split("\r\n").filter(Boolean).map(pemEncoding);
+        logger.info(`[INJECT-CAS]: ${certs.length} CAs retrieved from system.`);
+        return certs;
       };
     },
   }),

--- a/packages/core/types/mocks.d.ts
+++ b/packages/core/types/mocks.d.ts
@@ -2,8 +2,6 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-declare module "win-ca"
-declare module "win-ca/api"
 
 // Support import for custom module extensions
 // https://www.typescriptlang.org/docs/handbook/modules.html#wildcard-module-declarations

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1058,6 +1058,9 @@ importers:
       '@types/webpack-node-externals':
         specifier: ^3.0.4
         version: 3.0.4(webpack-cli@6.0.1)
+      '@types/win-ca':
+        specifier: ^3.5.4
+        version: 3.5.4
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -4689,6 +4692,9 @@ packages:
 
   '@types/webpack@5.28.5':
     resolution: {integrity: sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw==}
+
+  '@types/win-ca@3.5.4':
+    resolution: {integrity: sha512-WDlA6ZvTg1g9ygKcDCQb4GjEtk0RcZyx09btQea9NZqfKPl+WtyOlEwNfYMhK2E5sRCo6hMtct1EX3l04yAC1A==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -10921,6 +10927,11 @@ snapshots:
       - webpack-cli
     optional: true
 
+  '@types/win-ca@3.5.4':
+    dependencies:
+      '@types/node': 22.15.32
+      '@types/node-forge': 1.3.11
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.15.32
@@ -11015,12 +11026,12 @@ snapshots:
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.99.9)':
     dependencies:
       webpack: 5.99.9(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.99.9)
+      webpack-cli: 6.0.1(webpack@5.99.9)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.99.9)':
     dependencies:
       webpack: 5.99.9(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.99.9)
+      webpack-cli: 6.0.1(webpack@5.99.9)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.2)(webpack@5.99.9)':
     dependencies:
@@ -15957,7 +15968,7 @@ snapshots:
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.99.9)
+      webpack-cli: 6.0.1(webpack@5.99.9)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild


### PR DESCRIPTION
- `win-ca/api` is used to load certificates and combine them in one array

There is a hope it will fix HTTP client for Windows arm64