### PR TITLE
Expose React JSX runtime for extensions

### DIFF
--- a/freelens/src/renderer/index.ts
+++ b/freelens/src/renderer/index.ts
@@ -79,6 +79,7 @@ export {
   MobxReact,
   React,
   ReactDOM,
+  ReactJsxRuntime,
   ReactRouter,
   ReactRouterDom,
 } from "@freelensapp/core/renderer";


### PR DESCRIPTION
It was exported in APIs but not `global`.