### PR TITLE
Use standard delete rather than eviction for removing pods

### DIFF
--- a/packages/core/src/common/k8s-api/kube-object.store.ts
+++ b/packages/core/src/common/k8s-api/kube-object.store.ts
@@ -408,9 +408,7 @@ export class KubeObjectStore<
   }
 
   async remove(item: K) {
-    // Some k8s apis might implement special more fine-grained "delete" request for resources (e.g. pod.api.ts)
-    // See also: https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/
-    await this.api.evict({ name: item.getName(), namespace: item.getNs() });
+    await this.api.delete({ name: item.getName(), namespace: item.getNs() });
     this.selectedItemsIds.delete(item.getId());
   }
 

--- a/packages/utility-features/kube-api/src/kube-api.ts
+++ b/packages/utility-features/kube-api/src/kube-api.ts
@@ -720,15 +720,6 @@ export class KubeApi<
     return parsed;
   }
 
-  /**
-   * Some k8s resources might implement special "delete" (e.g. pod.api)
-   * See also: https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/
-   * By default should work same as delete()
-   */
-  async evict(desc: DeleteResourceDescriptor): Promise<KubeStatus | KubeObject | unknown> {
-    return this.delete(desc);
-  }
-
   async delete({ propagationPolicy = "Background", ...desc }: DeleteResourceDescriptor) {
     await this.checkPreferredVersion();
     const apiUrl = this.formatUrlForNotListing(desc);


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #847

**Description of changes:**

- Removes `evict` from default APIs and leaves it only for pods API.
- Removing resources calls `delete` instead of `evict`.

