### PR TITLE
Manual trunk upgrade trunk-io/plugins v1.7.0 → v1.7.1

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,49 +7,18 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.0
+      ref: v1.7.1
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
     - go@1.21.0
-    - node@22.15.1!
+    - node@22.15.1! # datasource=node-version depName=node
     - python@3.11.9
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
-tools:
-  definitions:
-    - name: yamlfmt
-      runtime: go
-      package: github.com/google/yamlfmt/cmd/yamlfmt
-      shims: [yamlfmt]
-      known_good_version: 0.16.0
 lint:
   definitions:
-    - name: yamlfmt
-      files: [yaml]
-      description: Formats yaml files
-      commands:
-        - name: format
-          output: rewrite
-          run: yamlfmt ${target}
-          run_from: ${parent}
-          success_codes: [0, 1]
-          cache_results: true
-          formatter: true
-          in_place: true
-          batch: true
-      tools: [yamlfmt]
-      direct_configs:
-        - .yamlfmt
-        - .yamlfmt.yaml
-        - .yamlfmt.yml
-        - yamlfmt.yaml
-        - yamlfmt.yml
-      suggest_if: config_present
-      version_command:
-        parse_regex: ${semver}
-        run: yamlfmt -version
-      known_good_version: 0.16.0
+    # See https://github.com/trunk-io/plugins/pull/1063
     - name: biome
       files:
         - astro
@@ -70,7 +39,7 @@ lint:
           parse_regex: " *(?P<path>.*?):(?P<line>\\d+):(?P<col>\\d+) (?P<code>[^ ]+)(?:[^×]*\\n).*× (?P<message>.*)\\n"
           read_output_from: stderr
           run: biome check ${target}
-          run_from: ${parent}
+          run_from: ${root_or_parent_with_any_config}
         - output: rewrite
           success_codes:
             - 0
@@ -81,7 +50,8 @@ lint:
           in_place: true
           name: fmt
           run: biome check --fix "${target}"
-          run_from: ${parent}
+          run_from: ${root_or_parent_with_any_config}
+    # Prettier checks only *.scss files
     - name: prettier
       files:
         - sass
@@ -90,7 +60,7 @@ lint:
     - biome@2.0.5! # datasource=npm depName=@biomejs/biome
     - git-diff-check
     - markdownlint@0.45.0
-    - prettier@3.6.0
+    - prettier@3.6.0! # datasource=npm depName=prettier
     - shellcheck@0.10.0
     - shfmt@3.6.0
     - yamlfmt@0.17.2


### PR DESCRIPTION
- plugins v1.7.1
- yamlfmt is in upstream
- `${root_or_parent_with_any_config}` for biome
- renovate tag for node
