### PR TITLE
Run node-fetch with proxy from renderer to bypass CORS

### DIFF
--- a/packages/core/src/common/fetch/proxy-download-binary.injectable.ts
+++ b/packages/core/src/common/fetch/proxy-download-binary.injectable.ts
@@ -5,20 +5,22 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import fetchInjectable from "./fetch.injectable";
+import proxyFetchInjectable from "./proxy-fetch.injectable";
 
 import type { AsyncResult } from "@freelensapp/utilities";
 
-export interface DownloadBinaryOptions {
+import type { Response } from "./node-fetch.injectable";
+
+export interface ProxyDownloadBinaryOptions {
   signal?: AbortSignal | null | undefined;
 }
 
-export type DownloadBinary = (url: string, opts?: DownloadBinaryOptions) => AsyncResult<Buffer, string>;
+export type ProxyDownloadBinary = (url: string, opts?: ProxyDownloadBinaryOptions) => AsyncResult<Buffer, string>;
 
-const downloadBinaryInjectable = getInjectable({
-  id: "download-binary",
-  instantiate: (di): DownloadBinary => {
-    const fetch = di.inject(fetchInjectable);
+const proxyDownloadBinaryInjectable = getInjectable({
+  id: "proxy-download-binary",
+  instantiate: (di): ProxyDownloadBinary => {
+    const fetch = di.inject(proxyFetchInjectable);
 
     return async (url, opts) => {
       let result: Response;
@@ -54,4 +56,4 @@ const downloadBinaryInjectable = getInjectable({
   },
 });
 
-export default downloadBinaryInjectable;
+export default proxyDownloadBinaryInjectable;

--- a/packages/core/src/common/utils/get-latest-version.injectable.ts
+++ b/packages/core/src/common/utils/get-latest-version.injectable.ts
@@ -5,7 +5,7 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import downloadJsonInjectable from "../fetch/download-json/normal.injectable";
+import proxyDownloadJsonInjectable from "../fetch/download-json/proxy.injectable";
 import { withTimeout } from "../fetch/timeout-controller";
 
 interface NpmRegistryPackageMetadata {
@@ -15,11 +15,11 @@ interface NpmRegistryPackageMetadata {
 const getLatestVersionInjectable = getInjectable({
   id: "get-latest-version",
   instantiate: (di) => {
-    const downloadJson = di.inject(downloadJsonInjectable);
+    const proxyDownloadJson = di.inject(proxyDownloadJsonInjectable);
 
     return async (name: string): Promise<string> => {
       const timeoutController = withTimeout(5000);
-      const result = await downloadJson(`https://registry.npmjs.org/${name}/latest`, {
+      const result = await proxyDownloadJson(`https://registry.npmjs.org/${name}/latest`, {
         signal: timeoutController.signal,
       });
       if (!result.callWasSuccessful) {

--- a/packages/core/src/renderer/components/extensions/__tests__/extensions.test.tsx
+++ b/packages/core/src/renderer/components/extensions/__tests__/extensions.test.tsx
@@ -11,7 +11,7 @@ import { observable, when } from "mobx";
 import React from "react";
 import directoryForDownloadsInjectable from "../../../../common/app-paths/directory-for-downloads/directory-for-downloads.injectable";
 import directoryForUserDataInjectable from "../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
-import downloadBinaryInjectable from "../../../../common/fetch/download-binary.injectable";
+import proxyDownloadBinaryInjectable from "../../../../common/fetch/proxy-download-binary.injectable";
 import removePathInjectable from "../../../../common/fs/remove.injectable";
 import extensionDiscoveryInjectable from "../../../../extensions/extension-discovery/extension-discovery.injectable";
 import extensionInstallationStateStoreInjectable from "../../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
@@ -23,7 +23,7 @@ import { renderFor } from "../../test-utils/renderFor";
 import { Extensions } from "../extensions";
 import installExtensionFromInputInjectable from "../install-extension-from-input.injectable";
 
-import type { DownloadBinary } from "../../../../common/fetch/download-binary.injectable";
+import type { ProxyDownloadBinary } from "../../../../common/fetch/proxy-download-binary.injectable";
 import type { RemovePath } from "../../../../common/fs/remove.injectable";
 import type { ExtensionDiscovery } from "../../../../extensions/extension-discovery/extension-discovery";
 import type { ExtensionInstallationStateStore } from "../../../../extensions/extension-installation-state-store/extension-installation-state-store";
@@ -38,7 +38,7 @@ describe("Extensions", () => {
   let extensionInstallationStateStore: ExtensionInstallationStateStore;
   let render: DiRender;
   let deleteFileMock: jest.MockedFunction<RemovePath>;
-  let downloadBinary: jest.MockedFunction<DownloadBinary>;
+  let downloadBinary: jest.MockedFunction<ProxyDownloadBinary>;
 
   beforeEach(() => {
     try {
@@ -59,7 +59,7 @@ describe("Extensions", () => {
       downloadBinary = jest.fn().mockImplementation((url) => {
         throw new Error(`Unexpected call to downloadJson for url=${url}`);
       });
-      di.override(downloadBinaryInjectable, () => downloadBinary);
+      di.override(proxyDownloadBinaryInjectable, () => downloadBinary);
 
       extensionLoader = di.inject(extensionLoaderInjectable);
       extensionDiscovery = di.inject(extensionDiscoveryInjectable);

--- a/packages/core/src/renderer/components/extensions/attempt-install-by-info.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/attempt-install-by-info.injectable.tsx
@@ -12,8 +12,8 @@ import { reduce } from "lodash";
 import React from "react";
 import { SemVer } from "semver";
 import URLParse from "url-parse";
-import downloadBinaryInjectable from "../../../common/fetch/download-binary.injectable";
-import downloadJsonInjectable from "../../../common/fetch/download-json/normal.injectable";
+import proxyDownloadJsonInjectable from "../../../common/fetch/download-json/proxy.injectable";
+import proxyDownloadBinaryInjectable from "../../../common/fetch/proxy-download-binary.injectable";
 import { withTimeout } from "../../../common/fetch/timeout-controller";
 import getBasenameOfPathInjectable from "../../../common/path/get-basename.injectable";
 import extensionInstallationStateStoreInjectable from "../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
@@ -53,8 +53,8 @@ const attemptInstallByInfoInjectable = getInjectable({
     const extensionInstallationStateStore = di.inject(extensionInstallationStateStoreInjectable);
     const confirm = di.inject(confirmInjectable);
     const getBasenameOfPath = di.inject(getBasenameOfPathInjectable);
-    const downloadJson = di.inject(downloadJsonInjectable);
-    const downloadBinary = di.inject(downloadBinaryInjectable);
+    const proxyDownloadJson = di.inject(proxyDownloadJsonInjectable);
+    const proxyDownloadBinary = di.inject(proxyDownloadBinaryInjectable);
     const showErrorNotification = di.inject(showErrorNotificationInjectable);
     const logger = di.inject(loggerInjectionToken);
 
@@ -66,7 +66,7 @@ const attemptInstallByInfoInjectable = getInjectable({
       let json: NpmRegistryPackageDescriptor;
 
       try {
-        const result = await downloadJson(registryUrl);
+        const result = await proxyDownloadJson(registryUrl);
 
         if (!result.callWasSuccessful) {
           showErrorNotification(`Failed to get registry information for extension: ${result.error}`);
@@ -189,7 +189,7 @@ const attemptInstallByInfoInjectable = getInjectable({
 
       const fileName = getBasenameOfPath(tarballUrl);
       const { signal } = withTimeout(30 * 60 * 1000);
-      const request = await downloadBinary(tarballUrl, { signal });
+      const request = await proxyDownloadBinary(tarballUrl, { signal });
 
       if (!request.callWasSuccessful) {
         showErrorNotification(`Failed to download extension: ${request.error}`);

--- a/packages/core/src/renderer/components/extensions/install-extension-from-input.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/install-extension-from-input.injectable.tsx
@@ -8,7 +8,7 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
 import React from "react";
-import downloadBinaryInjectable from "../../../common/fetch/download-binary.injectable";
+import proxyDownloadBinaryInjectable from "../../../common/fetch/proxy-download-binary.injectable";
 import { withTimeout } from "../../../common/fetch/timeout-controller";
 import getBasenameOfPathInjectable from "../../../common/path/get-basename.injectable";
 import extensionInstallationStateStoreInjectable from "../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
@@ -33,7 +33,7 @@ const installExtensionFromInputInjectable = getInjectable({
     const getBasenameOfPath = di.inject(getBasenameOfPathInjectable);
     const showErrorNotification = di.inject(showErrorNotificationInjectable);
     const logger = di.inject(loggerInjectionToken);
-    const downloadBinary = di.inject(downloadBinaryInjectable);
+    const downloadBinary = di.inject(proxyDownloadBinaryInjectable);
 
     return async (input) => {
       let disposer: ExtendableDisposer | undefined = undefined;


### PR DESCRIPTION
Normal fetch works on Mac and Windows and doesn't work on Linux and fails with

```
extensions:1 Access to fetch at 'https://registry.npmjs.org/@freelensapp/fuxcd-extension' from origin 'https://renderer.freelens.app:45479' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
registry.npmjs.org/@freelensapp/fuxcd-
            
            
           Failed to load resource: net::ERR_FAILED
```
