### PR TITLE
Prometheus graphs ignores metrics with empty container label

### DIFF
--- a/packages/technical-features/prometheus/src/operator-provider.injectable.ts.ts
+++ b/packages/technical-features/prometheus/src/operator-provider.injectable.ts.ts
@@ -82,23 +82,23 @@ export const getOperatorLikeQueryFor =
       case "pods":
         switch (queryName) {
           case "cpuUsage":
-            return `sum(rate(container_cpu_usage_seconds_total{pod=~"${opts.pods}", namespace="${opts.namespace}"}[${rateAccuracy}])) by (${opts.selector})`;
+            return `sum(rate(container_cpu_usage_seconds_total{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}[${rateAccuracy}])) by (${opts.selector})`;
           case "cpuRequests":
             return `sum(kube_pod_container_resource_requests{pod=~"${opts.pods}", resource="cpu", namespace="${opts.namespace}"}) by (${opts.selector})`;
           case "cpuLimits":
             return `sum(kube_pod_container_resource_limits{pod=~"${opts.pods}", resource="cpu", namespace="${opts.namespace}"}) by (${opts.selector})`;
           case "memoryUsage":
-            return `sum(container_memory_working_set_bytes{pod=~"${opts.pods}", namespace="${opts.namespace}"}) by (${opts.selector})`;
+            return `sum(container_memory_working_set_bytes{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}) by (${opts.selector})`;
           case "memoryRequests":
             return `sum(kube_pod_container_resource_requests{pod=~"${opts.pods}", resource="memory", namespace="${opts.namespace}"}) by (${opts.selector})`;
           case "memoryLimits":
             return `sum(kube_pod_container_resource_limits{pod=~"${opts.pods}", resource="memory", namespace="${opts.namespace}"}) by (${opts.selector})`;
           case "fsUsage":
-            return `sum(container_fs_usage_bytes{pod=~"${opts.pods}", namespace="${opts.namespace}"}) by (${opts.selector})`;
+            return `sum(container_fs_usage_bytes{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}) by (${opts.selector})`;
           case "fsWrites":
-            return `sum(rate(container_fs_writes_bytes_total{pod=~"${opts.pods}", namespace="${opts.namespace}"}[${rateAccuracy}])) by (${opts.selector})`;
+            return `sum(rate(container_fs_writes_bytes_total{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}[${rateAccuracy}])) by (${opts.selector})`;
           case "fsReads":
-            return `sum(rate(container_fs_reads_bytes_total{pod=~"${opts.pods}", namespace="${opts.namespace}"}[${rateAccuracy}])) by (${opts.selector})`;
+            return `sum(rate(container_fs_reads_bytes_total{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}[${rateAccuracy}])) by (${opts.selector})`;
           case "networkReceive":
             return `sum(rate(container_network_receive_bytes_total{pod=~"${opts.pods}", namespace="${opts.namespace}"}[${rateAccuracy}])) by (${opts.selector})`;
           case "networkTransmit":


### PR DESCRIPTION
freelens doesn't calculate the pod cpu, memory and filesystem usage correctly. Here's an example of a single-container pod:

Before:
![before-pod](https://github.com/user-attachments/assets/b4686236-7858-48f4-9003-853aa8530779)
![before-container](https://github.com/user-attachments/assets/7d5ba3b3-1201-4990-b370-76c0987e9d30)

After:

![after-pod](https://github.com/user-attachments/assets/46ec32d4-8e9d-4a7c-bf6d-3ba01d6eb4c4)
![after-container](https://github.com/user-attachments/assets/c97b6038-3bb3-4af7-97d6-17d0e628e16c)

I have this issue with those metrics: 

```
container_cpu_usage_seconds_total
container_memory_working_set_bytes
container_fs_usage_bytes
container_fs_writes_bytes_total
container_fs_reads_bytes_total
```

Those are all metrics where the name starts with `container_*`, excluding `container_network_*` (Those never have a `container` attribute).

All other `*-provider.injectable.ts` have this same fix applied. I haven't been able to find why this one is different, so let's set them to the same queries.

**Info about my cluster**

I'm running k3s, with one master node and multiple "worker" nodes.  
Prometheus is provided by the `bitnami/kube-prometheus` helm chart.

**Tests**

The tests have successfully ran on a testing PR on my own repo: https://github.com/RubenNL/freelens/pull/1