### PR TITLE
Add ephemeral containers to pods view

### DIFF
--- a/packages/core/src/renderer/components/__tests__/cronjob.store.test.ts
+++ b/packages/core/src/renderer/components/__tests__/cronjob.store.test.ts
@@ -36,7 +36,7 @@ const scheduledCronJob = new CronJob({
           metadata: {},
           spec: {
             containers: [],
-            restartPolicy: "restart",
+            restartPolicy: "Always",
             terminationGracePeriodSeconds: 1,
             dnsPolicy: "no",
             hostPID: true,
@@ -71,7 +71,7 @@ const suspendedCronJob = new CronJob({
           metadata: {},
           spec: {
             containers: [],
-            restartPolicy: "restart",
+            restartPolicy: "Always",
             terminationGracePeriodSeconds: 1,
             dnsPolicy: "no",
             hostPID: true,
@@ -106,7 +106,7 @@ const otherSuspendedCronJob = new CronJob({
           metadata: {},
           spec: {
             containers: [],
-            restartPolicy: "restart",
+            restartPolicy: "Always",
             terminationGracePeriodSeconds: 1,
             dnsPolicy: "no",
             hostPID: true,

--- a/packages/core/src/renderer/components/__tests__/deployments.store.test.ts
+++ b/packages/core/src/renderer/components/__tests__/deployments.store.test.ts
@@ -35,7 +35,7 @@ const spec: PodSpec = {
       imagePullPolicy: "Always",
     },
   ],
-  restartPolicy: "restart",
+  restartPolicy: "Always",
   terminationGracePeriodSeconds: 1200,
   dnsPolicy: "dns",
   serviceAccountName: "test",

--- a/packages/core/src/renderer/components/workloads-deployments/scale/dialog.test.tsx
+++ b/packages/core/src/renderer/components/workloads-deployments/scale/dialog.test.tsx
@@ -53,7 +53,7 @@ const dummyDeployment = new Deployment({
             imagePullPolicy: "Always",
           },
         ],
-        restartPolicy: "dummy",
+        restartPolicy: "Never",
         terminationGracePeriodSeconds: 10,
         dnsPolicy: "dummy",
         serviceAccountName: "dummy",

--- a/packages/core/src/renderer/components/workloads-pods/details/containers/pod-details-ephemeral-containers.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/containers/pod-details-ephemeral-containers.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { observer } from "mobx-react";
+import React from "react";
+import { DrawerTitle } from "../../../drawer";
+import { PodDetailsContainer } from "../../pod-details-container";
+
+import type { Pod } from "@freelensapp/kube-object";
+
+interface PodDetailsContainersProps {
+  pod: Pod;
+}
+
+const PodDetailsEphemeralContainers = observer(({ pod }: PodDetailsContainersProps) => {
+  const ephemeralContainers = pod.getEphemeralContainers();
+
+  if (ephemeralContainers.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <DrawerTitle>Ephemeral Containers</DrawerTitle>
+      {ephemeralContainers.map((container) => (
+        <PodDetailsContainer key={container.name} pod={pod} container={container} />
+      ))}
+    </>
+  );
+});
+
+export { PodDetailsEphemeralContainers };

--- a/packages/core/src/renderer/components/workloads-pods/pod-details.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details.tsx
@@ -24,6 +24,7 @@ import { Badge } from "../badge";
 import { DrawerItem } from "../drawer";
 import getDetailsUrlInjectable from "../kube-detail-params/get-details-url.injectable";
 import { PodDetailsContainers } from "./details/containers/pod-details-containers";
+import { PodDetailsEphemeralContainers } from "./details/containers/pod-details-ephemeral-containers";
 import { PodDetailsInitContainers } from "./details/containers/pod-details-init-containers";
 import { PodVolumes } from "./details/volumes/view";
 import { PodDetailsAffinities } from "./pod-details-affinities";
@@ -148,6 +149,8 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
         <PodDetailsInitContainers pod={pod} />
 
         <PodDetailsContainers pod={pod} />
+
+        <PodDetailsEphemeralContainers pod={pod} />
 
         <PodVolumes pod={pod} />
       </div>

--- a/packages/kube-object/src/types/ephemeral-container.ts
+++ b/packages/kube-object/src/types/ephemeral-container.ts
@@ -15,37 +15,51 @@ import type { VolumeDevice } from "./volume-device";
 import type { VolumeMount } from "./volume-mount";
 
 /**
- * A single application container that you want to run within a pod.
+ * A single ephemeral container.
+ *
+ * Ephemeral containers may be run in an existing pod to perform
+ * user-initiated actions such as debugging. This list cannot be specified
+ * when creating a pod, and it cannot be modified by updating the pod spec. In
+ * order to add an ephemeral container to an existing pod, use the pod's
+ * ephemeralcontainers subresource.
+ *
+ * More info:
+ * https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/
  */
-export interface Container {
+export interface EphemeralContainer {
   /**
-   * Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable
-   * references `$(VAR_NAME)` are expanded using the container's environment.
+   * Arguments to the entrypoint. The image's CMD is used if this is not
+   * provided. Variable references `$(VAR_NAME)` are expanded using the
+   * container's environment.
    *
-   * If a variable cannot be resolved, the reference in the input string will be unchanged.
-   * Double `$$` are reduced to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax:
-   * i.e. `"$$(VAR_NAME)"` will produce the string literal `"$(VAR_NAME)`".
+   * If a variable cannot be resolved, the reference in the input string will
+   * be unchanged. Double `$$` are reduced to a single `$`, which allows for
+   * escaping the `$(VAR_NAME)` syntax: i.e. `"$$(VAR_NAME)"` will produce the
+   * string literal `"$(VAR_NAME)"`.
    *
-   * Escaped references will never be expanded, regardless of whether the variable exists or not.
-   * Cannot be updated.
+   * Escaped references will never be expanded, regardless of whether the
+   * variable exists or not. Cannot be updated.
    *
-   * More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+   * More info:
+   * https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
    */
   args?: string[];
 
   /**
-   * Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this
-   * is not provided. Variable references `$(VAR_NAME)` are expanded using the container's
-   * environment.
+   * Entrypoint array. Not executed within a shell. The docker image's
+   * ENTRYPOINT is used if this is not provided. Variable references
+   * `$(VAR_NAME)` are expanded using the container's environment.
    *
-   * If a variable cannot be resolved, the reference in the input string will be unchanged.
-   * Double `$$` are reduced to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax:
-   * i.e. `"$$(VAR_NAME)"` will produce the string literal `"$(VAR_NAME)`".
+   * If a variable cannot be resolved, the reference in the input string will
+   * be unchanged. Double `$$` are reduced to a single `$`, which allows for
+   * escaping the `$(VAR_NAME)` syntax: i.e. `"$$(VAR_NAME)"` will produce the
+   * string literal `"$(VAR_NAME)`".
    *
-   * Escaped references will never be expanded, regardless of whether the variable exists or not.
-   * Cannot be updated.
+   * Escaped references will never be expanded, regardless of whether the
+   * variable exists or not. Cannot be updated.
    *
-   * More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+   * More info:
+   * https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
    */
   command?: string[];
 
@@ -97,8 +111,8 @@ export interface Container {
   livenessProbe?: Probe;
 
   /**
-   * Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique
-   * name. Cannot be updated.
+   * Name of the ephemeral container specified as a DNS_LABEL. This name must
+   * be unique among all containers, init containers and ephemeral containers.
    */
   name: string;
 
@@ -167,6 +181,18 @@ export interface Container {
    * @default false
    */
   stdinOnce?: boolean;
+
+  /**
+   * If set, the name of the container from PodSpec that this ephemeral
+   * container targets. The ephemeral container will be run in the namespaces
+   * (IPC, PID, etc) of this container. If not set then the ephemeral
+   * container uses the namespaces configured in the Pod spec.
+   *
+   * The container runtime must implement support for this feature. If the
+   * runtime does not support namespace targeting then the result of setting
+   * this field is undefined.
+   */
+  targetContainerName?: string;
 
   /**
    * Path at which the file to which the container's termination message will be written

--- a/packages/kube-object/src/types/index.ts
+++ b/packages/kube-object/src/types/index.ts
@@ -15,6 +15,7 @@ export * from "./env-source";
 export * from "./env-var";
 export * from "./env-var-key-selector";
 export * from "./env-var-source";
+export * from "./ephemeral-container";
 export * from "./exec-action";
 export * from "./handler";
 export * from "./http-get-action";


### PR DESCRIPTION
**Description of changes:**

Closes #184

- [x] Add ephemeralContainers to Pods API
- [x] Add to pod details
- [ ] Start a new ephemeral container with the image/command from settings (and/or parameters from dialog)
- [ ] Terminate ephemeral container

Terminating the ephemeral container is tricky as Kubernetes does not hold information about the main PID for containers with shared PIDs. The workaround might be either adding some information about main PID to logs or using cgroups to find out the main PID to kill.

Creating/killing the containers will be in a separate PR.
