### PR TITLE
Show resource requests and limits in Pod details

### DIFF
--- a/packages/core/src/renderer/components/workloads-pods/pod-details-container.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details-container.tsx
@@ -183,7 +183,7 @@ class NonInjectedPodDetailsContainer extends React.Component<PodDetailsContainer
         {requests.length > 0 && (
           <DrawerItem name="Requests" labelsOnly>
             {requests.map(([key, value], index) => (
-              <Badge key={index} label={`${key}: ${value}`} />
+              <Badge key={index} label={`${key}=${value}`} />
             ))}
           </DrawerItem>
         )}
@@ -191,7 +191,7 @@ class NonInjectedPodDetailsContainer extends React.Component<PodDetailsContainer
         {limits.length > 0 && (
           <DrawerItem name="Limits" labelsOnly>
             {limits.map(([key, value], index) => (
-              <Badge key={index} label={`${key}: ${value}`} />
+              <Badge key={index} label={`${key}=${value}`} />
             ))}
           </DrawerItem>
         )}


### PR DESCRIPTION
This PR resolves #893 in showing container resource requests and limits in the pod detail container.

Let me know if there's anything to do. Linting, etc. seemed fine.