### PR TITLE
API batch/v1beta1 is not supported anymore

### DIFF
--- a/packages/core/src/renderer/components/kube-object-menu/kube-object-menu-items/cron-job-menu.injectable.ts
+++ b/packages/core/src/renderer/components/kube-object-menu/kube-object-menu-items/cron-job-menu.injectable.ts
@@ -16,7 +16,7 @@ const cronJobMenuInjectable = getInjectable({
 
   instantiate: () => ({
     kind: "CronJob",
-    apiVersions: ["batch/v1beta1", "batch/v1"],
+    apiVersions: ["batch/v1"],
     Component: CronJobMenu as KubeObjectMenuItemComponent,
     enabled: computed(() => true),
     orderNumber: 20,

--- a/packages/core/src/renderer/components/kube-object-menu/kube-object-menu-items/job-menu-copy.injectable.ts
+++ b/packages/core/src/renderer/components/kube-object-menu/kube-object-menu-items/job-menu-copy.injectable.ts
@@ -16,7 +16,7 @@ const jobMenuInjectable = getInjectable({
 
   instantiate: () => ({
     kind: "Job",
-    apiVersions: ["batch/v1beta1", "batch/v1"],
+    apiVersions: ["batch/v1"],
     Component: JobMenu as KubeObjectMenuItemComponent,
     enabled: computed(() => true),
     orderNumber: 20,


### PR DESCRIPTION
<!-- markdownlint-disable -->
**Description of changes:**

- Removed API batch/v1beta1

New CronJob view is not backward compatible and it would take too much effort to support old, long forgotten API. Sorry!