### PR TITLE
New presentation for container and service ports

### DIFF
--- a/packages/core/src/renderer/components/network-services/service-port-component.tsx
+++ b/packages/core/src/renderer/components/network-services/service-port-component.tsx
@@ -176,9 +176,9 @@ class NonInjectedServicePortComponent extends React.Component<ServicePortCompone
     const name = port.name ? `${port.name}: ` : "";
     const nodeAddr = port.nodePort ? `${port.nodePort} → ` : "";
     const appProtocol = port.appProtocol ? `/${port.appProtocol}` : "";
-    const servicePort = `${port.port}${appProtocol}`;
+    const servicePort = `${port.port}${appProtocol} → `;
     const targetPort = `${port.targetPort ?? port.port}/${port.protocol ?? "TCP"}`;
-    const text = `${name}${nodeAddr}${servicePort} → ${targetPort}`;
+    const text = `${name}${nodeAddr}${servicePort}${targetPort}`;
 
     const portForwardAction = action(async () => {
       if (this.isPortForwarded) {

--- a/packages/core/src/renderer/components/network-services/service-port-component.tsx
+++ b/packages/core/src/renderer/components/network-services/service-port-component.tsx
@@ -173,6 +173,13 @@ class NonInjectedServicePortComponent extends React.Component<ServicePortCompone
   render() {
     const { port, service } = this.props;
 
+    const name = port.name ? `${port.name}: ` : "";
+    const nodeAddr = port.nodePort ? `${port.nodePort} → ` : "";
+    const appProtocol = port.appProtocol ? `/${port.appProtocol}` : "";
+    const servicePort = `${port.port}${appProtocol}`;
+    const targetPort = `${port.targetPort ?? port.port}/${port.protocol ?? "TCP"}`;
+    const text = `${name}${nodeAddr}${servicePort} → ${targetPort}`;
+
     const portForwardAction = action(async () => {
       if (this.isPortForwarded) {
         await this.stopPortForward();
@@ -196,7 +203,7 @@ class NonInjectedServicePortComponent extends React.Component<ServicePortCompone
     return (
       <div className={cssNames("ServicePortComponent", { waiting: this.waiting })}>
         <span title="Open in a browser" onClick={() => this.portForward()}>
-          {port.toString()}
+          {text}
         </span>
         <Button primary onClick={portForwardAction}>
           {" "}

--- a/packages/core/src/renderer/components/network-services/services.tsx
+++ b/packages/core/src/renderer/components/network-services/services.tsx
@@ -9,7 +9,6 @@ import "./services.scss";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
-import { Badge } from "../badge";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectListLayout } from "../kube-object-list-layout";
 import { KubeObjectStatusIcon } from "../kube-object-status-icon";
@@ -25,12 +24,11 @@ import type { ServiceStore } from "./store";
 enum columnId {
   name = "name",
   namespace = "namespace",
-  selector = "selector",
-  ports = "port",
+  type = "type",
   clusterIp = "cluster-ip",
   externalIp = "external-ip",
+  ports = "port",
   age = "age",
-  type = "type",
   status = "status",
 }
 
@@ -65,7 +63,6 @@ class NonInjectedServices extends React.Component<Dependencies> {
           sortingCallbacks={{
             [columnId.name]: (service) => service.getName(),
             [columnId.namespace]: (service) => service.getNs(),
-            [columnId.selector]: (service) => service.getSelector(),
             [columnId.ports]: (service) => (service.spec.ports || []).map(({ port }) => port)[0],
             [columnId.clusterIp]: (service) => service.getClusterIp(),
             [columnId.type]: (service) => service.getType(),
@@ -86,7 +83,6 @@ class NonInjectedServices extends React.Component<Dependencies> {
             { title: "Cluster IP", className: "clusterIp", sortBy: columnId.clusterIp, id: columnId.clusterIp },
             { title: "External IP", className: "externalIp", id: columnId.externalIp },
             { title: "Ports", className: "ports", sortBy: columnId.ports, id: columnId.ports },
-            { title: "Selector", className: "selector", sortBy: columnId.selector, id: columnId.selector },
             { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
             { title: "Status", className: "status", sortBy: columnId.status, id: columnId.status },
           ]}
@@ -98,11 +94,6 @@ class NonInjectedServices extends React.Component<Dependencies> {
             <WithTooltip>{service.getClusterIp()}</WithTooltip>,
             <WithTooltip>{formatExternalIps(service)}</WithTooltip>,
             <WithTooltip>{service.getPorts().join(", ")}</WithTooltip>,
-            <WithTooltip>
-              {service.getSelector().map((label) => (
-                <Badge key={label} label={label} />
-              ))}
-            </WithTooltip>,
             <KubeObjectAge key="age" object={service} />,
             { title: service.getStatus(), className: service.getStatus().toLowerCase() },
           ]}

--- a/packages/core/src/renderer/components/workloads-pods/pod-container-port.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-container-port.tsx
@@ -168,8 +168,11 @@ class NonInjectedPodContainerPort extends React.Component<PodContainerPortProps 
 
   render() {
     const { pod, port } = this.props;
-    const { name, containerPort, protocol } = port;
-    const text = `${name ? `${name}: ` : ""}${containerPort}/${protocol}`;
+
+    const name = port.name ? `${port.name}: ` : "";
+    const hostAddr = port.hostPort? `${port.hostIP ?? "0.0.0.0"}:${port.hostPort} → ` : "";
+    const containerPort = `${port.containerPort}/${port.protocol ?? "TCP"}`
+    const text = `${name}${hostAddr}${containerPort}`;
 
     const portForwardAction = action(async () => {
       if (this.isPortForwarded) {

--- a/packages/kube-object/src/specifics/service.ts
+++ b/packages/kube-object/src/specifics/service.ts
@@ -31,20 +31,11 @@ export interface ServicePortSpec {
   nodePort?: number;
 }
 
-export class ServicePort {
-  name?: string;
-  protocol?: Protocol;
-  appProtocol?: string;
-  port: number;
-  targetPort?: number | string;
-  nodePort?: number;
+export interface ServicePort extends ServicePortSpec {}
 
+export class ServicePort {
   constructor(data: ServicePortSpec) {
-    this.name = data.name;
-    this.protocol = data.protocol;
-    this.port = data.port;
-    this.targetPort = data.targetPort;
-    this.nodePort = data.nodePort;
+    Object.assign(this, data);
   }
 
   toString() {

--- a/packages/kube-object/src/specifics/service.ts
+++ b/packages/kube-object/src/specifics/service.ts
@@ -8,23 +8,35 @@ import { KubeObject } from "../kube-object";
 
 import type { NamespaceScopedMetadata } from "../api-types";
 
+export type ServiceType = "ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName";
+
+export type Protocol = "TCP" | "UDP" | "SCTP";
+
+export type IPFamily = "IPv4" | "IPv6" | "";
+
+export type ServiceAffinity = "ClientIP" | "None";
+
+export type ServiceExternalTrafficPolicy = "Cluster" | "Local";
+
+export type ServiceInternalTrafficPolicy = "Cluster" | "Local";
+
+export type TrafficDistribution = "PreferClose" | "PreferSameZone" | "PreferSameNode";
+
 export interface ServicePortSpec {
   name?: string;
-  protocol: string;
+  protocol?: Protocol;
+  appProtocol?: string;
   port: number;
-  targetPort: number;
+  targetPort?: number | string;
   nodePort?: number;
 }
 
 export class ServicePort {
   name?: string;
-
-  protocol: string;
-
+  protocol?: Protocol;
+  appProtocol?: string;
   port: number;
-
-  targetPort: number;
-
+  targetPort?: number | string;
   nodePort?: number;
 
   constructor(data: ServicePortSpec) {
@@ -42,25 +54,36 @@ export class ServicePort {
   }
 }
 
+export interface ClientIPConfigApplyConfiguration {
+  timeoutSeconds?: number;
+}
+
+export interface SessionAffinityConfigApplyConfiguration {
+  clientIP?: ClientIPConfigApplyConfiguration;
+}
+
 export interface ServiceSpec {
-  type: string;
+  ports?: ServicePort[];
+  selector?: Partial<Record<string, string>>;
   clusterIP: string;
   clusterIPs?: string[];
-  externalTrafficPolicy?: string;
-  externalName?: string;
+  type?: ServiceType;
+  externalIPs?: string[];
+  sessionAffinity: ServiceAffinity;
   loadBalancerIP?: string;
   loadBalancerSourceRanges?: string[];
-  sessionAffinity: string;
-  selector: Partial<Record<string, string>>;
-  ports: ServicePortSpec[];
+  externalName?: string;
+  externalTrafficPolicy?: ServiceExternalTrafficPolicy;
   healthCheckNodePort?: number;
-  externalIPs?: string[]; // https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+  publishNotReadyAddresses?: boolean;
+  sessionAffinityConfig?: SessionAffinityConfigApplyConfiguration;
   topologyKeys?: string[];
-  ipFamilies?: string[];
+  ipFamilies?: IPFamily[];
   ipFamilyPolicy?: string;
   allocateLoadBalancerNodePorts?: boolean;
   loadBalancerClass?: string;
-  internalTrafficPolicy?: string;
+  internalTrafficPolicy?: ServiceInternalTrafficPolicy;
+  trafficDistribution?: TrafficDistribution;
 }
 
 export interface ServiceStatus {


### PR DESCRIPTION
More clear presentation of container and service ports.

Services (node ports, load balancers):

<img width="702" height="87" alt="image" src="https://github.com/user-attachments/assets/4db58e0a-f7e1-4cf2-abe3-9acbae7bf887" />

Services (cluster):

<img width="675" height="83" alt="image" src="https://github.com/user-attachments/assets/59ef9e60-2eec-4baf-b1ab-26f398a9248b" />

Services (target port is name):

<img width="707" height="57" alt="image" src="https://github.com/user-attachments/assets/2fcfece3-bbd7-405e-8e92-6c8541aa9d3f" />

Pods (minimal information):

<img width="693" height="123" alt="image" src="https://github.com/user-attachments/assets/6ae7664d-6258-45e7-9b46-ea835006a129" />

Pods (host network):

<img width="678" height="56" alt="image" src="https://github.com/user-attachments/assets/3d670dd7-e3f2-48b4-b63b-6700e320e76b" />

Pods (with appProtocol):

<img width="695" height="59" alt="image" src="https://github.com/user-attachments/assets/3ed55e2c-4ce0-45b4-baca-6681f30efad0" />
