### PR TITLE
Fix CronJobs list for sorting

### DIFF
--- a/packages/core/src/renderer/components/workloads-cronjobs/cronjobs.tsx
+++ b/packages/core/src/renderer/components/workloads-cronjobs/cronjobs.tsx
@@ -53,7 +53,7 @@ const NonInjectedCronJobs = observer((props: Dependencies) => {
         sortingCallbacks={{
           [columnId.name]: (cronJob) => cronJob.getName(),
           [columnId.namespace]: (cronJob) => cronJob.getNs(),
-          [columnId.timezone]: (cronJob) => cronJob.spec.timeZone,
+          [columnId.timezone]: (cronJob) => cronJob.spec.timeZone ?? "",
           [columnId.suspend]: (cronJob) => cronJob.getSuspendFlag(),
           [columnId.active]: (cronJob) => cronJobStore.getActiveJobsNum(cronJob),
           [columnId.lastSchedule]: (cronJob) =>


### PR DESCRIPTION
Casting to the correct types in sortable columns for CronJobs list view.

Maybe it will fix the crashes.