### PR TITLE
Fix for node mtrics alignment

### DIFF
--- a/packages/core/src/renderer/components/nodes/nodes.scss
+++ b/packages/core/src/renderer/components/nodes/nodes.scss
@@ -26,6 +26,11 @@
     &.cpu {
       flex: 0.6;
       align-self: center;
+      justify-content: right;
+
+      &.sorting {
+        justify-content: left;
+      }
 
       .LineProgress {
         color: var(--blue);
@@ -35,6 +40,11 @@
     &.memory {
       flex: 0.6;
       align-self: center;
+      justify-content: right;
+
+      &.sorting {
+        justify-content: left;
+      }
 
       .LineProgress {
         color: var(--magenta);
@@ -44,6 +54,11 @@
     &.disk {
       flex: 0.6;
       align-self: center;
+      justify-content: right;
+
+      &.sorting {
+        justify-content: left;
+      }
 
       .LineProgress {
         color: var(--golden);


### PR DESCRIPTION
They are aligned to right like for pods already.

<img width="451" height="352" alt="image" src="https://github.com/user-attachments/assets/3e513835-68c4-43a6-bf6f-45dec68f1156" />
