### PR TITLE
API exports new LensExtensionKubeObject class

### DIFF
--- a/packages/core/src/common/k8s-api/kube-object.store.ts
+++ b/packages/core/src/common/k8s-api/kube-object.store.ts
@@ -390,9 +390,9 @@ export class KubeObjectStore<
     return newItem;
   }
 
-  async patch(item: K, patch: PartialDeep<Object>, strategy: "strategic" | "merge"): Promise<K>;
+  async patch(item: K, patch: PartialDeep<K>, strategy: "strategic" | "merge"): Promise<K>;
   async patch(item: K, patch: JsonPatch, strategy?: "json"): Promise<K>;
-  async patch(item: K, patch: PartialDeep<Object> | JsonPatch, strategy: KubeApiPatchType = "json"): Promise<K> {
+  async patch(item: K, patch: PartialDeep<K> | JsonPatch, strategy: KubeApiPatchType = "json"): Promise<K> {
     let rawItem: K | null;
 
     if (strategy === "json") {

--- a/packages/core/src/extensions/common-api/k8s-api.ts
+++ b/packages/core/src/extensions/common-api/k8s-api.ts
@@ -357,18 +357,18 @@ export class LensExtensionKubeObject<
    * @example
    *
    * ```ts
-   * const api = Example.getApi();
+   * const api = Example.getApi<Example>();
    * const url = api.formatUrlForNotListing({ name: "foo" });
    * ```
    */
-  static getApi<Api extends KubeApi>(): Api {
+  static getApi<K extends KubeObject<any, any, any>, Api extends KubeApi<K> = KubeApi<K>>(): Api {
     if (!this.crd) {
       throw new Error(`API for ${this.name} is not for CRD and misses metainfo. Extension won't work correctly.`);
     }
     if (this.kind) {
       for (let apiVersion of this.crd.apiVersions) {
         const api = apiManager.getApiByKind(this.kind, apiVersion);
-        if (api) return api as Api;
+        if (api) return api as unknown as Api;
       }
     }
     throw new Error(`API for ${this.name} is not registered. Extension won't work correctly.`);
@@ -381,11 +381,14 @@ export class LensExtensionKubeObject<
    * @example
    *
    * ```ts
-   * const api = Example.getStore();
+   * const api = Example.getStore<Example>();
    * await store.loadAll({ namespaces });
    * ```
    */
-  static getStore<Store extends KubeObjectStore<any, any, any>>(): Store {
+  static getStore<
+    K extends KubeObject<any, any, any>,
+    Store extends KubeObjectStore<any, any, any> = KubeObjectStore<K, any, any>,
+  >(): Store {
     const api = this.getApi();
     if (api) {
       const store = apiManager.getStore(api);


### PR DESCRIPTION
The object was already used in FluxCD extension and has static methods `getStore` and `getApi` and additional property with metainfo for CRDs.