### PR TITLE
Do not resolve resources by kind only

### DIFF
--- a/packages/core/src/common/k8s-api/api-manager/api-manager.ts
+++ b/packages/core/src/common/k8s-api/api-manager/api-manager.ts
@@ -192,13 +192,6 @@ export class ApiManager {
       }
     }
 
-    // resolve by kind only (hpa's might use refs to older versions of resources for example)
-    const apiByKind = this.getApi((api) => api.kind === kind);
-
-    if (apiByKind) {
-      return apiByKind.formatUrlForNotListing({ name, namespace });
-    }
-
     // otherwise generate link with default prefix
     // resource still might exists in k8s, but api is not registered in the app
     return createKubeApiURL({ apiVersion, name, namespace, resource });


### PR DESCRIPTION
**Description of changes:**

- API manager does not resolve objects by Kind only as for CRDs many resources might have the same name (Cluster, Role, Policy, etc.)