### PR TITLE
Show all versions of CRDs

### DIFF
--- a/packages/core/src/renderer/components/custom-resource-definitions/details.tsx
+++ b/packages/core/src/renderer/components/custom-resource-definitions/details.tsx
@@ -70,7 +70,14 @@ class NonInjectedCustomResourceDefinitionDetails extends React.Component<
             </DrawerItem>
           ))}
         </DrawerItem>
-        <DrawerItem name="Stored versions">{crd.getStoredVersions()}</DrawerItem>
+        <DrawerItem name="Stored Versions">
+          {crd
+            .getStoredVersions()
+            .split(", ")
+            ?.map((version) => (
+              <DrawerItem name="">{version}</DrawerItem>
+            ))}
+        </DrawerItem>
         <DrawerItem name="Scope">{crd.getScope()}</DrawerItem>
         <DrawerItem name="Resource">
           <Link to={crd.getResourceUrl()}>{crd.getResourceTitle()}</Link>

--- a/packages/core/src/renderer/components/custom-resource-definitions/details.tsx
+++ b/packages/core/src/renderer/components/custom-resource-definitions/details.tsx
@@ -6,6 +6,7 @@
 
 import "./details.scss";
 
+import { Icon } from "@freelensapp/icon";
 import { CustomResourceDefinition } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { withInjectables } from "@ogre-tools/injectable-react";
@@ -56,7 +57,19 @@ class NonInjectedCustomResourceDefinitionDetails extends React.Component<
     return (
       <div className="CustomResourceDefinitionDetails">
         <DrawerItem name="Group">{crd.getGroup()}</DrawerItem>
-        <DrawerItem name="Version">{crd.getVersion()}</DrawerItem>
+        <DrawerItem name="Versions">
+          {crd.getVersions()?.map((version) => (
+            <DrawerItem name="">
+              {version}
+              {version === crd.getVersion() && (
+                <>
+                  {" "}
+                  <Icon small material="star" tooltip="Preferred Version" className="set_default_icon" />
+                </>
+              )}
+            </DrawerItem>
+          ))}
+        </DrawerItem>
         <DrawerItem name="Stored versions">{crd.getStoredVersions()}</DrawerItem>
         <DrawerItem name="Scope">{crd.getScope()}</DrawerItem>
         <DrawerItem name="Resource">

--- a/packages/kube-object/src/specifics/custom-resource-definition.ts
+++ b/packages/kube-object/src/specifics/custom-resource-definition.ts
@@ -184,6 +184,10 @@ export class CustomResourceDefinition extends KubeObject<
     return this.getPreferredVersion().name;
   }
 
+  getVersions() {
+    return this.spec.versions?.map((version) => version.name);
+  }
+
   isNamespaced() {
     return this.getScope() === "Namespaced";
   }


### PR DESCRIPTION
**Description of changes:**

- All versions are presented
- The preferred version is marked
- API has a new method `getVersions()`

<img width="687" height="233" alt="image" src="https://github.com/user-attachments/assets/70816c0e-cb0d-4a3f-986a-a2a7f45bce8d" />
