### PR TITLE
CSS tweaks for condition badges

### DIFF
--- a/packages/core/src/renderer/components/custom-resources/details.scss
+++ b/packages/core/src/renderer/components/custom-resources/details.scss
@@ -8,10 +8,8 @@ $custom-resource-condition-colors: (
   Accepted: var(--colorOk),
   Available: var(--colorOk),
   Ready: var(--colorSuccess),
-  ReconcileSuccess: var(--colorOk),
   Succeeded: var(--colorOk),
   Success: var(--colorOk),
-  UpgradeSucceeded: var(--colorOk),
 );
 
 .CustomResourceDetails {

--- a/packages/core/src/renderer/components/custom-resources/details.scss
+++ b/packages/core/src/renderer/components/custom-resources/details.scss
@@ -7,9 +7,9 @@
 $custom-resource-condition-colors: (
   Accepted: var(--colorOk),
   Available: var(--colorOk),
-  Ready: var(--colorSuccess),
   Succeeded: var(--colorOk),
   Success: var(--colorOk),
+  Ready: var(--colorSuccess),
 );
 
 .CustomResourceDetails {


### PR DESCRIPTION
**Description of changes:**

- Ready state is peferred before others

<img width="483" height="78" alt="image" src="https://github.com/user-attachments/assets/246a0b60-f686-4ca2-9f39-7e59e343cf9e" />

"Ready" is more dark so other statuses should not "depromote" it