### PR TITLE
Use spaces for printable columns for CRDs

### DIFF
--- a/packages/core/src/renderer/components/custom-resources/__tests__/__snapshots__/custom-resource-details.test.tsx.snap
+++ b/packages/core/src/renderer/components/custom-resources/__tests__/__snapshots__/custom-resource-details.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<CustomResourceDetails /> with a CRD with a boolean field should displa
       <span
         class="name"
       >
-        MyField
+        My Field
       </span>
       <span
         class="value"
@@ -38,7 +38,7 @@ exports[`<CustomResourceDetails /> with a CRD with a boolean field should displa
       <span
         class="name"
       >
-        MyField
+        My Field
       </span>
       <span
         class="value"
@@ -65,7 +65,7 @@ exports[`<CustomResourceDetails /> with a CRD with a number field should display
       <span
         class="name"
       >
-        MyField
+        My Field
       </span>
       <span
         class="value"
@@ -88,7 +88,7 @@ exports[`<CustomResourceDetails /> with a CRD with a number field should display
       <span
         class="name"
       >
-        MyField
+        My Field
       </span>
       <span
         class="value"

--- a/packages/core/src/renderer/components/custom-resources/details.tsx
+++ b/packages/core/src/renderer/components/custom-resources/details.tsx
@@ -10,6 +10,7 @@ import { CustomResourceDefinition, KubeObject } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { cssNames, safeJSONPathValue } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
+import { startCase } from "lodash/fp";
 import { observer } from "mobx-react";
 import React from "react";
 import { BadgeBoolean } from "../badge";
@@ -61,7 +62,7 @@ interface Dependencies {
 class NonInjectedCustomResourceDetails extends React.Component<CustomResourceDetailsProps & Dependencies> {
   renderAdditionalColumns(resource: KubeObject, columns: AdditionalPrinterColumnsV1[]) {
     return columns.map(({ name, jsonPath }) => (
-      <DrawerItem key={name} name={name}>
+      <DrawerItem key={name} name={startCase(name)}>
         {convertSpecValue(safeJSONPathValue(resource, jsonPath))}
       </DrawerItem>
     ));

--- a/packages/core/src/renderer/components/custom-resources/view.tsx
+++ b/packages/core/src/renderer/components/custom-resources/view.tsx
@@ -8,6 +8,7 @@ import "./view.scss";
 
 import { formatJSONValue, safeJSONPathValue } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
+import { startCase } from "lodash/fp";
 import { computed, makeObservable } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
@@ -100,7 +101,7 @@ class NonInjectedCustomResources extends React.Component<Dependencies> {
               ? { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace }
               : undefined,
             ...extraColumns.map(({ name }) => ({
-              title: name,
+              title: startCase(name),
               className: name.toLowerCase().replace(/\s+/g, "-"),
               sortBy: name,
               id: name,

--- a/packages/core/src/renderer/components/nodes/details-resources.tsx
+++ b/packages/core/src/renderer/components/nodes/details-resources.tsx
@@ -38,9 +38,7 @@ export function NodeDetailsResources({ type, node: { status = {} } }: NodeDetail
         }
         return (
           <DrawerItem key={key} name={key}>
-            <WithTooltip tooltip={tooltip}>
-              <span>{value}</span>
-            </WithTooltip>
+            <WithTooltip tooltip={tooltip}>{value}</WithTooltip>
           </DrawerItem>
         );
       })}


### PR DESCRIPTION
**Description of changes:**

- `startCase` for printable columns

<img width="716" height="45" alt="image" src="https://github.com/user-attachments/assets/c032f147-3935-4243-8684-452c79239bd4" />

<img width="1150" height="136" alt="image" src="https://github.com/user-attachments/assets/90128aae-3aac-4993-a989-68f9a125d964" />
