### PR TITLE
CSS fix for DrawerItem without name

### DIFF
--- a/packages/core/src/renderer/components/drawer/drawer-item.scss
+++ b/packages/core/src/renderer/components/drawer/drawer-item.scss
@@ -16,6 +16,10 @@
   border-bottom: 1px solid var(--borderFaintColor);
   padding: $padding 0;
 
+  &.WithoutName {
+    grid-template-columns: auto;
+  }
+
   > .name {
     padding-right: $padding;
     overflow: hidden;

--- a/packages/core/src/renderer/components/drawer/drawer-item.tsx
+++ b/packages/core/src/renderer/components/drawer/drawer-item.tsx
@@ -39,7 +39,11 @@ export function DrawerItem({
   }
 
   return (
-    <div {...elemProps} className={cssNames("DrawerItem", className, { labelsOnly })} title={title}>
+    <div
+      {...elemProps}
+      className={cssNames("DrawerItem", className, name ? "WithName" : "WithoutName", { labelsOnly })}
+      title={title}
+    >
       {name && <span className="name">{name}</span>}
       <span className="value">{children}</span>
     </div>

--- a/packages/core/src/renderer/components/drawer/drawer-item.tsx
+++ b/packages/core/src/renderer/components/drawer/drawer-item.tsx
@@ -41,7 +41,7 @@ export function DrawerItem({
   return (
     <div
       {...elemProps}
-      className={cssNames("DrawerItem", className, name ? "WithName" : "WithoutName", { labelsOnly })}
+      className={cssNames("DrawerItem", className, name ? "" : "WithoutName", { labelsOnly })}
       title={title}
     >
       {name && <span className="name">{name}</span>}


### PR DESCRIPTION
**Description of changes:**

- Renders auto column if DrawerItem hasn't a name
