### PR TITLE
Columns with role name and ref types in RBAC bindings

### DIFF
--- a/packages/core/src/extensions/renderer-api/components.ts
+++ b/packages/core/src/extensions/renderer-api/components.ts
@@ -67,6 +67,7 @@ export * from "../../renderer/components/item-object-list";
 export * from "../../renderer/components/kube-object";
 export * from "../../renderer/components/kube-object-conditions";
 export * from "../../renderer/components/kube-object-details";
+export * from "../../renderer/components/kube-object-link";
 export * from "../../renderer/components/kube-object-list-layout";
 export * from "../../renderer/components/kube-object-menu";
 export * from "../../renderer/components/kube-object-meta";

--- a/packages/core/src/extensions/renderer-api/navigation.ts
+++ b/packages/core/src/extensions/renderer-api/navigation.ts
@@ -14,6 +14,9 @@ import showEntityDetailsInjectable, {
 import getDetailsUrlInjectable, {
   type GetDetailsUrl,
 } from "../../renderer/components/kube-detail-params/get-details-url.injectable";
+import getMaybeDetailsUrlInjectable, {
+  type GetMaybeDetailsUrl,
+} from "../../renderer/components/kube-detail-params/get-maybe-details-url.injectable";
 import hideDetailsInjectable, {
   type HideDetails,
 } from "../../renderer/components/kube-detail-params/hide-details.injectable";
@@ -36,12 +39,14 @@ export type {
   HideDetails,
   HideEntityDetails,
   IsRouteActive,
+  GetMaybeDetailsUrl,
   Navigate,
   ShowDetails,
   ShowEntityDetails,
 };
 
 export const getDetailsUrl = asLegacyGlobalFunctionForExtensionApi(getDetailsUrlInjectable);
+export const getMaybeDetailsUrl = asLegacyGlobalFunctionForExtensionApi(getMaybeDetailsUrlInjectable);
 export const showDetails = asLegacyGlobalFunctionForExtensionApi(showDetailsInjectable);
 export const hideDetails = asLegacyGlobalFunctionForExtensionApi(hideDetailsInjectable);
 export const createPageParam = asLegacyGlobalFunctionForExtensionApi(createPageParamInjectable);

--- a/packages/core/src/renderer/components/kube-detail-params/get-maybe-details-url.injectable.ts
+++ b/packages/core/src/renderer/components/kube-detail-params/get-maybe-details-url.injectable.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getInjectable } from "@ogre-tools/injectable";
+import getDetailsUrlInjectable from "./get-details-url.injectable";
+
+export type GetMaybeDetailsUrl = (selfLink?: string) => string;
+
+const getMaybeDetailsUrlInjectable = getInjectable({
+  id: "get-maybe-details-url",
+  instantiate: (di): GetMaybeDetailsUrl => {
+    const getDetailsUrl = di.inject(getDetailsUrlInjectable);
+
+    return (selfLink) => {
+      if (selfLink) {
+        return getDetailsUrl(selfLink);
+      } else {
+        return "";
+      }
+    };
+  },
+});
+
+export default getMaybeDetailsUrlInjectable;

--- a/packages/core/src/renderer/components/kube-object-link/index.ts
+++ b/packages/core/src/renderer/components/kube-object-link/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+export * from "./link-to-cluster-role";
+export * from "./link-to-namespace";
+export * from "./link-to-object";
+export * from "./link-to-role";
+export * from "./link-to-secret";
+export * from "./link-to-service-account";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-cluster-role.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-cluster-role.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { clusterRoleApiInjectable } from "@freelensapp/kube-api-specifics";
+import { stopPropagation } from "@freelensapp/utilities";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import React from "react";
+import getMaybeDetailsUrlInjectable, {
+  type GetMaybeDetailsUrl,
+} from "../kube-detail-params/get-maybe-details-url.injectable";
+import { MaybeLink } from "../maybe-link";
+import { WithTooltip } from "../with-tooltip";
+
+import type { ClusterRoleApi } from "@freelensapp/kube-api";
+
+interface Dependencies {
+  getMaybeDetailsUrl: GetMaybeDetailsUrl;
+  clusterRoleApi: ClusterRoleApi;
+}
+
+interface LinkToClusterRoleProps {
+  name?: string;
+}
+
+function NonInjectedLinkToClusterRole({
+  name,
+  getMaybeDetailsUrl,
+  clusterRoleApi,
+}: LinkToClusterRoleProps & Dependencies) {
+  if (!name) return null;
+
+  return (
+    <MaybeLink
+      key="link"
+      to={getMaybeDetailsUrl(
+        clusterRoleApi.formatUrlForNotListing({
+          name,
+        }),
+      )}
+      onClick={stopPropagation}
+    >
+      <WithTooltip>{name}</WithTooltip>
+    </MaybeLink>
+  );
+}
+
+export const LinkToClusterRole = withInjectables<Dependencies, LinkToClusterRoleProps>(NonInjectedLinkToClusterRole, {
+  getProps: (di, props) => ({
+    ...props,
+    getMaybeDetailsUrl: di.inject(getMaybeDetailsUrlInjectable),
+    clusterRoleApi: di.inject(clusterRoleApiInjectable),
+  }),
+});

--- a/packages/core/src/renderer/components/kube-object-link/link-to-namespace.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-namespace.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { namespaceApiInjectable } from "@freelensapp/kube-api-specifics";
+import { stopPropagation } from "@freelensapp/utilities";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import React from "react";
+import getMaybeDetailsUrlInjectable, {
+  type GetMaybeDetailsUrl,
+} from "../kube-detail-params/get-maybe-details-url.injectable";
+import { MaybeLink } from "../maybe-link";
+import { WithTooltip } from "../with-tooltip";
+
+import type { NamespaceApi } from "@freelensapp/kube-api";
+
+interface Dependencies {
+  getMaybeDetailsUrl: GetMaybeDetailsUrl;
+  namespaceApi: NamespaceApi;
+}
+
+interface LinkToNamespaceProps {
+  namespace?: string;
+}
+
+function NonInjectedLinkToNamespace({
+  namespace,
+  getMaybeDetailsUrl,
+  namespaceApi,
+}: LinkToNamespaceProps & Dependencies) {
+  if (!namespace) return null;
+
+  return (
+    <MaybeLink
+      key="link"
+      to={getMaybeDetailsUrl(
+        namespaceApi.formatUrlForNotListing({
+          name: namespace,
+        }),
+      )}
+      onClick={stopPropagation}
+    >
+      <WithTooltip>{namespace}</WithTooltip>
+    </MaybeLink>
+  );
+}
+
+export const LinkToNamespace = withInjectables<Dependencies, LinkToNamespaceProps>(NonInjectedLinkToNamespace, {
+  getProps: (di, props) => ({
+    ...props,
+    getMaybeDetailsUrl: di.inject(getMaybeDetailsUrlInjectable),
+    namespaceApi: di.inject(namespaceApiInjectable),
+  }),
+});

--- a/packages/core/src/renderer/components/kube-object-link/link-to-object.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-object.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { stopPropagation } from "@freelensapp/utilities";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import React from "react";
+import getMaybeDetailsUrlInjectable, {
+  type GetMaybeDetailsUrl,
+} from "../kube-detail-params/get-maybe-details-url.injectable";
+import { MaybeLink } from "../maybe-link";
+import { WithTooltip } from "../with-tooltip";
+
+import type { KubeObject, LocalObjectReference, ObjectReference } from "@freelensapp/kube-object";
+
+interface Dependencies {
+  getMaybeDetailsUrl: GetMaybeDetailsUrl;
+}
+
+interface LinkToObjectProps {
+  objectRef?: LocalObjectReference | ObjectReference;
+  object?: KubeObject;
+  tooltip?: string | React.ReactNode;
+  content?: string | React.ReactNode;
+}
+
+function getRefUrl(objectRef: LocalObjectReference | ObjectReference, object: KubeObject): string {
+  // Implementation depends on the specific requirements
+  // For LocalObjectReference, we need to infer kind and namespace from the parent object
+  if ("kind" in objectRef && objectRef.kind) {
+    // ObjectReference with kind
+    if ("namespace" in objectRef && objectRef.namespace) {
+      return `/api/v1/namespaces/${objectRef.namespace}/${objectRef.kind.toLowerCase()}s/${objectRef.name}`;
+    }
+    return `/api/v1/${objectRef.kind.toLowerCase()}s/${objectRef.name}`;
+  }
+  // LocalObjectReference - use parent object's namespace and infer type
+  return `/api/v1/namespaces/${object.getNs()}/${object.kind.toLowerCase()}s/${objectRef.name}`;
+}
+
+function NonInjectedLinkToObject({
+  objectRef,
+  object,
+  tooltip,
+  content,
+  getMaybeDetailsUrl,
+}: LinkToObjectProps & Dependencies) {
+  if (!objectRef || !object) return null;
+
+  return (
+    <MaybeLink to={getMaybeDetailsUrl(getRefUrl(objectRef, object))} onClick={stopPropagation}>
+      <WithTooltip tooltip={tooltip}>{content ?? objectRef?.name}</WithTooltip>
+    </MaybeLink>
+  );
+}
+
+export const LinkToObject = withInjectables<Dependencies, LinkToObjectProps>(NonInjectedLinkToObject, {
+  getProps: (di, props) => ({
+    ...props,
+    getMaybeDetailsUrl: di.inject(getMaybeDetailsUrlInjectable),
+  }),
+});

--- a/packages/core/src/renderer/components/kube-object-link/link-to-role.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-role.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { roleApiInjectable } from "@freelensapp/kube-api-specifics";
+import { stopPropagation } from "@freelensapp/utilities";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import React from "react";
+import getMaybeDetailsUrlInjectable, {
+  type GetMaybeDetailsUrl,
+} from "../kube-detail-params/get-maybe-details-url.injectable";
+import { MaybeLink } from "../maybe-link";
+import { WithTooltip } from "../with-tooltip";
+
+import type { RoleApi } from "@freelensapp/kube-api";
+
+interface Dependencies {
+  getMaybeDetailsUrl: GetMaybeDetailsUrl;
+  roleApi: RoleApi;
+}
+
+interface LinkToRoleProps {
+  name?: string;
+  namespace?: string;
+}
+
+function NonInjectedLinkToRole({ name, namespace, getMaybeDetailsUrl, roleApi }: LinkToRoleProps & Dependencies) {
+  if (!name || !namespace) return null;
+
+  return (
+    <MaybeLink
+      key="link"
+      to={getMaybeDetailsUrl(
+        roleApi.formatUrlForNotListing({
+          name,
+          namespace,
+        }),
+      )}
+      onClick={stopPropagation}
+    >
+      <WithTooltip>{name}</WithTooltip>
+    </MaybeLink>
+  );
+}
+
+export const LinkToRole = withInjectables<Dependencies, LinkToRoleProps>(NonInjectedLinkToRole, {
+  getProps: (di, props) => ({
+    ...props,
+    getMaybeDetailsUrl: di.inject(getMaybeDetailsUrlInjectable),
+    roleApi: di.inject(roleApiInjectable),
+  }),
+});

--- a/packages/core/src/renderer/components/kube-object-link/link-to-secret.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-secret.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { secretApiInjectable } from "@freelensapp/kube-api-specifics";
+import { stopPropagation } from "@freelensapp/utilities";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import React from "react";
+import getMaybeDetailsUrlInjectable, {
+  type GetMaybeDetailsUrl,
+} from "../kube-detail-params/get-maybe-details-url.injectable";
+import { MaybeLink } from "../maybe-link";
+import { WithTooltip } from "../with-tooltip";
+
+import type { SecretApi } from "@freelensapp/kube-api";
+
+interface Dependencies {
+  getMaybeDetailsUrl: GetMaybeDetailsUrl;
+  secretApi: SecretApi;
+}
+
+interface LinkToSecretProps {
+  name?: string;
+  namespace?: string;
+}
+
+function NonInjectedLinkToSecret({ name, namespace, getMaybeDetailsUrl, secretApi }: LinkToSecretProps & Dependencies) {
+  if (!name || !namespace) return null;
+
+  return (
+    <MaybeLink
+      key="link"
+      to={getMaybeDetailsUrl(
+        secretApi.formatUrlForNotListing({
+          name,
+          namespace,
+        }),
+      )}
+      onClick={stopPropagation}
+    >
+      <WithTooltip>{name}</WithTooltip>
+    </MaybeLink>
+  );
+}
+
+export const LinkToSecret = withInjectables<Dependencies, LinkToSecretProps>(NonInjectedLinkToSecret, {
+  getProps: (di, props) => ({
+    ...props,
+    getMaybeDetailsUrl: di.inject(getMaybeDetailsUrlInjectable),
+    secretApi: di.inject(secretApiInjectable),
+  }),
+});

--- a/packages/core/src/renderer/components/kube-object-link/link-to-service-account.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-service-account.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { serviceAccountApiInjectable } from "@freelensapp/kube-api-specifics";
+import { stopPropagation } from "@freelensapp/utilities";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import React from "react";
+import getMaybeDetailsUrlInjectable, {
+  type GetMaybeDetailsUrl,
+} from "../kube-detail-params/get-maybe-details-url.injectable";
+import { MaybeLink } from "../maybe-link";
+import { WithTooltip } from "../with-tooltip";
+
+import type { ServiceAccountApi } from "@freelensapp/kube-api";
+
+interface Dependencies {
+  getMaybeDetailsUrl: GetMaybeDetailsUrl;
+  serviceAccountApi: ServiceAccountApi;
+}
+
+interface LinkToServiceAccountProps {
+  name?: string;
+  namespace?: string;
+}
+
+function NonInjectedLinkToServiceAccount({
+  name,
+  namespace,
+  getMaybeDetailsUrl,
+  serviceAccountApi,
+}: LinkToServiceAccountProps & Dependencies) {
+  if (!name || !namespace) return null;
+
+  return (
+    <MaybeLink
+      key="link"
+      to={getMaybeDetailsUrl(
+        serviceAccountApi.formatUrlForNotListing({
+          name,
+          namespace,
+        }),
+      )}
+      onClick={stopPropagation}
+    >
+      <WithTooltip>{name}</WithTooltip>
+    </MaybeLink>
+  );
+}
+
+export const LinkToServiceAccount = withInjectables<Dependencies, LinkToServiceAccountProps>(
+  NonInjectedLinkToServiceAccount,
+  {
+    getProps: (di, props) => ({
+      ...props,
+      getMaybeDetailsUrl: di.inject(getMaybeDetailsUrlInjectable),
+      serviceAccountApi: di.inject(serviceAccountApiInjectable),
+    }),
+  },
+);

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/details.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/details.tsx
@@ -15,7 +15,9 @@ import React from "react";
 import { AddRemoveButtons } from "../../add-remove-buttons";
 import openConfirmDialogInjectable from "../../confirm-dialog/open.injectable";
 import { DrawerTitle } from "../../drawer";
+import { LinkToClusterRole, LinkToNamespace, LinkToServiceAccount } from "../../kube-object-link";
 import { Table, TableCell, TableHead, TableRow } from "../../table";
+import { WithTooltip } from "../../with-tooltip";
 import { hashSubject } from "../hashers";
 import openClusterRoleBindingDialogInjectable from "./dialog/open.injectable";
 import clusterRoleBindingStoreInjectable from "./store.injectable";
@@ -91,9 +93,15 @@ class NonInjectedClusterRoleBindingDetails extends React.Component<ClusterRoleBi
             <TableCell>API Group</TableCell>
           </TableHead>
           <TableRow>
-            <TableCell>{roleRef.kind}</TableCell>
-            <TableCell>{roleRef.name}</TableCell>
-            <TableCell>{roleRef.apiGroup}</TableCell>
+            <TableCell>
+              <WithTooltip>{roleRef.kind}</WithTooltip>
+            </TableCell>
+            <TableCell>
+              <LinkToClusterRole name={roleRef.name} />
+            </TableCell>
+            <TableCell>
+              <WithTooltip>{roleRef.apiGroup}</WithTooltip>
+            </TableCell>
           </TableRow>
         </Table>
 
@@ -117,9 +125,15 @@ class NonInjectedClusterRoleBindingDetails extends React.Component<ClusterRoleBi
                   onClick={prevDefault(() => this.selectedSubjects.toggle(subject))}
                 >
                   <TableCell checkbox isChecked={isSelected} />
-                  <TableCell className="type">{kind}</TableCell>
-                  <TableCell className="binding">{name}</TableCell>
-                  <TableCell className="ns">{namespace || "-"}</TableCell>
+                  <TableCell className="type">
+                    <WithTooltip>{kind}</WithTooltip>
+                  </TableCell>
+                  <TableCell className="binding">
+                    {kind === "ServiceAccount" ? <LinkToServiceAccount name={name} namespace={namespace} /> : name}
+                  </TableCell>
+                  <TableCell className="ns">
+                    <LinkToNamespace namespace={namespace} />
+                  </TableCell>
                 </TableRow>
               );
             })}

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/view.tsx
@@ -10,6 +10,7 @@ import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
 import { KubeObjectAge } from "../../kube-object/age";
+import { LinkToClusterRole } from "../../kube-object-link";
 import { KubeObjectListLayout } from "../../kube-object-list-layout";
 import { KubeObjectStatusIcon } from "../../kube-object-status-icon";
 import { SiblingsInTabLayout } from "../../layout/siblings-in-tab-layout";
@@ -79,7 +80,7 @@ class NonInjectedClusterRoleBindings extends React.Component<Dependencies> {
           renderTableContents={(binding) => [
             <WithTooltip>{binding.getName()}</WithTooltip>,
             <KubeObjectStatusIcon key="icon" object={binding} />,
-            <WithTooltip>{binding.roleRef.name}</WithTooltip>,
+            <LinkToClusterRole name={binding.roleRef.name} />,
             <WithTooltip>{binding.getSubjectTypes()}</WithTooltip>,
             <WithTooltip>{binding.getSubjectNames()}</WithTooltip>,
             <KubeObjectAge key="age" object={binding} />,

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/view.tsx
@@ -28,6 +28,7 @@ import type { ClusterRoleBindingStore } from "./store";
 enum columnId {
   name = "name",
   namespace = "namespace",
+  role = "role",
   bindings = "bindings",
   age = "age",
 }
@@ -54,6 +55,7 @@ class NonInjectedClusterRoleBindings extends React.Component<Dependencies> {
           dependentStores={[clusterRoleStore, serviceAccountStore]}
           sortingCallbacks={{
             [columnId.name]: (binding) => binding.getName(),
+            [columnId.role]: (binding) => binding.roleRef.name,
             [columnId.bindings]: (binding) => binding.getSubjectNames(),
             [columnId.age]: (binding) => -binding.getCreationTimestamp(),
           }}
@@ -62,12 +64,14 @@ class NonInjectedClusterRoleBindings extends React.Component<Dependencies> {
           renderTableHeader={[
             { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },
             { className: "warning", showWithColumn: columnId.name },
+            { title: "Role", className: "role", sortBy: columnId.role, id: columnId.role },
             { title: "Bindings", className: "bindings", sortBy: columnId.bindings, id: columnId.bindings },
             { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
           ]}
           renderTableContents={(binding) => [
             <WithTooltip>{binding.getName()}</WithTooltip>,
             <KubeObjectStatusIcon key="icon" object={binding} />,
+            <WithTooltip>{binding.roleRef.name}</WithTooltip>,
             <WithTooltip>{binding.getSubjectNames()}</WithTooltip>,
             <KubeObjectAge key="age" object={binding} />,
           ]}

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/view.tsx
@@ -28,7 +28,7 @@ import type { ClusterRoleBindingStore } from "./store";
 enum columnId {
   name = "name",
   namespace = "namespace",
-  role = "role",
+  clusterRole = "cluster-role",
   bindings = "bindings",
   age = "age",
 }
@@ -55,7 +55,7 @@ class NonInjectedClusterRoleBindings extends React.Component<Dependencies> {
           dependentStores={[clusterRoleStore, serviceAccountStore]}
           sortingCallbacks={{
             [columnId.name]: (binding) => binding.getName(),
-            [columnId.role]: (binding) => binding.roleRef.name,
+            [columnId.clusterRole]: (binding) => binding.roleRef.name,
             [columnId.bindings]: (binding) => binding.getSubjectNames(),
             [columnId.age]: (binding) => -binding.getCreationTimestamp(),
           }}
@@ -64,7 +64,12 @@ class NonInjectedClusterRoleBindings extends React.Component<Dependencies> {
           renderTableHeader={[
             { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },
             { className: "warning", showWithColumn: columnId.name },
-            { title: "Role", className: "role", sortBy: columnId.role, id: columnId.role },
+            {
+              title: "Cluster Role",
+              className: "cluster-role",
+              sortBy: columnId.clusterRole,
+              id: columnId.clusterRole,
+            },
             { title: "Bindings", className: "bindings", sortBy: columnId.bindings, id: columnId.bindings },
             { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
           ]}

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/view.tsx
@@ -29,6 +29,7 @@ enum columnId {
   name = "name",
   namespace = "namespace",
   clusterRole = "cluster-role",
+  types = "types",
   bindings = "bindings",
   age = "age",
 }
@@ -56,6 +57,7 @@ class NonInjectedClusterRoleBindings extends React.Component<Dependencies> {
           sortingCallbacks={{
             [columnId.name]: (binding) => binding.getName(),
             [columnId.clusterRole]: (binding) => binding.roleRef.name,
+            [columnId.types]: (binding) => binding.getSubjectTypes(),
             [columnId.bindings]: (binding) => binding.getSubjectNames(),
             [columnId.age]: (binding) => -binding.getCreationTimestamp(),
           }}
@@ -70,6 +72,7 @@ class NonInjectedClusterRoleBindings extends React.Component<Dependencies> {
               sortBy: columnId.clusterRole,
               id: columnId.clusterRole,
             },
+            { title: "Types", className: "types", sortBy: columnId.types, id: columnId.types },
             { title: "Bindings", className: "bindings", sortBy: columnId.bindings, id: columnId.bindings },
             { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
           ]}
@@ -77,6 +80,7 @@ class NonInjectedClusterRoleBindings extends React.Component<Dependencies> {
             <WithTooltip>{binding.getName()}</WithTooltip>,
             <KubeObjectStatusIcon key="icon" object={binding} />,
             <WithTooltip>{binding.roleRef.name}</WithTooltip>,
+            <WithTooltip>{binding.getSubjectTypes()}</WithTooltip>,
             <WithTooltip>{binding.getSubjectNames()}</WithTooltip>,
             <KubeObjectAge key="age" object={binding} />,
           ]}

--- a/packages/core/src/renderer/components/user-management/role-bindings/details.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/details.tsx
@@ -14,7 +14,9 @@ import React from "react";
 import { AddRemoveButtons } from "../../add-remove-buttons";
 import openConfirmDialogInjectable from "../../confirm-dialog/open.injectable";
 import { DrawerTitle } from "../../drawer";
+import { LinkToNamespace, LinkToRole, LinkToServiceAccount } from "../../kube-object-link";
 import { Table, TableCell, TableHead, TableRow } from "../../table";
+import { WithTooltip } from "../../with-tooltip";
 import { hashSubject } from "../hashers";
 import openRoleBindingDialogInjectable from "./dialog/open.injectable";
 import roleBindingStoreInjectable from "./store.injectable";
@@ -74,6 +76,7 @@ class NonInjectedRoleBindingDetails extends React.Component<RoleBindingDetailsPr
     }
     const { roleRef } = roleBinding;
     const subjects = roleBinding.getSubjects();
+    const namespace = roleBinding.getNs();
 
     return (
       <div className="RoleBindingDetails">
@@ -85,9 +88,15 @@ class NonInjectedRoleBindingDetails extends React.Component<RoleBindingDetailsPr
             <TableCell>API Group</TableCell>
           </TableHead>
           <TableRow>
-            <TableCell>{roleRef.kind}</TableCell>
-            <TableCell>{roleRef.name}</TableCell>
-            <TableCell>{roleRef.apiGroup}</TableCell>
+            <TableCell>
+              <WithTooltip>{roleRef.kind}</WithTooltip>
+            </TableCell>
+            <TableCell>
+              <LinkToRole name={roleRef.name} namespace={namespace} />
+            </TableCell>
+            <TableCell>
+              <WithTooltip>{roleRef.apiGroup}</WithTooltip>
+            </TableCell>
           </TableRow>
         </Table>
 
@@ -111,9 +120,15 @@ class NonInjectedRoleBindingDetails extends React.Component<RoleBindingDetailsPr
                   onClick={prevDefault(() => this.selectedSubjects.toggle(subject))}
                 >
                   <TableCell checkbox isChecked={isSelected} />
-                  <TableCell className="type">{kind}</TableCell>
-                  <TableCell className="binding">{name}</TableCell>
-                  <TableCell className="ns">{namespace || "-"}</TableCell>
+                  <TableCell className="type">
+                    <WithTooltip>{kind}</WithTooltip>
+                  </TableCell>
+                  <TableCell className="binding">
+                    {kind === "ServiceAccount" ? <LinkToServiceAccount name={name} namespace={namespace} /> : name}
+                  </TableCell>
+                  <TableCell className="ns">
+                    <LinkToNamespace namespace={namespace} />
+                  </TableCell>
                 </TableRow>
               );
             })}

--- a/packages/core/src/renderer/components/user-management/role-bindings/view.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/view.tsx
@@ -31,6 +31,7 @@ import type { RoleBindingStore } from "./store";
 enum columnId {
   name = "name",
   namespace = "namespace",
+  role = "role",
   bindings = "bindings",
   age = "age",
 }
@@ -59,6 +60,7 @@ class NonInjectedRoleBindings extends React.Component<Dependencies> {
           sortingCallbacks={{
             [columnId.name]: (binding) => binding.getName(),
             [columnId.namespace]: (binding) => binding.getNs(),
+            [columnId.role]: (binding) => binding.roleRef.name,
             [columnId.bindings]: (binding) => binding.getSubjectNames(),
             [columnId.age]: (binding) => -binding.getCreationTimestamp(),
           }}
@@ -68,6 +70,7 @@ class NonInjectedRoleBindings extends React.Component<Dependencies> {
             { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },
             { className: "warning", showWithColumn: columnId.name },
             { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace },
+            { title: "Role", className: "role", sortBy: columnId.role, id: columnId.role },
             { title: "Bindings", className: "bindings", sortBy: columnId.bindings, id: columnId.bindings },
             { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
           ]}
@@ -75,6 +78,7 @@ class NonInjectedRoleBindings extends React.Component<Dependencies> {
             <WithTooltip>{binding.getName()}</WithTooltip>,
             <KubeObjectStatusIcon key="icon" object={binding} />,
             <NamespaceSelectBadge key="namespace" namespace={binding.getNs()} />,
+            <WithTooltip>{binding.roleRef.name}</WithTooltip>,
             <WithTooltip>{binding.getSubjectNames()}</WithTooltip>,
             <KubeObjectAge key="age" object={binding} />,
           ]}

--- a/packages/core/src/renderer/components/user-management/role-bindings/view.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/view.tsx
@@ -10,6 +10,7 @@ import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
 import { KubeObjectAge } from "../../kube-object/age";
+import { LinkToRole } from "../../kube-object-link";
 import { KubeObjectListLayout } from "../../kube-object-list-layout";
 import { KubeObjectStatusIcon } from "../../kube-object-status-icon";
 import { SiblingsInTabLayout } from "../../layout/siblings-in-tab-layout";
@@ -81,7 +82,7 @@ class NonInjectedRoleBindings extends React.Component<Dependencies> {
             <WithTooltip>{binding.getName()}</WithTooltip>,
             <KubeObjectStatusIcon key="icon" object={binding} />,
             <NamespaceSelectBadge key="namespace" namespace={binding.getNs()} />,
-            <WithTooltip>{binding.roleRef.name}</WithTooltip>,
+            <LinkToRole name={binding.roleRef.name} namespace={binding.getNs()} />,
             <WithTooltip>{binding.getSubjectTypes()}</WithTooltip>,
             <WithTooltip>{binding.getSubjectNames()}</WithTooltip>,
             <KubeObjectAge key="age" object={binding} />,

--- a/packages/core/src/renderer/components/user-management/role-bindings/view.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/view.tsx
@@ -32,6 +32,7 @@ enum columnId {
   name = "name",
   namespace = "namespace",
   role = "role",
+  types = "types",
   bindings = "bindings",
   age = "age",
 }
@@ -61,6 +62,7 @@ class NonInjectedRoleBindings extends React.Component<Dependencies> {
             [columnId.name]: (binding) => binding.getName(),
             [columnId.namespace]: (binding) => binding.getNs(),
             [columnId.role]: (binding) => binding.roleRef.name,
+            [columnId.types]: (binding) => binding.getSubjectTypes(),
             [columnId.bindings]: (binding) => binding.getSubjectNames(),
             [columnId.age]: (binding) => -binding.getCreationTimestamp(),
           }}
@@ -71,6 +73,7 @@ class NonInjectedRoleBindings extends React.Component<Dependencies> {
             { className: "warning", showWithColumn: columnId.name },
             { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace },
             { title: "Role", className: "role", sortBy: columnId.role, id: columnId.role },
+            { title: "Types", className: "types", sortBy: columnId.types, id: columnId.types },
             { title: "Bindings", className: "bindings", sortBy: columnId.bindings, id: columnId.bindings },
             { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
           ]}
@@ -79,6 +82,7 @@ class NonInjectedRoleBindings extends React.Component<Dependencies> {
             <KubeObjectStatusIcon key="icon" object={binding} />,
             <NamespaceSelectBadge key="namespace" namespace={binding.getNs()} />,
             <WithTooltip>{binding.roleRef.name}</WithTooltip>,
+            <WithTooltip>{binding.getSubjectTypes()}</WithTooltip>,
             <WithTooltip>{binding.getSubjectNames()}</WithTooltip>,
             <KubeObjectAge key="age" object={binding} />,
           ]}

--- a/packages/kube-object/src/specifics/cluster-role-binding.ts
+++ b/packages/kube-object/src/specifics/cluster-role-binding.ts
@@ -42,4 +42,9 @@ export class ClusterRoleBinding extends KubeObject<ClusterScopedMetadata, void, 
       .map((subject) => subject.name)
       .join(", ");
   }
+
+  getSubjectTypes(): string {
+    const types = this.getSubjects().map((subject) => subject.kind);
+    return Array.from(new Set(types)).sort().join(", ");
+  }
 }

--- a/packages/kube-object/src/specifics/role-binding.ts
+++ b/packages/kube-object/src/specifics/role-binding.ts
@@ -41,4 +41,9 @@ export class RoleBinding extends KubeObject<NamespaceScopedMetadata, void, void>
       .map((subject) => subject.name)
       .join(", ");
   }
+
+  getSubjectTypes(): string {
+    const types = this.getSubjects().map((subject) => subject.kind);
+    return Array.from(new Set(types)).sort().join(", ");
+  }
 }


### PR DESCRIPTION
**Description of changes:**

- Added the column with (cluster) role name and binding types (Kind)

<img width="1198" height="315" alt="image" src="https://github.com/user-attachments/assets/21024789-11b2-4938-b3c5-d4e18f1efeda" />

- Lists are hyperlinked

<img width="1164" height="261" alt="image" src="https://github.com/user-attachments/assets/d059d875-450b-4496-a399-451331d9c31e" />

- Details too

<img width="718" height="354" alt="image" src="https://github.com/user-attachments/assets/7b17e8e5-020c-4be9-8ef1-6334fc57bb0b" />

- New components simplify linking. All they started with `<LinkTo...>` and will be used later in other views.