### PR TITLE
Add HTTPS support and custom prefix in Prometheus settings

### DIFF
--- a/packages/core/src/common/catalog-entities/kubernetes-cluster.ts
+++ b/packages/core/src/common/catalog-entities/kubernetes-cluster.ts
@@ -29,6 +29,7 @@ export interface KubernetesClusterPrometheusMetrics {
     service: string;
     port: number;
     prefix: string;
+    https?: boolean;
   };
   type?: string;
 }

--- a/packages/core/src/common/cluster-types.ts
+++ b/packages/core/src/common/cluster-types.ts
@@ -116,6 +116,8 @@ export interface ClusterPrometheusPreferences {
     service: string;
     port: number;
     prefix: string;
+    /** When true, add "https:" prefix to service proxy path */
+    https?: boolean;
   };
   prometheusProvider?: {
     type: string;

--- a/packages/core/src/main/cluster/prometheus-handler/prometheus-handler.ts
+++ b/packages/core/src/main/cluster/prometheus-handler/prometheus-handler.ts
@@ -26,6 +26,7 @@ interface PrometheusServicePreferences {
   service: string;
   port: number;
   prefix: string;
+  https?: boolean;
 }
 
 interface Dependencies {
@@ -40,8 +41,10 @@ export interface ClusterPrometheusHandler {
   getPrometheusDetails(): Promise<PrometheusDetails>;
 }
 
-const ensurePrometheusPath = ({ service, namespace, port }: PrometheusService) =>
-  `${namespace}/services/${service}:${port}`;
+// Build the Kubernetes service-proxy path. If HTTPS is requested, use the
+// "https:" prefix before the service name per K8s API conventions.
+const ensurePrometheusPath = (service: PrometheusService, useHttps?: boolean) =>
+  `${service.namespace}/services/${useHttps ? "https:" : ""}${service.service}:${service.port}`;
 
 export const createClusterPrometheusHandler = (...args: [Dependencies, Cluster]): ClusterPrometheusHandler => {
   const [deps, cluster] = args;
@@ -114,7 +117,7 @@ export const createClusterPrometheusHandler = (...args: [Dependencies, Cluster])
 
   const getPrometheusDetails: ClusterPrometheusHandler["getPrometheusDetails"] = async () => {
     const service = await getPrometheusService();
-    const prometheusPath = ensurePrometheusPath(service);
+    const prometheusPath = ensurePrometheusPath(service, prometheus?.https);
     const provider = ensurePrometheusProvider(service);
 
     return { prometheusPath, provider };


### PR DESCRIPTION
Fixes #1132

This PR adds explicit HTTPS support and a custom path prefix to Prometheus settings.

What
- Add `https?: boolean` to Prometheus preferences and related cluster metrics types
- Respect HTTPS in service-proxy paths by prefixing services with `https:` per K8s API conventions
- Prometheus settings UI improvements:
  - Add an explicit HTTPS toggle
  - Add a separate custom path prefix field (auto-sanitized to start with a leading slash)
  - Persist all settings cohesively on blur/change
- Default behavior remains unchanged (HTTP, no prefix) for backward compatibility

Why
Externally hosted Prometheus deployments often require HTTPS and a path prefix (e.g., `/prometheus`). Previously this had to be encoded implicitly and assumed HTTP, making configuration error-prone. This change makes the configuration explicit and safer while remaining backward compatible.

FYI
It was also introduced as a feature by Lens itself.
<img width="1482" height="1042" alt="Lens 2025-08-26 14 09 42" src="https://github.com/user-attachments/assets/a1ef984d-0497-44a9-af8c-b139d83e8b12" />