### PR TITLE
Field name renamed from Susped to Resumed for Jobs and CronJobs

### DIFF
--- a/packages/core/src/renderer/components/kube-object-link/index.ts
+++ b/packages/core/src/renderer/components/kube-object-link/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from "./link-to-cluster-role";
+export * from "./link-to-job";
 export * from "./link-to-namespace";
 export * from "./link-to-node";
 export * from "./link-to-object";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-job.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-job.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { jobApiInjectable } from "@freelensapp/kube-api-specifics";
+import { stopPropagation } from "@freelensapp/utilities";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import React from "react";
+import getMaybeDetailsUrlInjectable, {
+  type GetMaybeDetailsUrl,
+} from "../kube-detail-params/get-maybe-details-url.injectable";
+import { MaybeLink } from "../maybe-link";
+import { WithTooltip } from "../with-tooltip";
+
+import type { JobApi } from "@freelensapp/kube-api";
+
+interface Dependencies {
+  getMaybeDetailsUrl: GetMaybeDetailsUrl;
+  jobApi: JobApi;
+}
+
+interface LinkToJobProps {
+  name?: string;
+  namespace?: string;
+}
+
+function NonInjectedLinkToJob({ name, namespace, getMaybeDetailsUrl, jobApi }: LinkToJobProps & Dependencies) {
+  if (!name || !namespace) return null;
+
+  return (
+    <MaybeLink
+      key="link"
+      to={getMaybeDetailsUrl(
+        jobApi.formatUrlForNotListing({
+          name,
+          namespace,
+        }),
+      )}
+      onClick={stopPropagation}
+    >
+      <WithTooltip>{name}</WithTooltip>
+    </MaybeLink>
+  );
+}
+
+export const LinkToJob = withInjectables<Dependencies, LinkToJobProps>(NonInjectedLinkToJob, {
+  getProps: (di, props) => ({
+    ...props,
+    getMaybeDetailsUrl: di.inject(getMaybeDetailsUrlInjectable),
+    jobApi: di.inject(jobApiInjectable),
+  }),
+});

--- a/packages/core/src/renderer/components/workloads-cronjobs/cronjob-details.scss
+++ b/packages/core/src/renderer/components/workloads-cronjobs/cronjob-details.scss
@@ -13,7 +13,8 @@
       margin-top: $margin * 2;
       margin-bottom: $margin;
 
-      a {
+      span {
+        font-weight: bold;
         color: var(--colorInfo);
       }
     }

--- a/packages/core/src/renderer/components/workloads-cronjobs/cronjob-details.tsx
+++ b/packages/core/src/renderer/components/workloads-cronjobs/cronjob-details.tsx
@@ -16,6 +16,7 @@ import { disposeOnUnmount, observer } from "mobx-react";
 import React from "react";
 import { Link } from "react-router-dom";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
+import { BadgeBoolean } from "../badge";
 import { Badge } from "../badge/badge";
 import { DrawerItem, DrawerTitle } from "../drawer";
 import { DurationAbsoluteTimestamp } from "../events";
@@ -79,7 +80,9 @@ class NonInjectedCronJobDetails extends React.Component<CronJobDetailsProps & De
         <DrawerItem name="Concurrency Policy" hidden={!cronJob.spec.concurrencyPolicy}>
           {cronJob.spec.concurrencyPolicy}
         </DrawerItem>
-        <DrawerItem name="Suspend">{cronJob.getSuspendFlag()}</DrawerItem>
+        <DrawerItem name="Resumed">
+          <BadgeBoolean value={!cronJob.spec.suspend} />
+        </DrawerItem>
         <DrawerItem name="Successful Jobs History Limit" hidden={!cronJob.spec.successfulJobsHistoryLimit}>
           {cronJob.spec.successfulJobsHistoryLimit}
         </DrawerItem>

--- a/packages/core/src/renderer/components/workloads-cronjobs/cronjobs.scss
+++ b/packages/core/src/renderer/components/workloads-cronjobs/cronjobs.scss
@@ -16,7 +16,7 @@
       @include table.table-cell-warning;
     }
 
-    &.suspend {
+    &.resumed {
       flex-grow: 0.4;
     }
 

--- a/packages/core/src/renderer/components/workloads-cronjobs/cronjobs.tsx
+++ b/packages/core/src/renderer/components/workloads-cronjobs/cronjobs.tsx
@@ -11,6 +11,7 @@ import cronstrue from "cronstrue";
 import { observer } from "mobx-react";
 import moment from "moment-timezone";
 import React from "react";
+import { BadgeBoolean } from "../badge";
 import eventStoreInjectable from "../events/store.injectable";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectListLayout } from "../kube-object-list-layout";
@@ -28,7 +29,7 @@ enum columnId {
   namespace = "namespace",
   schedule = "schedule",
   timezone = "timezone",
-  suspend = "suspend",
+  resumed = "resumed",
   active = "active",
   lastSchedule = "last-schedule",
   age = "age",
@@ -54,7 +55,7 @@ const NonInjectedCronJobs = observer((props: Dependencies) => {
           [columnId.name]: (cronJob) => cronJob.getName(),
           [columnId.namespace]: (cronJob) => cronJob.getNs(),
           [columnId.timezone]: (cronJob) => cronJob.spec.timeZone ?? "",
-          [columnId.suspend]: (cronJob) => cronJob.getSuspendFlag(),
+          [columnId.resumed]: (cronJob) => String(!cronJob.spec.suspend),
           [columnId.active]: (cronJob) => cronJobStore.getActiveJobsNum(cronJob),
           [columnId.lastSchedule]: (cronJob) =>
             cronJob.status?.lastScheduleTime ? moment().diff(cronJob.status.lastScheduleTime) : 0,
@@ -68,7 +69,7 @@ const NonInjectedCronJobs = observer((props: Dependencies) => {
           { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace },
           { title: "Schedule", className: "schedule", id: columnId.schedule },
           { title: "Timezone", className: "timezone", id: columnId.timezone },
-          { title: "Suspend", className: "suspend", sortBy: columnId.suspend, id: columnId.suspend },
+          { title: "Resumed", className: "resumed", sortBy: columnId.resumed, id: columnId.resumed },
           { title: "Active", className: "active", sortBy: columnId.active, id: columnId.active },
           {
             title: "Last schedule",
@@ -88,7 +89,7 @@ const NonInjectedCronJobs = observer((props: Dependencies) => {
             {cronJob.isNeverRun() ? "never" : cronJob.getSchedule()}
           </WithTooltip>,
           <WithTooltip>{cronJob.spec.timeZone}</WithTooltip>,
-          cronJob.getSuspendFlag(),
+          <BadgeBoolean value={!cronJob.spec.suspend} />,
           cronJobStore.getActiveJobsNum(cronJob),
           <WithTooltip
             tooltip={cronJob.status?.lastScheduleTime ? moment(cronJob.status?.lastScheduleTime).toDate() : undefined}

--- a/packages/core/src/renderer/components/workloads-jobs/job-details.tsx
+++ b/packages/core/src/renderer/components/workloads-jobs/job-details.tsx
@@ -13,7 +13,7 @@ import { withInjectables } from "@ogre-tools/injectable-react";
 import { disposeOnUnmount, observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
-import { Badge } from "../badge";
+import { Badge, BadgeBoolean } from "../badge";
 import { DrawerItem } from "../drawer";
 import { DurationAbsoluteTimestamp } from "../events";
 import { KubeObjectConditionsDrawer } from "../kube-object-conditions";
@@ -88,7 +88,9 @@ class NonInjectedJobDetails extends React.Component<JobDetailsProps & Dependenci
         <DrawerItem name="Completion Mode" hidden={!job.spec.completionMode}>
           {job.spec.completionMode}
         </DrawerItem>
-        <DrawerItem name="Suspend">{job.getSuspendFlag()}</DrawerItem>
+        <DrawerItem name="Resumed">
+          <BadgeBoolean value={!job.spec.suspend} />
+        </DrawerItem>
         <DrawerItem name="Backoff Limit" hidden={job.spec.backoffLimit !== undefined}>
           {job.spec.backoffLimit}
         </DrawerItem>

--- a/packages/core/src/renderer/components/workloads-jobs/jobs.scss
+++ b/packages/core/src/renderer/components/workloads-jobs/jobs.scss
@@ -13,7 +13,7 @@
       flex-grow: 2;
     }
 
-    &.suspend {
+    &.resumed {
       flex-grow: 0.4;
     }
 

--- a/packages/core/src/renderer/components/workloads-jobs/jobs.tsx
+++ b/packages/core/src/renderer/components/workloads-jobs/jobs.tsx
@@ -127,7 +127,7 @@ const NonInjectedJobs = observer((props: Dependencies) => {
           { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },
           { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace },
           { className: "warning", showWithColumn: columnId.name },
-          { title: "resumed", className: "resumed", sortBy: columnId.resumed, id: columnId.resumed },
+          { title: "Resumed", className: "resumed", sortBy: columnId.resumed, id: columnId.resumed },
           { title: "Status", className: "status", sortBy: columnId.status, id: columnId.status },
           { title: "Succeeded", className: "succeeded", sortBy: columnId.succeeded, id: columnId.succeeded },
           { title: "Completions", className: "completions", sortBy: columnId.completions, id: columnId.completions },

--- a/packages/core/src/renderer/components/workloads-jobs/jobs.tsx
+++ b/packages/core/src/renderer/components/workloads-jobs/jobs.tsx
@@ -10,7 +10,7 @@ import { formatDuration } from "@freelensapp/utilities/dist";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
-import { Badge } from "../badge";
+import { Badge, BadgeBoolean } from "../badge";
 import { DurationAbsoluteTimestamp } from "../events";
 import eventStoreInjectable from "../events/store.injectable";
 import { KubeObjectAge } from "../kube-object/age";
@@ -29,7 +29,7 @@ import type { JobStore } from "./store";
 enum columnId {
   name = "name",
   namespace = "namespace",
-  suspend = "suspend",
+  resumed = "resumed",
   status = "status",
   succeeded = "succeeded",
   completions = "completions",
@@ -113,7 +113,7 @@ const NonInjectedJobs = observer((props: Dependencies) => {
         sortingCallbacks={{
           [columnId.name]: (job) => job.getName(),
           [columnId.namespace]: (job) => job.getNs(),
-          [columnId.suspend]: (job) => job.getSuspendFlag(),
+          [columnId.resumed]: (job) => String(!job.spec.suspend),
           [columnId.succeeded]: (job) => job.getCompletions(),
           [columnId.completions]: (job) => job.getDesiredCompletions(),
           [columnId.parallelism]: (job) => job.getParallelism(),
@@ -127,7 +127,7 @@ const NonInjectedJobs = observer((props: Dependencies) => {
           { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },
           { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace },
           { className: "warning", showWithColumn: columnId.name },
-          { title: "Suspend", className: "suspend", sortBy: columnId.suspend, id: columnId.suspend },
+          { title: "resumed", className: "resumed", sortBy: columnId.resumed, id: columnId.resumed },
           { title: "Status", className: "status", sortBy: columnId.status, id: columnId.status },
           { title: "Succeeded", className: "succeeded", sortBy: columnId.succeeded, id: columnId.succeeded },
           { title: "Completions", className: "completions", sortBy: columnId.completions, id: columnId.completions },
@@ -140,7 +140,7 @@ const NonInjectedJobs = observer((props: Dependencies) => {
             <WithTooltip>{job.getName()}</WithTooltip>,
             <NamespaceSelectBadge key="namespace" namespace={job.getNs()} />,
             <KubeObjectStatusIcon key="icon" object={job} />,
-            job.getSuspendFlag(),
+            <BadgeBoolean value={!job.spec.suspend} />,
             <Badge className={getStatusClass(job)} label={getStatusText(job)} tooltip={getStatusText(job)} />,
             job.getCompletions(),
             job.getDesiredCompletions(),


### PR DESCRIPTION
**Description of changes:**

- The field is renamed from "Suspend" to "Resumed" so if it is active then it should be green by default as True that means it is all healthy and running.

<img width="1170" height="150" alt="image" src="https://github.com/user-attachments/assets/7bac3f44-60dc-410c-b094-6c1ad9c76117" />

<img width="719" height="81" alt="image" src="https://github.com/user-attachments/assets/6cc7289f-c8d8-415e-a9e4-ef54d82ea463" />
