### PR TITLE
Allow to add list of entries separated with comma

### DIFF
--- a/packages/core/src/renderer/components/cluster-settings/accessible-namespaces.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/accessible-namespaces.tsx
@@ -8,7 +8,7 @@ import { makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
 import { EditableList } from "../editable-list";
-import { systemName } from "../input/input_validators";
+import { systemNames } from "../input/input_validators";
 import { SubTitle } from "../layout/sub-title";
 
 import type { Cluster } from "../../../common/cluster/cluster";
@@ -31,12 +31,13 @@ export class ClusterAccessibleNamespaces extends React.Component<ClusterAccessib
       <>
         <SubTitle title="Accessible Namespaces" id="accessible-namespaces" />
         <EditableList
-          placeholder="Add new namespace..."
+          placeholder="Add new namespaces (comma-separated)..."
+          separator=","
           add={(newNamespace) => {
             this.namespaces.add(newNamespace);
             this.props.cluster.accessibleNamespaces.replace([...this.namespaces]);
           }}
-          validators={systemName}
+          validators={systemNames}
           items={Array.from(this.namespaces)}
           remove={({ oldItem: oldNamespace }) => {
             this.namespaces.delete(oldNamespace);

--- a/packages/core/src/renderer/components/editable-list/editable-list.tsx
+++ b/packages/core/src/renderer/components/editable-list/editable-list.tsx
@@ -18,6 +18,7 @@ import type { InputProps, InputValidator } from "../input";
 
 export interface EditableListProps<T> {
   items: T[];
+  separator?: string;
   add: (newItem: string) => void;
   remove: (info: { oldItem: T; index: number }) => void;
   placeholder?: string;
@@ -30,7 +31,7 @@ export interface EditableListProps<T> {
 }
 
 const defaultProps = {
-  placeholder: "Add new item...",
+  placeholder: "Add new items...",
   renderItem: (item: any, index: number) => <React.Fragment key={index}>{item}</React.Fragment>,
   inputTheme: "round",
 };
@@ -47,7 +48,11 @@ class DefaultedEditableList<T> extends React.Component<EditableListProps<T> & ty
   onSubmit(val: string, evt: React.KeyboardEvent) {
     if (val) {
       evt.preventDefault();
-      this.props.add(val);
+      if (this.props.separator) {
+        val.split(this.props.separator).forEach((v) => this.props.add(v));
+      } else {
+        this.props.add(val);
+      }
     }
   }
 

--- a/packages/core/src/renderer/components/input/input_validators.ts
+++ b/packages/core/src/renderer/components/input/input_validators.ts
@@ -235,6 +235,15 @@ export const systemName = inputValidator({
   validate: (value) => !!value.match(systemNameMatcher),
 });
 
+const systemNamesMatcher =
+  /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(,[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)*$/;
+
+export const systemNames = inputValidator({
+  message: () =>
+    `A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics.`,
+  validate: (value) => !!value.match(systemNamesMatcher),
+});
+
 export const accountId = inputValidator({
   message: () => `Invalid account ID`,
   validate: (value) => isEmail.validate(value) || systemName.validate(value),

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
@@ -217,7 +217,8 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
 
         <b>Users</b>
         <EditableList
-          placeholder="Bind to User Account ..."
+          placeholder="Bind to User Accounts (comma-separated) ..."
+          separator=","
           add={(newUser) => this.selectedUsers.add(newUser)}
           items={Array.from(this.selectedUsers)}
           remove={({ oldItem }) => this.selectedUsers.delete(oldItem)}
@@ -225,7 +226,8 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
 
         <b>Groups</b>
         <EditableList
-          placeholder="Bind to User Group ..."
+          placeholder="Bind to User Groups (comma-separated) ..."
+          separator=","
           add={(newGroup) => this.selectedGroups.add(newGroup)}
           items={Array.from(this.selectedGroups)}
           remove={({ oldItem }) => this.selectedGroups.delete(oldItem)}

--- a/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
@@ -226,7 +226,8 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
 
         <b>Users</b>
         <EditableList
-          placeholder="Bind to User Account ..."
+          placeholder="Bind to User Accounts (comma-separated) ..."
+          separator=","
           add={(newUser) => this.selectedUsers.add(newUser)}
           items={Array.from(this.selectedUsers)}
           remove={({ oldItem }) => this.selectedUsers.delete(oldItem)}
@@ -234,7 +235,8 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
 
         <b>Groups</b>
         <EditableList
-          placeholder="Bind to User Group ..."
+          placeholder="Bind to User Groups (comma-separated) ..."
+          separator=","
           add={(newGroup) => this.selectedGroups.add(newGroup)}
           items={Array.from(this.selectedGroups)}
           remove={({ oldItem }) => this.selectedGroups.delete(oldItem)}


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #1113

**Description of changes:**

- EditableList component has a new `separator` property and then splits string.
- To use it correctly the validating regexp must be used as well.
