### PR TITLE
Do not crash when CronJob schedule is misformatted

### DIFF
--- a/packages/core/src/renderer/components/workloads-cronjobs/cronjob-details.tsx
+++ b/packages/core/src/renderer/components/workloads-cronjobs/cronjob-details.tsx
@@ -11,7 +11,6 @@ import { CronJob } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { formatDuration } from "@freelensapp/utilities/dist";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import cronstrue from "cronstrue";
 import kebabCase from "lodash/kebabCase";
 import { disposeOnUnmount, observer } from "mobx-react";
 import React from "react";
@@ -23,6 +22,7 @@ import { DurationAbsoluteTimestamp } from "../events";
 import { LinkToJob } from "../kube-object-link";
 import jobStoreInjectable from "../workloads-jobs/store.injectable";
 import cronJobStoreInjectable from "./store.injectable";
+import { getScheduleFullDescription } from "./utils";
 
 import type { Job } from "@freelensapp/kube-object";
 import type { Logger } from "@freelensapp/logger";
@@ -68,9 +68,7 @@ class NonInjectedCronJobDetails extends React.Component<CronJobDetailsProps & De
 
     return (
       <div className="CronJobDetails">
-        <DrawerItem name="Schedule">
-          {`${cronJob.getSchedule()} (${cronJob.isNeverRun() ? "never" : cronstrue.toString(cronJob.getSchedule())})`}
-        </DrawerItem>
+        <DrawerItem name="Schedule">{getScheduleFullDescription(cronJob)}</DrawerItem>
         <DrawerItem name="Timezone">{cronJob.spec.timeZone}</DrawerItem>
         <DrawerItem name="Starting Deadline Seconds" hidden={!cronJob.spec.startingDeadlineSeconds}>
           {formatDuration(cronJob.spec.startingDeadlineSeconds || 0)}

--- a/packages/core/src/renderer/components/workloads-cronjobs/cronjobs.tsx
+++ b/packages/core/src/renderer/components/workloads-cronjobs/cronjobs.tsx
@@ -7,7 +7,6 @@
 import "./cronjobs.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
-import cronstrue from "cronstrue";
 import { observer } from "mobx-react";
 import moment from "moment-timezone";
 import React from "react";
@@ -20,6 +19,7 @@ import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";
 import { NamespaceSelectBadge } from "../namespaces/namespace-select-badge";
 import { WithTooltip } from "../with-tooltip";
 import cronJobStoreInjectable from "./store.injectable";
+import { getScheduleFullDescription } from "./utils";
 
 import type { EventStore } from "../events/store";
 import type { CronJobStore } from "./store";
@@ -83,9 +83,7 @@ const NonInjectedCronJobs = observer((props: Dependencies) => {
           <WithTooltip>{cronJob.getName()}</WithTooltip>,
           <KubeObjectStatusIcon key="icon" object={cronJob} />,
           <NamespaceSelectBadge key="namespace" namespace={cronJob.getNs()} />,
-          <WithTooltip
-            tooltip={`${cronJob.getSchedule()} (${cronJob.isNeverRun() ? "never" : cronstrue.toString(cronJob.getSchedule())})`}
-          >
+          <WithTooltip tooltip={getScheduleFullDescription(cronJob)}>
             {cronJob.isNeverRun() ? "never" : cronJob.getSchedule()}
           </WithTooltip>,
           <WithTooltip>{cronJob.spec.timeZone}</WithTooltip>,

--- a/packages/core/src/renderer/components/workloads-cronjobs/index.ts
+++ b/packages/core/src/renderer/components/workloads-cronjobs/index.ts
@@ -6,3 +6,4 @@
 
 export * from "./cronjob-details";
 export * from "./cronjobs";
+export * from "./utils";

--- a/packages/core/src/renderer/components/workloads-cronjobs/utils.ts
+++ b/packages/core/src/renderer/components/workloads-cronjobs/utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import cronstrue from "cronstrue";
+
+import type { CronJob } from "@freelensapp/kube-object";
+
+export function humanizeSchedule(schedule: string): string {
+  try {
+    return cronstrue.toString(schedule, { verbose: true });
+  } catch {
+    return "Unrecognized cron expression syntax";
+  }
+}
+
+export function getScheduleFullDescription(cronJob: CronJob): string {
+  const schedule = cronJob.getSchedule().replace(/\s+/g, " ");
+  const humanized = humanizeSchedule(schedule);
+  return `${schedule} (${humanized}${cronJob.isNeverRun() ? ", never ran" : ""})`;
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #969

**Description of changes:**

- Do not crash on unrecognized schedule
- Verbose description
- Mix with info that never ran
