### PR TITLE
Presents Ready/NotReady first on the conditions list

### DIFF
--- a/packages/core/src/renderer/components/kube-object-conditions/components.tsx
+++ b/packages/core/src/renderer/components/kube-object-conditions/components.tsx
@@ -36,8 +36,8 @@ export function getTooltip(condition: Condition, id: string) {
 }
 
 export function getClassName(condition: Condition, ...additionalClasses: string[]) {
-  if (condition.status === "False") {
-    return cssNames("False", ...additionalClasses);
+  if (condition.status === "False" || condition.status === "Unknown") {
+    return cssNames("error", ...additionalClasses);
   }
   return cssNames(condition.type, condition.reason, ...additionalClasses);
 }

--- a/packages/core/src/renderer/components/kube-object-conditions/kube-object-conditions-list.tsx
+++ b/packages/core/src/renderer/components/kube-object-conditions/kube-object-conditions-list.tsx
@@ -36,14 +36,21 @@ export const KubeObjectConditionsList = observer((props: KubeObjectConditionsLis
   return (
     <>
       {sortConditions(conditions, conditionTypePriorities)
-        ?.filter((condition) => condition.status === "True")
+        ?.filter((condition) => condition.status === "True" || condition.type === "Ready")
+        ?.sort((a, b) => {
+          // Always put "Ready" type first
+          if (a.type === "Ready" && b.type !== "Ready") return -1;
+          if (b.type === "Ready" && a.type !== "Ready") return 1;
+          return 0;
+        })
         ?.map((condition) => {
           const { type } = condition;
           const id = `list-${object.getId()}-condition-${type}`;
+          const name = condition.status === "False" || condition.status === "Unknown" ? `Not${type}` : type;
 
           return (
             <div key={type} id={id} className={getClassName(condition, "condition")}>
-              {type}
+              {name}
               <Tooltip targetId={id} formatters={{ tableView: true }}>
                 {getTooltip(condition, id)}
               </Tooltip>

--- a/packages/core/src/renderer/components/nodes/nodes.scss
+++ b/packages/core/src/renderer/components/nodes/nodes.scss
@@ -65,6 +65,10 @@
       }
     }
 
+    &.schedulable {
+      flex: 0.6;
+    }
+
     &.taints {
       flex: 0.6;
     }

--- a/packages/core/src/renderer/components/nodes/nodes.scss
+++ b/packages/core/src/renderer/components/nodes/nodes.scss
@@ -81,6 +81,10 @@
       flex-grow: 1.3;
     }
 
+    &.age {
+      flex-grow: 0.4;
+    }
+
     &.conditions {
       flex: 1.7;
 

--- a/packages/core/src/renderer/components/nodes/route.tsx
+++ b/packages/core/src/renderer/components/nodes/route.tsx
@@ -14,6 +14,7 @@ import { makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
 import requestAllNodeMetricsInjectable from "../../../common/k8s-api/endpoints/metrics.api/request-metrics-for-all-nodes.injectable";
+import { BadgeBoolean } from "../badge";
 import eventStoreInjectable from "../events/store.injectable";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectConditionsList } from "../kube-object-conditions";
@@ -38,12 +39,13 @@ enum columnId {
   cpu = "cpu",
   memory = "memory",
   disk = "disk",
-  conditions = "condition",
   taints = "taints",
   roles = "roles",
-  age = "age",
   version = "version",
   internalIp = "internalIp",
+  age = "age",
+  schedulable = "schedulable",
+  conditions = "condition",
   status = "status",
 }
 
@@ -204,12 +206,13 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
             [columnId.cpu]: (node) => this.getLastMetricValues(node, ["cpuUsage"]),
             [columnId.memory]: (node) => this.getLastMetricValues(node, ["memoryUsage"]),
             [columnId.disk]: (node) => this.getLastMetricValues(node, ["fsUsage"]),
-            [columnId.conditions]: (node) => node.getNodeConditionText(),
             [columnId.taints]: (node) => node.getTaints().length,
             [columnId.roles]: (node) => node.getRoleLabels(),
             [columnId.version]: (node) => node.getKubeletVersion(),
             [columnId.internalIp]: (node) => node.getInternalIP(),
             [columnId.age]: (node) => -node.getCreationTimestamp(),
+            [columnId.schedulable]: (node) => (node.isUnschedulable() ? "False" : "True"),
+            [columnId.conditions]: (node) => node.getNodeConditionText(),
           }}
           searchFilters={[
             (node) => node.getSearchFields(),
@@ -226,11 +229,12 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
             { title: "CPU", className: "cpu", sortBy: columnId.cpu, id: columnId.cpu },
             { title: "Memory", className: "memory", sortBy: columnId.memory, id: columnId.memory },
             { title: "Disk", className: "disk", sortBy: columnId.disk, id: columnId.disk },
-            { title: "Taints", className: "taints", sortBy: columnId.taints, id: columnId.taints },
             { title: "Roles", className: "roles", sortBy: columnId.roles, id: columnId.roles },
+            { title: "Taints", className: "taints", sortBy: columnId.taints, id: columnId.taints },
             { title: "Version", className: "version", sortBy: columnId.version, id: columnId.version },
             { title: "Internal IP", className: "internalIp", sortBy: columnId.internalIp, id: columnId.internalIp },
             { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
+            { title: "Schedulable", className: "schedulable", sortBy: columnId.schedulable, id: columnId.schedulable },
             {
               title: "Conditions",
               className: "conditions scrollable",
@@ -258,6 +262,7 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
               <WithTooltip>{node.getKubeletVersion()}</WithTooltip>,
               <WithTooltip>{node.getInternalIP()}</WithTooltip>,
               <KubeObjectAge key="age" object={node} />,
+              <BadgeBoolean value={!node.isUnschedulable()} />,
               <KubeObjectConditionsList key="conditions" object={node} />,
             ];
           }}

--- a/packages/core/src/renderer/components/nodes/route.tsx
+++ b/packages/core/src/renderer/components/nodes/route.tsx
@@ -252,13 +252,13 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
               this.renderCpuUsage(node),
               this.renderMemoryUsage(node),
               this.renderDiskUsage(node),
+              <WithTooltip>{node.getRoleLabels()}</WithTooltip>,
               <>
                 <span id={tooltipId}>{taints.length}</span>
                 <Tooltip targetId={tooltipId} tooltipOnParentHover={true} style={{ whiteSpace: "pre-line" }}>
                   {taints.map(formatNodeTaint).join("\n")}
                 </Tooltip>
               </>,
-              <WithTooltip>{node.getRoleLabels()}</WithTooltip>,
               <WithTooltip>{node.getKubeletVersion()}</WithTooltip>,
               <WithTooltip>{node.getInternalIP()}</WithTooltip>,
               <KubeObjectAge key="age" object={node} />,


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #1196

**Description of changes:**

- Presents Ready or NotReady as the first condition on the list
- Separte column for Schedulable/Unschedulable status

Either NotReady or ScheduledDisabled are not real conditions. NotReady is just "Ready" if state is unknown or error. To not list all failed conditions only "Ready" is presented for negation.

ScheduledDisabled is added if `spec.unschedulable === true`. Because I prefer condition list for real conditions (NotReady is actually real condition even if negated) then schedulable will be yet another column.

<img width="1171" height="136" alt="image" src="https://github.com/user-attachments/assets/69d3812d-254e-4bf6-adf7-d5aa8576aa35" />
