### PR TITLE
Downgrade dependency minimatch to ^3.1.2

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,6 @@ overrides:
   form-data: ^4.0.4
   http-proxy-middleware: ^3.0.0
   http-proxy: npm:http-proxy-node16@^1.0.0
-  minimatch@3.1.2: ^5.0.0
   tmp@^0.2.0: ^0.2.5
 
 packages:


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #1228

**Description of changes:**

- Removed forced upgrade of minimatch as it broke compiling additional binary packages for Windows
