### PR TITLE
Fix integration test for deleting the pod

### DIFF
--- a/freelens/integration/__tests__/cluster-pages.tests.ts
+++ b/freelens/integration/__tests__/cluster-pages.tests.ts
@@ -153,12 +153,13 @@ describeIf(kindReady(TEST_KIND_CLUSTER_NAME, TEST_NAMESPACE))("KinD based tests"
 
       await frame.click(".Dock .Button >> text='Create'");
       await frame.waitForSelector(`.TableCell >> text=${testPodName}`);
+
       await frame.click(".TableRow .TableCell.menu");
       await frame.click(".MenuItem >> text=Delete");
-      await frame.click("button >> text=Remove");
+      await frame.click("button >> text=Delete");
       await frame.waitForSelector(`.TableCell >> text=${testPodName}`, { state: "detached" });
     },
-    10 * 60 * 1000,
+    45 * 60 * 1000,
   );
 });
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes regression after implementation of the new delete buttons.

**Description of changes:**

- Button is renamed.
- Raises timeout to 45 (time for downloading image + timeout for deleting pod)
