### PR TITLE
Exclude node-pty from post install scripts

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -84,10 +84,6 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
-      - name: Disable pre post scripts for pnpm
-        shell: bash
-        run: pnpm config set enablePrePostScripts false
-
       - name: Get Electron version
         shell: bash
         run: echo "electron_version=$(yq -r .importers.freelens.devDependencies.electron.version pnpm-lock.yaml | sed 's/(.*)//')"
@@ -174,6 +170,9 @@ jobs:
         if: runner.os == 'macOS' && matrix.arch == 'arm64' || runner.os == 'Linux' && matrix.arch == 'x64' || runner.os ==
           'Windows'
         run: pnpm --color=always --stream build
+
+      - name: Rebuild native packages for Electron
+        run: pnpm --color=always electron-rebuild -a ${{ matrix.arch }}
 
       - name: Build extra resources
         id: build-resources

--- a/.github/workflows/knip.yaml
+++ b/.github/workflows/knip.yaml
@@ -51,10 +51,6 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
-      - name: Disable pre post scripts for pnpm
-        shell: bash
-        run: pnpm config set enablePrePostScripts false
-
       - name: Install pnpm dependencies
         id: install-pnpm
         run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,10 +123,6 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
-      - name: Disable pre post scripts for pnpm
-        shell: bash
-        run: pnpm config set enablePrePostScripts false
-
       - name: Get Electron version
         shell: bash
         run: echo "electron_version=$(yq -r .importers.freelens.devDependencies.electron.version pnpm-lock.yaml | sed 's/(.*)//')"
@@ -181,8 +177,6 @@ jobs:
           echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
 
       - name: Rebuild native packages for Electron
-        if: runner.os == 'macOS' && matrix.arch == 'x64' || runner.os == 'Linux' && matrix.arch == 'arm64' || runner.os ==
-          'Windows' && matrix.arch == 'arm64'
         run: pnpm --color=always electron-rebuild -a ${{ matrix.arch }}
         env:
           npm_config_arch: ${{ matrix.arch }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -51,10 +51,6 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.arch }}-node-
 
-      - name: Disable pre post scripts for pnpm
-        shell: bash
-        run: pnpm config set enablePrePostScripts false
-
       - name: Install pnpm dependencies
         id: install-pnpm
         run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,6 @@ onlyBuiltDependencies:
   - electron
   - electron-winstaller
   - esbuild
-  - node-pty
   - playwright
   - sharp
 


### PR DESCRIPTION
**Description of changes:**

- node-pty is excluded so not built during install
- electron-rebuild should be called to rebuild it

