### PR TITLE
Add Clusters Search to Command Palette

### DIFF
--- a/packages/core/src/main/cluster/cluster-connection.injectable.ts
+++ b/packages/core/src/main/cluster/cluster-connection.injectable.ts
@@ -14,7 +14,7 @@ import createCanIInjectable from "../../common/cluster/create-can-i.injectable";
 import createCoreApiInjectable from "../../common/cluster/create-core-api.injectable";
 import createRequestNamespaceListPermissionsInjectable from "../../common/cluster/create-request-namespace-list-permissions.injectable";
 import createListNamespacesInjectable from "../../common/cluster/list-namespaces.injectable";
-import { ClusterStatus } from "../../common/cluster-types";
+import { ClusterMetadataKey, ClusterStatus } from "../../common/cluster-types";
 import broadcastMessageInjectable from "../../common/ipc/broadcast-message.injectable";
 import { clusterListNamespaceForbiddenChannel } from "../../common/ipc/cluster";
 import { formatKubeApiResource } from "../../common/rbac";
@@ -309,6 +309,7 @@ class ClusterConnection {
 
       runInAction(() => {
         this.cluster.metadata.version = versionData.value;
+        this.cluster.metadata[ClusterMetadataKey.LAST_SEEN] = new Date().toJSON();
       });
 
       return ClusterStatus.AccessGranted;

--- a/packages/core/src/renderer/components/clusters/index.ts
+++ b/packages/core/src/renderer/components/clusters/index.ts
@@ -4,4 +4,4 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-export * from "./activate-entity-command";
+export * from "./search-command";

--- a/packages/core/src/renderer/components/command-palette/registered-commands/internal-commands.injectable.tsx
+++ b/packages/core/src/renderer/components/command-palette/registered-commands/internal-commands.injectable.tsx
@@ -6,6 +6,7 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import React from "react";
+import navigateToCatalogInjectable from "../../../../common/front-end-routing/routes/catalog/navigate-to-catalog.injectable";
 import navigateToConfigMapsInjectable from "../../../../common/front-end-routing/routes/cluster/config/config-maps/navigate-to-config-maps.injectable";
 import navigateToHorizontalPodAutoscalersInjectable from "../../../../common/front-end-routing/routes/cluster/config/horizontal-pod-autoscalers/navigate-to-horizontal-pod-autoscalers.injectable";
 import navigateToLimitRangesInjectable from "../../../../common/front-end-routing/routes/cluster/config/limit-ranges/navigate-to-limit-ranges.injectable";
@@ -31,6 +32,7 @@ import navigateToStatefulsetsInjectable from "../../../../common/front-end-routi
 import navigateToEntitySettingsInjectable from "../../../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
 // TODO: Importing from features is not OK. Make commands to comply with Open Closed Principle to allow moving implementation under a feature
 import navigateToPreferencesInjectable from "../../../../features/preferences/common/navigate-to-preferences.injectable";
+import { ClustersSearchCommand } from "../../clusters";
 import createTerminalTabInjectable from "../../dock/terminal/create-terminal-tab.injectable";
 import hasCatalogEntitySettingItemsInjectable from "../../entity-settings/has-settings.injectable";
 import { HotbarAddCommand } from "../../hotbar/hotbar-add-command";
@@ -42,7 +44,6 @@ import commandOverlayInjectable from "../command-overlay.injectable";
 import type { DockTabCreate } from "../../dock/dock/store";
 import type { HasCatalogEntitySettingItems } from "../../entity-settings/has-settings.injectable";
 import type { CommandContext, CommandRegistration } from "./commands";
-import navigateToCatalogInjectable from "../../../../common/front-end-routing/routes/catalog/navigate-to-catalog.injectable";
 
 export function isKubernetesClusterActive(context: CommandContext): boolean {
   return context.entity?.kind === "KubernetesCluster";
@@ -90,6 +91,11 @@ function getInternalCommands(dependencies: Dependencies): CommandRegistration[] 
       id: "app.showPreferences",
       title: "Preferences: Open",
       action: () => dependencies.navigateToPreferences(),
+    },
+    {
+      id: "clusters.search",
+      title: "Clusters: Search ...",
+      action: () => dependencies.openCommandDialog(<ClustersSearchCommand />),
     },
     {
       id: "cluster.viewHelmCharts",


### PR DESCRIPTION
Fixes #925

Description of changes:
- Replace _Catalog: Activate Entity_ for _Catalog: Open_ in the command palette
- Add _Clusters: Search_ to command palette for quick cluster switching 
- Sort clusters by `lastSeen` timestamp (most recently used first)
- Update `lastSeen` cluster.metadata every 30 seconds during connection status refresh

The cluster search command allows quickly switching between clusters from the command palette. Clusters are sorted by when they were last connected, making it easy to jump back to recently used clusters. To make sorting work properly, `lastSeen` now updates during the regular connection status check (every 30s), reusing the existing `/version` API call so hopefully there's no performance overhead. Previously it only updated every 15 minutes, causing inconsistencies.

Screenshots:
<img width="1175" height="445" alt="Command-palette-new" src="https://github.com/user-attachments/assets/5892c1c3-b208-4c73-95a6-acf38b2a8fa3" />
<img width="721" height="185" alt="Command-palette-new2" src="https://github.com/user-attachments/assets/d28dac41-faa6-48fe-a1df-327666fdf465" />