### PR TITLE
Less confusing indicator for restarted containers

### DIFF
--- a/packages/core/src/renderer/components/status-brick/status-brick.scss
+++ b/packages/core/src/renderer/components/status-brick/status-brick.scss
@@ -32,7 +32,8 @@
 
   &.restarted {
     background-color: var(--colorOk);
-    border: 1px solid var(--colorWarning);
+    outline: 1px solid var(--colorWarning);
+    outline-offset: 3px;
   }
 
   &.terminated {


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #1237

**Description of changes:**

- Restarted containers have 3px outline

<img width="1171" height="183" alt="image" src="https://github.com/user-attachments/assets/fbc79d19-e6bc-48c2-9316-6a9b0f93810e" />

<img width="1151" height="58" alt="image" src="https://github.com/user-attachments/assets/aa691d80-b6df-4dd2-9588-8a1e21ecaeb4" />
