### PR TITLE
Remove annotation from search fields

### DIFF
--- a/packages/kube-object/src/kube-object.ts
+++ b/packages/kube-object/src/kube-object.ts
@@ -216,7 +216,7 @@ export class KubeObject<
   }
 
   getSearchFields() {
-    return [this.getName(), this.getNs(), this.getId(), ...this.getLabels(), ...this.getAnnotations(true)];
+    return [this.getName(), this.getNs(), this.getId(), ...this.getLabels()];
   }
 
   toPlainObject(omitFields: string[] = ["metadata.managedFields"]) {


### PR DESCRIPTION
**Description of changes:**

-Removed annotations from the search fields.

Annotations are not so useful: usually they are managed automatically by operators and contain generic strings like `karpenter`, `kubectl`, `eks` or `amazon`.

