### PR TITLE
Workflows: reverting changes for cache cleanup: it can work only for own repo PRs

### DIFF
--- a/.github/workflows/cleanup-cache.yaml
+++ b/.github/workflows/cleanup-cache.yaml
@@ -15,13 +15,12 @@ jobs:
     name: cleanup cache
 
     runs-on: ubuntu-24.04
-    environment: workflows
 
     steps:
       - name: Cleanup cache
         run: gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id' | xargs -n1 -r -t gh cache delete
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge


### PR DESCRIPTION
GITHUB_TOKEN for PRs from foreigh repo cannot be used securely and own repo PRs has token that is allowed to delete caches, so I'm reverting the changes.