### PR TITLE
Allow to notarize application when built with Turborepo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,24 +1,33 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalPassThroughEnv": [
+    "APPLEID",
+    "APPLEIDPASS",
+    "APPLETEAMID",
+    "CSC_LINK",
+    "CSC_KEY_PASSWORD",
+    "CSC_INSTALLER_LINK",
+    "CSC_INSTALLER_KEY_PASSWORD"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "env": ["CC", "CXX", "NODE_ENV"],
+      "env": ["CC", "CXX", "DOWNLOAD_ALL_ARCHITECTURES", "NODE_ENV"],
       "outputs": ["binaries/**", "dist/**", "static/build/**"]
     },
     "build:app": {
       "dependsOn": ["^build:app"],
-      "env": ["APPLEIDPASS", "CC", "CXX", "NODE_ENV"],
+      "env": ["CC", "CXX", "NODE_ENV"],
       "outputs": ["dist/**"]
     },
     "build:dev": {
       "dependsOn": ["^build:dev"],
-      "env": ["CC", "CXX", "NODE_ENV"],
+      "env": ["CC", "CXX", "DOWNLOAD_ALL_ARCHITECTURES", "NODE_ENV"],
       "outputs": ["binaries/**", "dist/**", "static/build/**"]
     },
     "build:resources": {
       "dependsOn": ["^build:resources"],
-      "env": ["CC", "CXX", "NODE_ENV"],
+      "env": ["CC", "CXX", "DOWNLOAD_ALL_ARCHITECTURES", "NODE_ENV"],
       "outputs": ["binaries/**", "static/build/**"]
     },
     "dev": {


### PR DESCRIPTION
Turbo has strict mode by default and we need to pass some variables for Mac notarization