### PR TITLE
Exit application on close if no tray icon is shown

### DIFF
--- a/packages/core/src/main/electron-app/runnables/setup-behaviour-on-close-of-last-window.injectable.ts
+++ b/packages/core/src/main/electron-app/runnables/setup-behaviour-on-close-of-last-window.injectable.ts
@@ -8,6 +8,7 @@ import { beforeElectronIsReadyInjectionToken } from "@freelensapp/application-fo
 import { runManySyncFor } from "@freelensapp/run-many";
 import { getInjectable } from "@ogre-tools/injectable";
 import isIntegrationTestingInjectable from "../../../common/vars/is-integration-testing.injectable";
+import userPreferencesStateInjectable from "../../../features/user-preferences/common/state.injectable";
 import { afterQuitOfFrontEndInjectionToken } from "../../start-main-application/runnable-tokens/phases";
 import electronAppInjectable from "../electron-app.injectable";
 import isAutoUpdatingInjectable from "../features/is-auto-updating.injectable";
@@ -25,7 +26,10 @@ const setupBehaviourOnCloseOfLastWindowInjectable = getInjectable({
       app.on("window-all-closed", () => {
         runAfterQuitOfFrontEnd();
 
-        if (isIntegrationTesting || isAutoUpdating.get()) {
+        const userPreferencesState = di.inject(userPreferencesStateInjectable);
+        const showTray = userPreferencesState.showTrayIcon;
+
+        if (isIntegrationTesting || isAutoUpdating.get() || !showTray) {
           app.quit();
         }
       });


### PR DESCRIPTION
Follows-up #1369 

**Description of changes:**

- Ensure the application exits when all windows are closed if the user preferences indicate that the tray icon is not displayed.

