### PR TITLE
CI: Set environment variables for correct job in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,12 +19,6 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 360
 
-    env:
-      DO_NOT_TRACK: "1"
-      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
-      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
-      ELECTRON_HEADERS_CACHE: ${{ github.workspace }}/.cache/electron-headers
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -77,8 +71,10 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref_name }}-${{ matrix.concurrency }}
 
     env:
+      DO_NOT_TRACK: "1"
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
+      ELECTRON_HEADERS_CACHE: ${{ github.workspace }}/.cache/electron-headers
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Workflow environment variable configuration:

* Moved the `DO_NOT_TRACK`, `ELECTRON_CACHE`, `ELECTRON_BUILDER_CACHE`, and `ELECTRON_HEADERS_CACHE` environment variables from the top-level job configuration to the matrix job's environment block, ensuring correct variable scoping for matrix jobs. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL22-L27) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR74-R77)