### PR TITLE
Open external URLs in the browser only

### DIFF
--- a/packages/core/src/main/start-main-application/lens-window/application-window/create-electron-window.injectable.ts
+++ b/packages/core/src/main/start-main-application/lens-window/application-window/create-electron-window.injectable.ts
@@ -137,11 +137,13 @@ const createElectronWindowInjectable = getInjectable({
           logger.info(`[CREATE-ELECTRON-WINDOW]: Window "${configuration.id}" loaded`);
         })
         .setWindowOpenHandler((details) => {
-          openLinkInBrowser(details.url).catch((error) => {
-            logger.error("[CREATE-ELECTRON-WINDOW]: failed to open browser", {
-              error,
+          if (!details.url.includes(".renderer.freelens.app:")) {
+            openLinkInBrowser(details.url).catch((error) => {
+              logger.error("[CREATE-ELECTRON-WINDOW]: failed to open browser", {
+                error,
+              });
             });
-          });
+          }
 
           return { action: "deny" };
         });


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #1395

**Description of changes:**

- Restrict opening links in the browser to only external URLs, preventing internal renderer URLs from being opened.

