### PR TITLE
Details for Kubernetes resources show managed fields

### DIFF
--- a/packages/core/src/renderer/components/drawer/drawer-param-toggler.tsx
+++ b/packages/core/src/renderer/components/drawer/drawer-param-toggler.tsx
@@ -13,7 +13,7 @@ import React from "react";
 import type { StrictReactNode } from "@freelensapp/utilities";
 
 export interface DrawerParamTogglerProps {
-  label: string | number;
+  label: string | number | StrictReactNode;
   children: StrictReactNode;
 }
 

--- a/packages/core/src/renderer/components/kube-object-meta/kube-object-meta.tsx
+++ b/packages/core/src/renderer/components/kube-object-meta/kube-object-meta.tsx
@@ -21,6 +21,7 @@ import { LinkToNamespace } from "../kube-object-link";
 import { KubeObjectStatusIcon } from "../kube-object-status-icon";
 import { LocaleDate } from "../locale-date";
 import { MonacoEditor } from "../monaco-editor";
+import { WithTooltip } from "../with-tooltip";
 
 import type { KubeMetaField } from "@freelensapp/kube-object";
 import type { Logger } from "@freelensapp/logger";
@@ -49,6 +50,16 @@ interface Dependencies {
   logger: Logger;
 }
 
+function ManagedFieldEntryLabel({ entry }: { entry: ManagedFieldsEntry }) {
+  return (
+    <WithTooltip tooltip={entry.time && <DurationAbsoluteTimestamp timestamp={entry.time} />}>
+      {entry.manager}
+      {": "}
+      {entry.operation}
+    </WithTooltip>
+  );
+}
+
 const NonInjectedKubeObjectMeta = observer((props: Dependencies & KubeObjectMetaProps) => {
   const { apiManager, getDetailsUrl, object, hideFields = ["uid", "resourceVersion", "selfLink"], logger } = props;
 
@@ -70,8 +81,10 @@ const NonInjectedKubeObjectMeta = observer((props: Dependencies & KubeObjectMeta
       entry !== null &&
       "manager" in entry &&
       typeof entry.manager === "string" &&
+      entry.manager.length > 0 &&
       "operation" in entry &&
-      typeof entry.operation === "string"
+      typeof entry.operation === "string" &&
+      entry.operation.length > 0
     );
   };
 
@@ -131,7 +144,7 @@ const NonInjectedKubeObjectMeta = observer((props: Dependencies & KubeObjectMeta
         <DrawerItem name="Managed Fields" hidden={isHidden("managedFields")}>
           {managedFields.filter(isManagedFieldsEntry).map((entry) => (
             <DrawerParamToggler
-              label={`${entry.manager}: ${entry.operation}`}
+              label={<ManagedFieldEntryLabel entry={entry} />}
               key={`${entry.manager}-${entry.operation}`}
             >
               <MonacoEditor


### PR DESCRIPTION
**Managed Fields Display:**

* Added a new section to the `KubeObjectMeta` drawer that lists managed fields if present, with each entry shown under a toggle labeled by manager and operation.
* Integrated the `MonacoEditor` to render the managed fields' details (`fieldsV1`) as YAML, improving readability for users.

<img width="714" height="397" alt="image" src="https://github.com/user-attachments/assets/33abb896-d504-4fca-bb86-b8ba7551c487" />
