### PR TITLE
Set User-Agent to own instead of generic node-fetch

### DIFF
--- a/packages/core/src/common/k8s-api/create-kube-json-api.injectable.ts
+++ b/packages/core/src/common/k8s-api/create-kube-json-api.injectable.ts
@@ -8,7 +8,7 @@ import { KubeJsonApi } from "@freelensapp/kube-api";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import { Agent } from "https";
-import { buildVersionInitializable } from "../../features/vars/build-version/common/token";
+import packageJson from "../../../package.json";
 import lensProxyCertificateInjectable from "../certificate/lens-proxy-certificate.injectable";
 import nodeFetchInjectable, { type NodeFetchRequestInit } from "../fetch/node-fetch.injectable";
 
@@ -24,7 +24,6 @@ const createKubeJsonApiInjectable = getInjectable({
       logger: di.inject(loggerInjectionToken),
     };
     const lensProxyCert = di.inject(lensProxyCertificateInjectable);
-    const buildVersion = di.inject(buildVersionInitializable.stateToken);
 
     return (config, reqInit) => {
       if (!config.getRequestOptions) {
@@ -33,10 +32,14 @@ const createKubeJsonApiInjectable = getInjectable({
             ca: lensProxyCert.get().cert,
           });
 
+          console.log({
+            "User-Agent": `Freelens/${packageJson.version}`,
+          });
+
           return {
             agent,
             headers: {
-              "User-Agent": `Freelens/${buildVersion}`,
+              "User-Agent": `Freelens/${packageJson.version}`,
             },
           };
         };


### PR DESCRIPTION
Enhancement to HTTP request metadata:

* Injected the `buildVersionInitializable.stateToken` to access the current build version for use in API requests.
* Added a `User-Agent` header to all outgoing requests from `createKubeJsonApiInjectable`, setting its value to `Freelens/{buildVersion}` for improved traceability.

In consequence, Freelens will be marked as an owner of the managed fields instead of "node-fetch".