### PR TITLE
Combine podIP and podIPs field and add a new hostIPs field

### DIFF
--- a/packages/core/src/renderer/components/workloads-pods/pod-details.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details.tsx
@@ -55,6 +55,8 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
     const podIPs = pod.getIPs();
     const { nodeName } = spec ?? {};
     const nodeSelector = pod.getNodeSelectors();
+    const { hostIP } = status ?? {};
+    const hostIPs = pod.getHostIPs();
 
     const namespace = pod.getNs();
     const priorityClassName = pod.getPriorityClassName();
@@ -69,9 +71,13 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
         <DrawerItem name="Node" hidden={!nodeName}>
           <LinkToNode name={nodeName} />
         </DrawerItem>
-        <DrawerItem name="Pod IP">{podIP}</DrawerItem>
-        <DrawerItem name="Pod IPs" hidden={podIPs.length === 0} labelsOnly>
-          {podIPs.map((label) => (
+        <DrawerItem name="Host IPs" hidden={!hostIPs.length && !hostIP} labelsOnly>
+          {(hostIPs.length ? hostIPs : hostIP ? [hostIP] : []).map((label) => (
+            <Badge key={label} label={label} />
+          ))}
+        </DrawerItem>
+        <DrawerItem name="Pod IPs" hidden={!podIPs.length && !podIP} labelsOnly>
+          {(podIPs.length ? podIPs : podIP ? [podIP] : []).map((label) => (
             <Badge key={label} label={label} />
           ))}
         </DrawerItem>

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -922,4 +922,10 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
 
     return podIPs.map((value) => value.ip);
   }
+
+  getHostIPs(): string[] {
+    const hostIPs = this.status?.hostIPs ?? [];
+
+    return hostIPs.map((value) => value.ip);
+  }
 }


### PR DESCRIPTION
**Pod details UI improvements:**

* The Pod details UI now displays Host IPs separately from Pod IPs, supporting multiple IPs for each type. This helps users distinguish between the IPs assigned to the pod itself and those assigned to the host node.
* The rendering logic for Pod IPs and Host IPs in `pod-details.tsx` was updated to conditionally display badges for each IP, handling cases where there may be multiple or single IPs.

**Pod model enhancements:**

* Added a new `getHostIPs()` method to the `Pod` class, which retrieves all host IPs from the pod status, supporting scenarios where multiple host IPs are present.
* Updated the pod details component to use both the new `getHostIPs()` method and the existing host IP field, ensuring comprehensive display of host IP information.