### PR TITLE
Add a portable Windows distribution target to support installation‑free use in corporate environments

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -319,7 +319,7 @@ jobs:
           trusted-signing-account-name: ${{ vars.AZURE_CODE_SIGNING_NAME }}
           certificate-profile-name: ${{ vars.AZURE_CERT_PROFILE_NAME }}
           files-folder: ${{ github.workspace }}\freelens\dist
-          files-folder-filter: exe,msi
+          files-folder-filter: exe,msi,portable
 
       - name: Tweak binaries
         shell: bash
@@ -346,6 +346,7 @@ jobs:
             s/-(amd64|arm64).(dmg|pkg)$/-macos-$1.$2/;
             s/-(amd64|arm64).(AppImage|deb|flatpak|rpm|snap)$/-linux-$1.$2/;
             s/-(amd64|arm64).(exe|msi|)$/-windows-$1.$2/;
+            s/-Portable-windows-(amd64|arm64)\.exe/-windows-$1-portable.exe/;
             my $dst = $_;
             if ($src ne $dst) {
               print "rename $src to $dst\n";

--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ by default.
 The version of the MSI package has the last 4th digit always `0` and this is a
 limitation of this package format.
 
+
+#### Portable
+
+Download the Portable EXE from the [releases](https://github.com/freelensapp/freelens/releases) page.
+It is a self-contained executable that can be run without installation.
+
 #### WinGet
 
 The package is available in

--- a/freelens/electron-builder.yml
+++ b/freelens/electron-builder.yml
@@ -138,6 +138,7 @@ win:
   appId: app.freelens.Freelens
   target:
     - nsis
+    - portable
   extraResources:
     - from: binaries/client/windows/${arch}/kubectl.exe
       to: ./${arch}/kubectl.exe


### PR DESCRIPTION
This pull request adds support for distributing Freelens as a portable Windows executable, making it easier for users to run the app without installation. The changes update the build configuration, release workflow, and documentation to include and properly handle the portable EXE.

**Rationale:**
Many employees in large organisations operate under strict IT and security policies that prohibit installing software without elevated privileges. Adding a portable, signed executable removes this barrier, allowing users to run Freelens directly from their home directory or a network share while still adhering to corporate security requirements. This change does not remove the existing NSIS/MSI installers; it simply provides an additional distribution type that expands the project’s usability.

**Build and Release Pipeline Updates:**

* Added `portable` as a build target in the Windows section of `electron-builder.yml` to generate a portable EXE during builds.
* Updated the release workflow (`release.yaml`) to include `portable` files in the signing step by modifying the `files-folder-filter` and to ensure correct renaming of portable EXE files for consistency. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL322-R322) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR349)

**Documentation:**

* Added a new section to the `README.md` describing the portable EXE, how to download it, and its benefits (no installation required).