### PR TITLE
Show Pod-level resource requests and limits

### DIFF
--- a/packages/core/src/renderer/components/workloads-pods/pod-details.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details.tsx
@@ -58,6 +58,9 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
     const { hostIP } = status ?? {};
     const hostIPs = pod.getHostIPs();
 
+    const requests = Object.entries(spec.resources?.requests ?? {});
+    const limits = Object.entries(spec.resources?.limits ?? {});
+
     const namespace = pod.getNs();
     const priorityClassName = pod.getPriorityClassName();
     const runtimeClassName = pod.getRuntimeClassName();
@@ -103,6 +106,22 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
 
         <PodDetailsTolerations workload={pod} />
         <PodDetailsAffinities workload={pod} />
+
+        {requests.length > 0 && (
+          <DrawerItem name="Requests" labelsOnly>
+            {requests.map(([key, value], index) => (
+              <Badge key={index} label={`${key}=${value}`} />
+            ))}
+          </DrawerItem>
+        )}
+
+        {limits.length > 0 && (
+          <DrawerItem name="Limits" labelsOnly>
+            {limits.map(([key, value], index) => (
+              <Badge key={index} label={`${key}=${value}`} />
+            ))}
+          </DrawerItem>
+        )}
 
         <DrawerItem name="Secrets" hidden={pod.getSecrets().length === 0}>
           <PodDetailsSecrets pod={pod} />

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -25,6 +25,7 @@ import type {
   PodSecurityContext,
   Probe,
   ResourceFieldSelector,
+  ResourceRequirements,
 } from "../types";
 import type { PersistentVolumeClaimSpec } from "./persistent-volume-claim";
 import type { SecretReference } from "./secret";
@@ -587,6 +588,7 @@ export interface PodSpec {
   tolerations?: Toleration[];
   topologySpreadConstraints?: TopologySpreadConstraint[];
   volumes?: PodSpecVolume[];
+  resources?: ResourceRequirements;
 }
 
 export type PodConditionType =


### PR DESCRIPTION
Fixes #1251 

**Pod details UI enhancements:**

* Displays resource requests in the Pod details drawer if defined in `spec.resources.requests`, showing each request as a badge. [[1]](diffhunk://#diff-1bad18d348b761a5aac6cf0f0aeeb65b5a510cb4f05d37f0d038fa1a823dec47R61-R63) [[2]](diffhunk://#diff-1bad18d348b761a5aac6cf0f0aeeb65b5a510cb4f05d37f0d038fa1a823dec47R110-R125)
* Displays resource limits in the Pod details drawer if defined in `spec.resources.limits`, showing each limit as a badge. [[1]](diffhunk://#diff-1bad18d348b761a5aac6cf0f0aeeb65b5a510cb4f05d37f0d038fa1a823dec47R61-R63) [[2]](diffhunk://#diff-1bad18d348b761a5aac6cf0f0aeeb65b5a510cb4f05d37f0d038fa1a823dec47R110-R125)

**Pod spec type updates:**

* Adds `ResourceRequirements` to the Pod spec TypeScript interface, allowing Pods to specify resource requests and limits. [[1]](diffhunk://#diff-b7f422f16cb2ea26b28d7a5bf16928f2416e72807e3142981c99b148230ccaf9R28) [[2]](diffhunk://#diff-b7f422f16cb2ea26b28d7a5bf16928f2416e72807e3142981c99b148230ccaf9R591)