### PR TITLE
Shai-Hulud 2.0 Security Check

### DIFF
--- a/.github/workflows/di-registration.yaml
+++ b/.github/workflows/di-registration.yaml
@@ -28,7 +28,6 @@ jobs:
 
     env:
       DO_NOT_TRACK: "1"
-      TURBOREPO_CACHE: ${{ github.workspace }}/.turbo
 
     steps:
       - name: Checkout
@@ -54,14 +53,6 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.arch }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.arch }}-node-
-
-      - name: Use Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.TURBOREPO_CACHE }}
-          key: ${{ matrix.os }}-${{ matrix.arch }}-turborepo-${{ hashFiles('**/package.json', '**/pnpm-lock.yaml', 'turbo.json') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.arch }}-turborepo-
 
       - name: Install pnpm dependencies
         id: install-pnpm

--- a/.github/workflows/knip.yaml
+++ b/.github/workflows/knip.yaml
@@ -24,7 +24,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 15
 
     env:
       DO_NOT_TRACK: "1"

--- a/.github/workflows/shai-hulud.yaml
+++ b/.github/workflows/shai-hulud.yaml
@@ -1,0 +1,63 @@
+name: Shai-Hulud 2.0 Security Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - '**/package.json'
+      - '**/pnpm-lock.yaml'
+  schedule:
+    - cron: 25 3 * * *
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  knip:
+    name: Shai-Hulud check
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            arch: x64
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    env:
+      DO_NOT_TRACK: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
+
+      - name: Setup pnpm
+        run: corepack enable
+
+      - name: Run Shai-Hulud 2.0 Detector
+        uses: gensecaihq/Shai-Hulud-2.0-Detector@v2
+        with:
+          fail-on-high: true
+          scan-lockfiles: true
+          output-format: sarif
+
+      - name: Upload SARIF to GitHub Security
+        if: always() && hashFiles('shai-hulud-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: shai-hulud-results.sarif
+        continue-on-error: true


### PR DESCRIPTION
**Security and automation improvements:**

* Added a new `.github/workflows/shai-hulud.yaml` workflow to run the Shai-Hulud 2.0 Detector on `package.json` and `pnpm-lock.yaml` files, uploading results as SARIF to GitHub Security. This workflow runs on pushes to `main`, pull requests, and a daily schedule.
