### PR TITLE
List automated updates separately in GitHub release description

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,13 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - automated
+          - renovate
+    - title: Dependencies
+      labels:
+        - automated
+        - renovate


### PR DESCRIPTION
This configuration will place renovatebot and automated PRs into a separate sections on the bottom, and all other merged PRs on top.

See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes