### PR TITLE
Fix ContainerResource HPA metric to display utilization percentage

### DIFF
--- a/packages/core/src/renderer/components/config-horizontal-pod-autoscalers/metric-parser-v2.ts
+++ b/packages/core/src/renderer/components/config-horizontal-pod-autoscalers/metric-parser-v2.ts
@@ -89,11 +89,13 @@ export class HorizontalPodAutoscalerV2MetricParser {
   }): MetricCurrentTarget {
     return {
       current:
-        current?.current?.averageValue ??
-        (current?.current?.averageUtilization ? `${current.current.averageUtilization}%` : undefined),
+        typeof current?.current?.averageUtilization === "number"
+          ? `${current.current.averageUtilization}%`
+          : current?.current?.averageValue,
       target:
-        target?.target?.averageValue ??
-        (target?.target?.averageUtilization ? `${target.target.averageUtilization}%` : undefined),
+        typeof target?.target?.averageUtilization === "number"
+          ? `${target.target.averageUtilization}%`
+          : target?.target?.averageValue,
     };
   }
 }


### PR DESCRIPTION
# Fix ContainerResource HPA metric to display utilization percentage

## Purpose

This PR fixes the display of HPA (HorizontalPodAutoscaler) metrics with `type: ContainerResource` to show utilization percentages instead of raw values.

**Before:** `935m / 80%`
**After:** `72% / 80%`

## Problem

When running pods with service mesh sidecars the standard HPA `type: Resource` metric calculates CPU utilization across **all containers** in a pod. This can lead to inaccurate scaling decisions because sidecar CPU usage dilutes the main application's utilization.

To solve this, Kubernetes provides `type: ContainerResource` which targets only a specific container. However, when viewing these HPAs in Freelens, the metrics column shows raw CPU/Memory values like `935m / 80%` instead of utilization percentages like `72% / 80%`.

This makes it difficult to understand at a glance how close the HPA is to scaling.

<img width="583" height="151" alt="image" src="https://github.com/user-attachments/assets/ab8771f3-86a6-460e-b6b4-59cff758043a" />
<img width="583" height="151" alt="image" src="https://github.com/user-attachments/assets/97b100c7-f8d1-44e3-8e13-5c5611f99596" />

## Root Cause

In `metric-parser-v2.ts`, the `getContainerResource()` method checks `averageValue` first and falls back to `averageUtilization`. This causes raw CPU/memory values to be displayed instead of percentages.

Meanwhile, `getResource()` does the opposite - it checks `averageUtilization` first, which correctly displays percentages.

## Solution

Changed `getContainerResource()` to match `getResource()` behavior:
- Check `averageUtilization` first
- Fall back to `averageValue` if utilization is not available

## Related Issues

None (discovered while using Freelens with Kubernetes HPA using `type: ContainerResource`)

## Testing

- [x] Created 2 deployments and 2 HPAs with type: Resource (CPU and Memory)
- [x] Created 2 deployments and 2 HPAs with type: ContainerResource (CPU and Memory)
- [x] Built and tested locally
- [x] Verified HPA with `type: ContainerResource` now displays `11% / 90%` instead of `10m / 90%`
- [x] Verified HPA with `type: Resource` still works correctly

<img width="583" height="152" alt="image" src="https://github.com/user-attachments/assets/75fde42f-3f71-40ba-8e43-02f0bc60baf1" />
<img width="583" height="159" alt="image" src="https://github.com/user-attachments/assets/8a600f91-5c13-4805-a599-61554f38aa09" />
