### PR TITLE
Normalize package.json files

### DIFF
--- a/freelens/package.json
+++ b/freelens/package.json
@@ -1,40 +1,42 @@
 {
   "name": "freelens",
-  "private": true,
-  "productName": "Freelens",
-  "description": "Freelens - Free IDE for Kubernetes",
-  "homepage": "https://freelens.app",
   "version": "1.8.2-0",
+  "private": true,
+  "description": "Freelens - Free IDE for Kubernetes",
+  "keywords": [],
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "keywords": [],
-  "bugs": {
-    "url": "https://github.com/freelensapp/freelens/issues"
-  },
-  "main": "static/build/main.js",
-  "copyright": "© 2024-2026 Freelens Authors",
   "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
+  "main": "static/build/main.js",
   "scripts": {
-    "clean": "corepack pnpm dlx rimraf@6.1.2 binaries dist static/build",
-    "clean:node_modules": "corepack pnpm dlx rimraf@6.1.2 node_modules",
     "build": "webpack --config webpack/webpack.ts --progress",
-    "build:dev": "NODE_ENV=development webpack --config webpack/webpack.ts --progress",
-    "build:resources": "corepack pnpm \"/^build:resources:/\"",
-    "build:resources:client": "ensure-binaries --package package.json --base-dir binaries/client",
-    "build:resources:license": "generate-license --prod --header license-header.txt --output static/build/license.txt",
-    "build:resources:tray": "generate-tray-icons --output static/build/tray --input @freelensapp/icon/icons/logo-lens.svg --notice-icon @freelensapp/icon/icons/notice.svg --spinner-icon @freelensapp/icon/icons/arrow-spinner.svg --none-color fbfbfb",
     "prebuild:app": "corepack pnpm electron-rebuild",
     "build:app": "corepack pnpm dlx run-script-os@1.1.6 --",
     "build:app:darwin": "electron-builder --publish never --macos",
     "build:app:default": "electron-builder --publish never",
     "build:app:linux": "electron-builder --publish never --linux",
     "build:app:win32": "electron-builder --publish never --win",
+    "build:dev": "NODE_ENV=development webpack --config webpack/webpack.ts --progress",
+    "build:resources": "corepack pnpm \"/^build:resources:/\"",
+    "build:resources:client": "ensure-binaries --package package.json --base-dir binaries/client",
+    "build:resources:license": "generate-license --prod --header license-header.txt --output static/build/license.txt",
+    "build:resources:tray": "generate-tray-icons --output static/build/tray --input @freelensapp/icon/icons/logo-lens.svg --notice-icon @freelensapp/icon/icons/notice.svg --spinner-icon @freelensapp/icon/icons/arrow-spinner.svg --none-color fbfbfb",
+    "clean": "corepack pnpm dlx rimraf@6.1.2 binaries dist static/build",
+    "clean:node_modules": "corepack pnpm dlx rimraf@6.1.2 node_modules",
+    "dev": "NODE_ENV=development corepack pnpm \"/^dev:/\"",
+    "dev:electron": "corepack pnpm dlx rimraf@6.1.2 ./static/build/freelens.js ./static/build/index.html && corepack pnpm dlx chokidar-cli@3.0.0 ./static/build/freelens.js ./static/build/index.html --throttle 5000 --command \"corepack pnpm start:electron\"",
+    "dev:server": "ts-node ./webpack/dev-server.ts",
+    "dev:webpack": "webpack --config webpack/main.ts --progress --watch",
     "electron-rebuild": "electron-rebuild -f",
     "jest": "jest",
     "start": "corepack pnpm dlx run-script-os@1.1.6 --",
@@ -43,10 +45,6 @@
     "start:darwin:x64": "./dist/mac/Freelens.app/Contents/MacOS/Freelens",
     "start:darwin:x86_64": "./dist/mac/Freelens.app/Contents/MacOS/Freelens",
     "start:default": "exit 1",
-    "dev": "NODE_ENV=development corepack pnpm \"/^dev:/\"",
-    "dev:electron": "corepack pnpm dlx rimraf@6.1.2 ./static/build/freelens.js ./static/build/index.html && corepack pnpm dlx chokidar-cli@3.0.0 ./static/build/freelens.js ./static/build/index.html --throttle 5000 --command \"corepack pnpm start:electron\"",
-    "dev:webpack": "webpack --config webpack/main.ts --progress --watch",
-    "dev:server": "ts-node ./webpack/dev-server.ts",
     "start:electron": "electron --remote-debugging-port=9223 --inspect .",
     "start:linux": "corepack pnpm start:linux:${npm_config_arch:-$(uname -m)}",
     "start:linux:arm64": "./dist/linux-arm64-unpacked/freelens",
@@ -56,14 +54,11 @@
     "test:integration": "jest -xyz --runInBand --detectOpenHandles --forceExit"
   },
   "config": {
-    "k8sProxyVersion": "1.5.1",
-    "bundledKubectlVersion": "1.35.1",
     "bundledHelmVersion": "4.1.1",
+    "bundledKubectlVersion": "1.35.1",
     "contentSecurityPolicy": "script-src 'unsafe-eval' 'self'; frame-src https://*.renderer.freelens.app:*/; img-src * data:",
+    "k8sProxyVersion": "1.5.1",
     "welcomeRoute": "/welcome"
-  },
-  "engines": {
-    "node": "^22.0.0"
   },
   "dependencies": {
     "@astronautlabs/jsonpath": "^1.1.2",
@@ -196,5 +191,10 @@
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2",
     "webpack-node-externals": "^3.0.0"
-  }
+  },
+  "engines": {
+    "node": "^22.0.0"
+  },
+  "copyright": "© 2024-2026 Freelens Authors",
+  "productName": "Freelens"
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,23 @@
 {
   "name": "freelens-monorepo",
   "private": true,
-  "workspaces": [
-    "packages/**/*",
-    "freelens"
-  ],
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
+  "workspaces": [
+    "packages/**/*",
+    "freelens"
+  ],
   "scripts": {
     "asar": "corepack pnpm dlx @electron/asar@4.0.1",
     "biome": "corepack pnpm dlx @biomejs/biome@2.3.14",
@@ -21,48 +30,48 @@
     "build:app:dir": "corepack pnpm build:app dir",
     "build:core": "cd packages/core && corepack pnpm build",
     "build:dev": "NODE_ENV=development turbo run build:dev --",
-    "build:di": "node scripts/generate-explicit-di-registration.mjs",
     "postbuild:dev": "turbo run build:resources --",
+    "build:di": "node scripts/generate-explicit-di-registration.mjs",
     "build:freelens": "cd freelens && corepack pnpm build",
     "build:resources": "turbo run build:resources --",
+    "bump-version": "corepack pnpm version --no-commit-hooks --no-git-tag-version --workspaces --no-workspaces-update",
     "clean": "corepack pnpm -r clean",
     "clean:node_modules": "corepack pnpm -r clean:node_modules && corepack pnpm dlx rimraf@6.1.2 node_modules",
+    "compute-versions": "corepack pnpm -r compute-versions",
     "dev": "turbo run dev --parallel --",
     "electron-rebuild": "cd freelens && corepack pnpm electron-rebuild",
+    "fmt": "corepack pnpm trunk fmt",
+    "knip": "corepack pnpm dlx knip@5.83.1 --dependencies --no-gitignore",
+    "knip:check": "corepack pnpm \"/^knip:(development|production)\\$/\"",
+    "knip:development": "corepack pnpm knip",
+    "knip:production": "corepack pnpm knip --production --strict",
+    "lint": "corepack pnpm trunk check",
+    "lint:fix": "corepack pnpm trunk check --fix",
+    "prettier": "corepack pnpm dlx prettier@3.8.1",
+    "prettier:check": "corepack pnpm prettier --check .",
+    "prettier:fix": "corepack pnpm prettier --write .",
     "start": "cd freelens && corepack pnpm start",
     "start:os": "corepack pnpm dlx run-script-os@1.1.6 --",
     "start:os:darwin": "open --stdout $(tty) --stderr $(tty) freelens:",
     "start:os:linux": "xdg-open freelens:",
     "start:os:win32": "powershell -NoProfile -Command \"Start-Process freelens:\"",
-    "knip": "corepack pnpm dlx knip@5.83.1 --dependencies --no-gitignore",
-    "knip:check": "corepack pnpm \"/^knip:(development|production)\\$/\"",
-    "knip:development": "corepack pnpm knip",
-    "knip:production": "corepack pnpm knip --production --strict",
-    "prettier": "corepack pnpm dlx prettier@3.8.1",
-    "prettier:check": "corepack pnpm prettier --check .",
-    "prettier:fix": "corepack pnpm prettier --write .",
-    "trunk": "corepack pnpm dlx @trunkio/launcher@1.3.4",
-    "trunk:check": "corepack pnpm trunk check",
-    "trunk:check:all": "corepack pnpm trunk check --all",
-    "trunk:fix": "corepack pnpm trunk check --fix",
-    "trunk:fix:all": "corepack pnpm trunk check --fix --all",
-    "fmt": "corepack pnpm trunk fmt",
-    "lint": "corepack pnpm trunk check",
-    "lint:fix": "corepack pnpm trunk check --fix",
+    "test:integration": "cd freelens && corepack pnpm test:integration",
     "test:unit": "corepack pnpm -r --no-bail test:unit",
     "test:unit:core": "cd packages/core && corepack pnpm test:unit",
     "test:unit:core:updatesnapshot": "cd packages/core && corepack pnpm test:unit -u",
     "test:unit:updatesnapshot": "corepack pnpm -r --no-bail test:unit -u",
-    "test:integration": "cd freelens && corepack pnpm test:integration",
-    "bump-version": "corepack pnpm version --no-commit-hooks --no-git-tag-version --workspaces --no-workspaces-update",
-    "compute-versions": "corepack pnpm -r compute-versions"
+    "trunk": "corepack pnpm dlx @trunkio/launcher@1.3.4",
+    "trunk:check": "corepack pnpm trunk check",
+    "trunk:check:all": "corepack pnpm trunk check --all",
+    "trunk:fix": "corepack pnpm trunk check --fix",
+    "trunk:fix:all": "corepack pnpm trunk check --fix --all"
   },
-  "engines": {
-    "node": ">=22.0.0"
-  },
-  "packageManager": "pnpm@10.29.2",
   "devDependencies": {
     "pnpm": "10.29.2",
     "turbo": "2.8.7"
+  },
+  "packageManager": "pnpm@10.29.2",
+  "engines": {
+    "node": ">=22.0.0"
   }
 }

--- a/packages/business-features/keyboard-shortcuts/package.json
+++ b/packages/business-features/keyboard-shortcuts/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/keyboard-shortcuts",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Keyboard shortcuts for Freelens",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -59,5 +58,9 @@
     "ts-jest": "^29.4.6",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/cluster-settings/package.json
+++ b/packages/cluster-settings/package.json
@@ -1,24 +1,32 @@
 {
   "name": "@freelensapp/cluster-settings",
   "version": "1.8.2-0",
-  "description": "Injection token exporter for cluster settings configuration",
-  "license": "MIT",
-  "type": "commonjs",
   "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "description": "Injection token exporter for cluster settings configuration",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
+  },
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "build": "lens-webpack-build",
-    "build:dev": "lens-webpack-build"
+    "build:dev": "lens-webpack-build",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
   },
   "dependencies": {
     "@ogre-tools/injectable": "^17.11.1"
@@ -29,5 +37,9 @@
     "@types/react": "^17.0.91",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/cluster-sidebar/package.json
+++ b/packages/cluster-sidebar/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/cluster-sidebar",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Injection tokens for adding new sidebar items within the Cluster View",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -50,5 +49,9 @@
     "ts-jest": "^29.4.6",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,22 +1,21 @@
 {
   "name": "@freelensapp/core",
-  "productName": "",
-  "description": "Freelens Core",
-  "homepage": "https://freelens.app",
   "version": "1.8.2-0",
+  "description": "Freelens Core",
+  "keywords": [],
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "keywords": [],
-  "bugs": {
-    "url": "https://github.com/freelensapp/freelens/issues"
+  "license": "MIT",
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
   },
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "main": "static/build/main.js",
   "exports": {
     "./package.json": "./package.json",
     "./main": "./static/build/library/main.js",
@@ -26,6 +25,7 @@
     "./vars.scss": "./src/renderer/components/vars.scss",
     "./fonts": "./static/build/library/fonts"
   },
+  "main": "static/build/main.js",
   "typesVersions": {
     "*": {
       "main": [
@@ -46,12 +46,6 @@
     "types/*",
     "tsconfig.json"
   ],
-  "copyright": "© 2023 OpenLens Authors",
-  "license": "MIT",
-  "author": {
-    "name": "Freelens Authors",
-    "email": "freelens@freelens.app"
-  },
   "scripts": {
     "build": "webpack --config webpack/library-bundle.ts --progress",
     "build:dev": "NODE_ENV=development webpack --config webpack/library-bundle.ts --progress",
@@ -62,14 +56,11 @@
     "test:watch": "jest --watch --testPathIgnorePatterns integration"
   },
   "config": {
-    "k8sProxyVersion": "1.5.1",
-    "bundledKubectlVersion": "1.35.1",
     "bundledHelmVersion": "4.1.1",
+    "bundledKubectlVersion": "1.35.1",
     "contentSecurityPolicy": "script-src 'unsafe-eval' 'self'; frame-src https://*.renderer.freelens.app:*/; img-src * data:",
+    "k8sProxyVersion": "1.5.1",
     "welcomeRoute": "/welcome"
-  },
-  "engines": {
-    "node": "^22.0.0"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -261,5 +252,14 @@
     "webpack": "^5.105.1",
     "webpack-cli": "^6.0.1",
     "webpack-node-externals": "^3.0.0"
-  }
+  },
+  "engines": {
+    "node": "^22.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "copyright": "© 2023 OpenLens Authors",
+  "productName": ""
 }

--- a/packages/ensure-binaries/package.json
+++ b/packages/ensure-binaries/package.json
@@ -1,23 +1,34 @@
 {
   "name": "@freelensapp/ensure-binaries",
   "version": "1.8.2-0",
+  "private": false,
   "description": "CLI for downloading configured versions of the bundled versions of CLIs",
-  "main": "dist/index.js",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
   "license": "MIT",
-  "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "tsc --pretty --project .",
-    "build:dev": "tsc --pretty --project .",
-    "start": "node ./dist/index.mjs"
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
+  },
+  "main": "dist/index.js",
+  "bin": {
+    "ensure-binaries": "bin/ensure-binaries.js"
   },
   "files": [
     "dist"
   ],
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "scripts": {
+    "build": "tsc --pretty --project .",
+    "build:dev": "tsc --pretty --project .",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
+    "start": "node ./dist/index.mjs"
   },
   "dependencies": {
     "arg": "^5.0.2",
@@ -34,7 +45,8 @@
     "@types/tar-stream": "^3.1.4",
     "typescript": "^5.9.3"
   },
-  "bin": {
-    "ensure-binaries": "bin/ensure-binaries.js"
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,10 +1,20 @@
 {
   "name": "@freelensapp/extensions",
-  "productName": "Freelens extensions",
-  "description": "Freelens - Free IDE for Kubernetes: extensions",
   "version": "1.8.2-0",
-  "copyright": "© 2024-2026 Freelens Authors",
+  "description": "Freelens - Free IDE for Kubernetes: extensions",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
   "license": "MIT",
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
+  },
   "main": "dist/extension-api.js",
   "types": "dist/extension-api.d.ts",
   "files": [
@@ -12,14 +22,6 @@
     "__mocks__/*.ts",
     "dist/**/*.js"
   ],
-  "author": {
-    "name": "Freelens Authors",
-    "email": "freelens@freelens.app"
-  },
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
   "scripts": {
     "build": "webpack --config webpack/extensions.ts",
     "build:dev": "webpack --config webpack/extensions.ts",
@@ -37,5 +39,11 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "webpack": "^5.105.1",
     "webpack-cli": "^6.0.1"
-  }
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "copyright": "© 2024-2026 Freelens Authors",
+  "productName": "Freelens extensions"
 }

--- a/packages/generate-license/package.json
+++ b/packages/generate-license/package.json
@@ -1,26 +1,38 @@
 {
   "name": "@freelensapp/generate-license",
   "version": "1.8.2-0",
+  "private": false,
   "description": "CLI for generating license files",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
   "license": "MIT",
-  "scripts": {
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
+  },
+  "type": "module",
+  "bin": {
+    "generate-license": "bin/generate-license.js"
   },
   "files": [
     "src"
   ],
-  "type": "module",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "scripts": {
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
   },
   "dependencies": {
     "@quantco/pnpm-licenses": "^2.2.3",
     "spdx-license-list": "^6.11.0"
   },
   "devDependencies": {},
-  "bin": {
-    "generate-license": "bin/generate-license.js"
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/generate-tray-icons/package.json
+++ b/packages/generate-tray-icons/package.json
@@ -1,23 +1,34 @@
 {
   "name": "@freelensapp/generate-tray-icons",
   "version": "1.8.2-0",
+  "private": false,
   "description": "CLI generating tray icons for building a lens-like application",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
   "license": "MIT",
-  "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "build": "tsc --pretty --project .",
-    "build:dev": "tsc --pretty --project .",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "start": "node --experimental-import-meta-resolve ./dist/index.js"
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
+  },
+  "type": "module",
+  "bin": {
+    "generate-tray-icons": "bin/generate-tray-icons.js"
   },
   "files": [
     "dist"
   ],
-  "type": "module",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "scripts": {
+    "build": "tsc --pretty --project .",
+    "build:dev": "tsc --pretty --project .",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
+    "start": "node --experimental-import-meta-resolve ./dist/index.js"
   },
   "dependencies": {
     "arg": "^5.0.2",
@@ -30,7 +41,8 @@
     "@types/node": "~22.19.11",
     "typescript": "^5.9.3"
   },
-  "bin": {
-    "generate-tray-icons": "bin/generate-tray-icons.js"
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/infrastructure/jest/package.json
+++ b/packages/infrastructure/jest/package.json
@@ -1,34 +1,37 @@
 {
   "name": "@freelensapp/jest",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Jest configuration and scripts for Freelens packages.",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "index.js",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "index.js",
   "scripts": {
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
   },
   "dependencies": {
-    "identity-obj-proxy": "^3.0.0",
     "glob": "^13.0.2",
+    "identity-obj-proxy": "^3.0.0",
     "lodash": "^4.17.23"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@types/jest": "^29.5.14"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/infrastructure/typescript/package.json
+++ b/packages/infrastructure/typescript/package.json
@@ -1,28 +1,31 @@
 {
   "name": "@freelensapp/typescript",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Typescript configuration for Freelens packages.",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
   "scripts": {
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
   },
   "dependencies": {
     "typescript": "^5.9.3",
     "typescript-plugin-css-modules": "^5.2.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/infrastructure/webpack/package.json
+++ b/packages/infrastructure/webpack/package.json
@@ -1,24 +1,26 @@
 {
   "name": "@freelensapp/webpack",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Webpack configurations and scripts for Lens packages.",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lensapp/lens.git"
+    "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://github.com/lensapp/lens",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "bin": {
+    "lens-webpack-build": "bin/webpack-build"
+  },
   "scripts": {
     "build": "webpack",
     "clean": "pnpm dlx rimraf@6.1.2 dist",
@@ -57,7 +59,8 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.4.6"
   },
-  "bin": {
-    "lens-webpack-build": "bin/webpack-build"
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/kube-object/package.json
+++ b/packages/kube-object/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/kube-object",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Injection tokens for list layout",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -49,5 +48,9 @@
     "ts-loader": "^9.5.4",
     "type-fest": "^5.4.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/kubectl-versions/package.json
+++ b/packages/kubectl-versions/package.json
@@ -1,30 +1,33 @@
 {
   "name": "@freelensapp/kubectl-versions",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Package of kubectl versions at build time",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
+    "precompute-versions": "tsc --pretty --project build",
     "compute-versions": "node ./build/compute-versions.mjs",
-    "dev": "lens-webpack-build --watch",
-    "precompute-versions": "tsc --pretty --project build"
+    "dev": "lens-webpack-build --watch"
   },
   "devDependencies": {
     "@freelensapp/typescript": "workspace:^",
@@ -37,5 +40,9 @@
     "typed-regex": "^0.0.8",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/legacy-global-di/package.json
+++ b/packages/legacy-global-di/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/legacy-global-di",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Injection tokens for implementing metrics for Freelens",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -35,5 +34,9 @@
     "@ogre-tools/injectable": "^17.11.1",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/list-layout/package.json
+++ b/packages/list-layout/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/list-layout",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Injection tokens for list layout",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -40,5 +39,9 @@
     "@ogre-tools/injectable": "^17.11.1",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/logger",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable logger in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -49,5 +48,9 @@
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1",
     "winston-transport": "^4.9.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/metrics",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Injection tokens for implementing metrics for Freelens",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -40,5 +39,9 @@
     "react": "^17.0.2",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -1,31 +1,30 @@
 {
   "name": "@freelensapp/random",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable random in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "exports": {
-    ".": "./dist/index.js"
-  },
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -42,5 +41,9 @@
     "@types/webpack-env": "^1.18.8",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/resource-templates/package.json
+++ b/packages/resource-templates/package.json
@@ -2,14 +2,25 @@
   "name": "@freelensapp/resource-templates",
   "version": "1.8.2-0",
   "private": false,
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
+  },
+  "files": [
+    "templates/**/*"
+  ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "copyright": "© 2023 OpenLens Authors",
-  "license": "MIT",
-  "author": "OpenLens Authors <freelens@freelens.app>",
-  "files": [
-    "templates/**/*"
-  ]
+  "copyright": "© 2023 OpenLens Authors"
 }

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/routing",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable routing in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -45,5 +44,9 @@
     "lodash": "^4.17.23",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -1,16 +1,28 @@
 {
   "name": "@freelensapp/semver",
   "version": "1.8.2-0",
-  "description": "CLI over semver package for picking parts of a version",
-  "license": "MIT",
   "private": true,
-  "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "tsc --pretty --project .",
-    "build:dev": "tsc --pretty --project ."
+  "description": "CLI over semver package for picking parts of a version",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
   },
   "type": "module",
+  "scripts": {
+    "build": "tsc --pretty --project .",
+    "build:dev": "tsc --pretty --project .",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
+  },
   "dependencies": {
     "command-line-args": "^6.0.1",
     "semver": "^7.7.4"

--- a/packages/technical-features/application/application-for-electron-main/package.json
+++ b/packages/technical-features/application/application-for-electron-main/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/application-for-electron-main",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Electron's main specifics for creating Freelens applications",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "lens-webpack-build",
     "clean": "pnpm dlx rimraf@6.1.2 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "lens-webpack-build",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -50,5 +49,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/technical-features/application/application/package.json
+++ b/packages/technical-features/application/application/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/application",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Package for creating Freelens applications",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "lens-webpack-build",
     "clean": "pnpm dlx rimraf@6.1.2 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "lens-webpack-build",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -49,5 +48,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/technical-features/application/legacy-extensions/package.json
+++ b/packages/technical-features/application/legacy-extensions/package.json
@@ -1,31 +1,30 @@
 {
   "name": "@freelensapp/legacy-extensions",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Package for Lens extensions using the v1 API",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
     "build": "lens-webpack-build",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
   },
   "dependencies": {
@@ -41,5 +40,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/technical-features/feature-core/package.json
+++ b/packages/technical-features/feature-core/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/feature-core",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Code that is common to all Features and those registering them.",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "lens-webpack-build",
     "clean": "pnpm dlx rimraf@6.1.2 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "lens-webpack-build",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -42,5 +41,9 @@
     "ts-jest": "^29.4.6",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/technical-features/messaging/computed-channel/package.json
+++ b/packages/technical-features/messaging/computed-channel/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/computed-channel",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "MobX-like computed between channels",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "lens-webpack-build",
     "clean": "pnpm dlx rimraf@6.1.2 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "lens-webpack-build",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -56,5 +55,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/technical-features/messaging/messaging-fake-bridge/package.json
+++ b/packages/technical-features/messaging/messaging-fake-bridge/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/messaging-fake-bridge",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Fake implementation to bridge multiple dependency injection containers.",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "lens-webpack-build",
     "clean": "pnpm dlx rimraf@6.1.2 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "lens-webpack-build",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -54,5 +53,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/technical-features/messaging/messaging-for-main/package.json
+++ b/packages/technical-features/messaging/messaging-for-main/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/messaging-for-main",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Implementations for 'messaging' in Electron main",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "lens-webpack-build",
     "clean": "pnpm dlx rimraf@6.1.2 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "lens-webpack-build",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -51,5 +50,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/technical-features/messaging/messaging-for-renderer/package.json
+++ b/packages/technical-features/messaging/messaging-for-renderer/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/messaging-for-renderer",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Implementations for 'messaging' in Electron renderer",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "lens-webpack-build",
     "clean": "pnpm dlx rimraf@6.1.2 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "lens-webpack-build",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -51,5 +50,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/technical-features/messaging/messaging/package.json
+++ b/packages/technical-features/messaging/messaging/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/messaging",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "An abstraction for messaging between Lens environments",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "lens-webpack-build",
     "clean": "pnpm dlx rimraf@6.1.2 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "lens-webpack-build",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -51,5 +50,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/technical-features/prometheus/package.json
+++ b/packages/technical-features/prometheus/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/prometheus",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Prometheus support for Freelens",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -45,5 +44,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/technical-features/react-application/package.json
+++ b/packages/technical-features/react-application/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/react-application",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Package for React Application",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "lens-webpack-build",
     "clean": "pnpm dlx rimraf@6.1.2 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
-    "build": "lens-webpack-build",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -59,5 +58,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/transpilation/kubernetes-client-node/package.json
+++ b/packages/transpilation/kubernetes-client-node/package.json
@@ -1,29 +1,32 @@
 {
   "name": "@freelensapp/kubernetes-client-node",
   "version": "1.8.2-0",
+  "private": false,
   "description": "Kubernetes client for Freelens",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "copyright": "© 2024-2026 Freelens Authors",
-  "license": "MIT",
-  "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
+  "type": "module",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
-  "type": "module",
   "files": [
     "dist"
   ],
   "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "build": "webpack",
-    "build:dev": "webpack"
+    "build:dev": "webpack",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
   },
   "dependencies": {
     "@freelensapp/node-fetch": "workspace:^",
@@ -42,5 +45,10 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
-  }
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "copyright": "© 2024-2026 Freelens Authors"
 }

--- a/packages/transpilation/node-fetch/package.json
+++ b/packages/transpilation/node-fetch/package.json
@@ -1,24 +1,32 @@
 {
   "name": "@freelensapp/node-fetch",
   "version": "1.8.2-0",
-  "description": "Node fetch for Freelens",
-  "license": "MIT",
   "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "description": "Node fetch for Freelens",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
+  },
+  "type": "module",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
-  "type": "module",
   "files": [
     "dist"
   ],
   "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "build": "webpack",
-    "build:dev": "webpack"
+    "build:dev": "webpack",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
   },
   "devDependencies": {
     "@freelensapp/typescript": "workspace:^",
@@ -26,5 +34,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/transpilation/openid-client/package.json
+++ b/packages/transpilation/openid-client/package.json
@@ -1,12 +1,20 @@
 {
   "name": "@freelensapp/openid-client",
   "version": "1.8.2-0",
-  "description": "Open ID for Freelens",
-  "license": "MIT",
   "private": false,
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "description": "Open ID for Freelens",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -14,10 +22,10 @@
     "dist"
   ],
   "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "build": "webpack",
-    "build:dev": "webpack"
+    "build:dev": "webpack",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
   },
   "devDependencies": {
     "@freelensapp/typescript": "workspace:^",
@@ -25,5 +33,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/ui-components/animate/package.json
+++ b/packages/ui-components/animate/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/animate",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable animate in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "exports": {
-    ".": "./dist/index.js",
-    "./styles": "./dist/index.css"
-  },
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "exports": {
+    ".": "./dist/index.js",
+    "./styles": "./dist/index.css"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -51,5 +50,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/ui-components/button/package.json
+++ b/packages/ui-components/button/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/button",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable button in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "exports": {
-    ".": "./dist/index.js",
-    "./styles": "./dist/index.css"
-  },
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "exports": {
+    ".": "./dist/index.js",
+    "./styles": "./dist/index.css"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -49,5 +48,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/ui-components/error-boundary/package.json
+++ b/packages/ui-components/error-boundary/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/error-boundary",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable error-boundary in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "exports": {
-    ".": "./dist/index.js",
-    "./styles": "./dist/index.css"
-  },
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "exports": {
+    ".": "./dist/index.js",
+    "./styles": "./dist/index.css"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -56,5 +55,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/ui-components/icon/package.json
+++ b/packages/ui-components/icon/package.json
@@ -1,34 +1,33 @@
 {
   "name": "@freelensapp/icon",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable icon in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "assets",
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
+  "license": "MIT",
+  "author": {
+    "name": "Freelens Authors",
+    "email": "freelens@freelens.app"
+  },
+  "type": "commonjs",
   "exports": {
     ".": "./dist/index.js",
     "./styles": "./dist/index.css",
     "./icons/*.svg": "./assets/*.svg"
   },
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "author": {
-    "name": "Freelens Authors",
-    "email": "freelens@freelens.app"
-  },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "files": [
+    "assets",
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -62,5 +61,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/ui-components/notifications/package.json
+++ b/packages/ui-components/notifications/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/notifications",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable notifications in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "exports": {
-    ".": "./dist/index.js",
-    "./styles": "./dist/index.css"
-  },
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "exports": {
+    ".": "./dist/index.js",
+    "./styles": "./dist/index.css"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -64,5 +63,9 @@
     "type-fest": "^5.4.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/ui-components/resizing-anchor/package.json
+++ b/packages/ui-components/resizing-anchor/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/resizing-anchor",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable resizing-anchor in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "exports": {
-    ".": "./dist/index.js",
-    "./styles": "./dist/index.css"
-  },
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "exports": {
+    ".": "./dist/index.js",
+    "./styles": "./dist/index.css"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -51,5 +50,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/ui-components/spinner/package.json
+++ b/packages/ui-components/spinner/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/spinner",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable spinner in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "exports": {
-    ".": "./dist/index.js",
-    "./styles": "./dist/index.css"
-  },
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "exports": {
+    ".": "./dist/index.js",
+    "./styles": "./dist/index.css"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -47,5 +46,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/ui-components/tooltip/package.json
+++ b/packages/ui-components/tooltip/package.json
@@ -1,32 +1,31 @@
 {
   "name": "@freelensapp/tooltip",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Highly extendable tooltip in the Freelens.",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "exports": {
-    ".": "./dist/index.js",
-    "./styles": "./dist/index.css"
-  },
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "exports": {
+    ".": "./dist/index.js",
+    "./styles": "./dist/index.css"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -62,5 +61,9 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/utility-features/event-emitter/package.json
+++ b/packages/utility-features/event-emitter/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/event-emitter",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Event emitter",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -40,5 +39,9 @@
     "ts-jest": "^29.4.6",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/utility-features/json-api/package.json
+++ b/packages/utility-features/json-api/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/json-api",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "JSON api client",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -46,5 +45,9 @@
     "ts-loader": "^9.5.4",
     "type-fest": "^5.4.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/utility-features/kube-api-specifics/package.json
+++ b/packages/utility-features/kube-api-specifics/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/kube-api-specifics",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Kube api",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -42,5 +41,9 @@
     "@types/webpack-env": "^1.18.8",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/utility-features/kube-api/package.json
+++ b/packages/utility-features/kube-api/package.json
@@ -1,28 +1,27 @@
 {
   "name": "@freelensapp/kube-api",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "Kube api",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
@@ -60,5 +59,9 @@
     "type-fest": "^5.4.4",
     "typescript": "^5.9.3",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/utility-features/react-testing-library-discovery/package.json
+++ b/packages/utility-features/react-testing-library-discovery/package.json
@@ -1,33 +1,32 @@
 {
   "name": "@freelensapp/react-testing-library-discovery",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "A way to discover HTML-elements using react-testing-library",
-  "type": "commonjs",
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "build": "lens-webpack-build",
-    "build:dev": "lens-webpack-build"
+    "build:dev": "lens-webpack-build",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
   },
   "dependencies": {
     "@testing-library/dom": "^10.4.1"
@@ -38,5 +37,9 @@
     "@testing-library/react": "^12.1.5",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/utility-features/run-many/package.json
+++ b/packages/utility-features/run-many/package.json
@@ -1,29 +1,32 @@
 {
   "name": "@freelensapp/run-many",
   "version": "1.8.2-0",
-  "type": "commonjs",
-  "description": "A package containing runMany and runManySync",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
   "private": false,
-  "files": [
-    "dist"
-  ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "description": "A package containing runMany and runManySync",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -48,5 +51,9 @@
     "type-fest": "^5.4.4",
     "typed-emitter": "^1.4.0",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/utility-features/startable-stoppable/package.json
+++ b/packages/utility-features/startable-stoppable/package.json
@@ -1,30 +1,29 @@
 {
   "name": "@freelensapp/startable-stoppable",
-  "private": false,
   "version": "1.8.2-0",
+  "private": false,
   "description": "TBD",
-  "type": "commonjs",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "test:unit": "jest --coverage --runInBand"
   },
   "devDependencies": {
@@ -37,5 +36,9 @@
     "ts-jest": "^29.4.6",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/utility-features/test-utils/package.json
+++ b/packages/utility-features/test-utils/package.json
@@ -1,29 +1,32 @@
 {
   "name": "@freelensapp/test-utils",
   "version": "1.8.2-0",
-  "description": "A collection of utilities for testing",
-  "type": "commonjs",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
   "private": false,
-  "files": [
-    "dist"
-  ],
+  "description": "A collection of utilities for testing",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "build": "lens-webpack-build",
-    "build:dev": "lens-webpack-build"
+    "build:dev": "lens-webpack-build",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules"
   },
   "dependencies": {
     "@ogre-tools/injectable": "^17.11.1",
@@ -44,5 +47,9 @@
     "react-dom": "^17.0.2",
     "ts-loader": "^9.5.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/utility-features/utilities/package.json
+++ b/packages/utility-features/utilities/package.json
@@ -1,29 +1,32 @@
 {
   "name": "@freelensapp/utilities",
-  "description": "A collection of useful types",
   "version": "1.8.2-0",
-  "type": "commonjs",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
   "private": false,
-  "files": [
-    "dist"
-  ],
+  "description": "A collection of useful types",
+  "homepage": "https://freelens.app",
+  "bugs": {
+    "url": "https://github.com/freelensapp/freelens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freelensapp/freelens.git"
+  },
+  "license": "MIT",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "license": "MIT",
-  "homepage": "https://freelens.app",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "clean": "pnpm dlx rimraf@6.1.2 dist",
-    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "build": "lens-webpack-build",
     "build:dev": "lens-webpack-build",
+    "clean": "pnpm dlx rimraf@6.1.2 dist",
+    "clean:node_modules": "pnpm dlx rimraf@6.1.2 node_modules",
     "test:unit": "jest --coverage --runInBand"
   },
   "dependencies": {
@@ -56,5 +59,9 @@
     "ts-loader": "^9.5.4",
     "type-fest": "^5.4.4",
     "webpack": "^5.105.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
New NPM workflow is more strict about `repository` field.

Here was a normalization done for all package.json files:

```sh
find -name package.json | grep -v node_module | while read p; do yq -i '.homepage="https://freelens.app" | .repository={"type": "git","url": "git+https://github.com/freelensapp/freelens.git"} | .license="MIT" | .author={"name": "Freelens Authors","email": "freelens@freelens.app"} | .bugs={"url": "https://github.com/freelensapp/freelens/issues"}' $p; done
find -name package.json | grep -v node_module | while read p; do ( cd $(dirname $p); pnpx sort-package-json; ); done
```
