### PR TITLE
Prefill log search with selected text on Ctrl+F / Cmd+F

### DIFF
--- a/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
@@ -75,6 +75,10 @@ describe("LogSearch tests", () => {
     user = userEvent.setup();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("renders w/o errors", () => {
     const model = getOnePodViewModel("foobar");
     const { container } = render(<LogSearch model={model} scrollToOverlay={jest.fn()} />);
@@ -121,5 +125,104 @@ describe("LogSearch tests", () => {
     await user.click(await screen.findByText("keyboard_arrow_down"));
     await user.click(await screen.findByText("keyboard_arrow_up"));
     expect(scrollToOverlay).not.toBeCalled();
+  });
+
+  it.each([
+    { label: "ctrl+f", eventInit: { key: "f", ctrlKey: true } },
+    { label: "cmd+f", eventInit: { key: "f", metaKey: true } },
+  ])("should prefill search on $label when selection is inside pod logs list", async ({ eventInit }) => {
+    const scrollToOverlay = jest.fn();
+    const model = getOnePodViewModel("foobar", {
+      getLogsWithoutTimestamps: () => ["hello", "world"],
+    });
+
+    render(
+      <div className="PodLogs">
+        <div className="LogList">
+          <span data-testid="selection-source">hello</span>
+        </div>
+        <LogSearch model={model} scrollToOverlay={scrollToOverlay} />
+      </div>,
+    );
+
+    const selectionSource = screen.getByTestId("selection-source").firstChild;
+
+    jest.spyOn(window, "getSelection").mockReturnValue({
+      anchorNode: selectionSource,
+      focusNode: selectionSource,
+      toString: () => "hello",
+    } as Selection);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", eventInit));
+
+    expect(await screen.findByPlaceholderText("Search...")).toHaveValue("hello");
+    expect(scrollToOverlay).toHaveBeenCalled();
+  });
+
+  it("should not prefill search on ctrl+f when selection is outside pod logs list", async () => {
+    const scrollToOverlay = jest.fn();
+    const model = getOnePodViewModel("foobar", {
+      getLogsWithoutTimestamps: () => ["hello", "world"],
+    });
+
+    render(
+      <div>
+        <div data-testid="outside-selection-source">hello</div>
+        <div className="PodLogs">
+          <div className="LogList" />
+          <LogSearch model={model} scrollToOverlay={scrollToOverlay} />
+        </div>
+      </div>,
+    );
+
+    const search = await screen.findByPlaceholderText("Search...");
+
+    await user.click(search);
+    await user.keyboard("o");
+
+    const outsideSelectionSource = screen.getByTestId("outside-selection-source").firstChild;
+
+    jest.spyOn(window, "getSelection").mockReturnValue({
+      anchorNode: outsideSelectionSource,
+      focusNode: outsideSelectionSource,
+      toString: () => "hello",
+    } as Selection);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true }));
+
+    expect(search).toHaveValue("o");
+  });
+
+  it("should keep existing query on ctrl+f when selection is empty", async () => {
+    const scrollToOverlay = jest.fn();
+    const model = getOnePodViewModel("foobar", {
+      getLogsWithoutTimestamps: () => ["hello", "world"],
+    });
+
+    render(
+      <div className="PodLogs">
+        <div className="LogList">
+          <span data-testid="selection-source">hello</span>
+        </div>
+        <LogSearch model={model} scrollToOverlay={scrollToOverlay} />
+      </div>,
+    );
+
+    const search = await screen.findByPlaceholderText("Search...");
+
+    await user.click(search);
+    await user.keyboard("o");
+
+    const selectionSource = screen.getByTestId("selection-source").firstChild;
+
+    jest.spyOn(window, "getSelection").mockReturnValue({
+      anchorNode: selectionSource,
+      focusNode: selectionSource,
+      toString: () => "",
+    } as Selection);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true }));
+
+    expect(search).toHaveValue("o");
   });
 });

--- a/packages/core/src/renderer/components/dock/logs/search.tsx
+++ b/packages/core/src/renderer/components/dock/logs/search.tsx
@@ -8,10 +8,43 @@ import "./search.scss";
 
 import { Icon } from "@freelensapp/icon";
 import { observer } from "mobx-react";
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { SearchInput } from "../../input";
 
 import type { LogTabViewModel } from "./logs-view-model";
+
+const isFindHotkey = (evt: KeyboardEvent) => evt.key.toLowerCase() === "f" && (evt.metaKey || evt.ctrlKey);
+
+const isInsideLogsList = (node: Node | null) => {
+  if (!node) {
+    return false;
+  }
+
+  const element = node instanceof Element ? node : node.parentElement;
+
+  return Boolean(element?.closest(".PodLogs .list, .PodLogs .LogList"));
+};
+
+const isSelectionInsideLogsList = (selection: Selection) => {
+  const commonAncestor = selection.rangeCount > 0 ? selection.getRangeAt(0).commonAncestorContainer : null;
+
+  return [selection.anchorNode, selection.focusNode, commonAncestor].some(isInsideLogsList);
+};
+
+const getSelectedTextFromLogsList = () => {
+  const selection = window.getSelection();
+  const selectedText = selection?.toString().trim();
+
+  if (!selection || !selectedText) {
+    return;
+  }
+
+  if (!isSelectionInsideLogsList(selection)) {
+    return;
+  }
+
+  return selectedText;
+};
 
 export interface PodLogSearchProps {
   onSearch?: (query: string) => void;
@@ -32,11 +65,14 @@ export const LogSearch = observer(
       searchStore;
     const jumpDisabled = !searchQuery || !occurrences.length;
 
-    const setSearch = (query: string) => {
-      searchStore.onSearch(logs, query);
-      onSearch?.(query);
-      scrollToOverlay(searchStore.activeOverlayLine);
-    };
+    const setSearch = useCallback(
+      (query: string) => {
+        searchStore.onSearch(logs, query);
+        onSearch?.(query);
+        scrollToOverlay(searchStore.activeOverlayLine);
+      },
+      [logs, searchStore, onSearch, scrollToOverlay],
+    );
 
     const onPrevOverlay = () => {
       setPrevOverlayActive();
@@ -66,6 +102,26 @@ export const LogSearch = observer(
       // Refresh search when logs changed
       searchStore.onSearch(logs);
     }, [logs]);
+
+    useEffect(() => {
+      const onGlobalFind = (evt: KeyboardEvent) => {
+        if (!isFindHotkey(evt)) {
+          return;
+        }
+
+        const selectedText = getSelectedTextFromLogsList();
+
+        if (selectedText) {
+          setSearch(selectedText);
+        }
+      };
+
+      window.addEventListener("keydown", onGlobalFind, true);
+
+      return () => {
+        window.removeEventListener("keydown", onGlobalFind, true);
+      };
+    }, [setSearch]);
 
     return (
       <div className="LogSearch flex box grow justify-flex-end gaps align-center">


### PR DESCRIPTION
## Summary

When pressing `Ctrl+F`/`Cmd+F` in the pod logs view, the search input is now prefilled with the currently selected text — but only if the selection originates from inside the logs list. If the selection is outside the logs area or empty, the existing search query is left untouched.

This mirrors the "find in page" behavior found in most editors and terminals. Fixing a minor quirk that I always notice while using Freelens.

## Changes

- Added a `keydown` listener on `window` (capture phase) that detects Ctrl+F / Cmd+F and prefills the search input with selected text from the logs list
- Extracted pure DOM helper functions (`isFindHotkey`, `isInsideLogsList`, `isSelectionInsideLogsList`, `getSelectedTextFromLogsList`) to module scope
- Wrapped `setSearch` in `useCallback` with a correct dependency array to avoid stale closures in the effect
- Added three test cases covering: prefill on Ctrl+F, prefill on Cmd+F (parameterized via `it.each`), no prefill when selection is outside logs, and no prefill when selection is empty
- Added `afterEach` with `jest.restoreAllMocks()` for proper spy cleanup

## Test plan

- [x] `pnpm test` — all 8 tests in `log-search.test.tsx` pass
- [x] `pnpm biome:check` — no lint or formatting issues