### PR TITLE
feat: Add custom theme and color customization

### DIFF
--- a/CUSTOM_THEME_IMPLEMENTATION.md
+++ b/CUSTOM_THEME_IMPLEMENTATION.md
@@ -1,0 +1,88 @@
+# Custom Theme Feature Implementation
+
+## Overview
+This implementation adds custom theme support to Freelens, allowing users to customize theme colors and create their own themes.
+
+## Files Added
+
+### 1. Theme System
+- `packages/core/src/renderer/themes/custom-theme.injectable.ts`
+  - Implements dynamic custom theme generation
+  - Reads user preferences for custom colors
+  - Supports both dark and light base themes
+
+### 2. User Preferences
+- `packages/core/src/features/user-preferences/common/custom-theme-colors.injectable.ts`
+  - Defines custom theme preference types
+  - Handles preference persistence
+
+### 3. UI Components
+- `packages/core/src/features/preferences/renderer/preference-items/application/theme/custom-theme-editor.tsx`
+  - Color picker UI for customizing theme colors
+  - Real-time preview of custom theme
+  - Supports 10+ customizable color properties
+
+- `packages/core/src/features/preferences/renderer/preference-items/application/theme/custom-theme-preference-block.injectable.ts`
+  - Registers custom theme editor in preferences
+
+## Features
+
+### Customizable Colors
+- Primary Color
+- Main Background
+- Sidebar Background
+- Primary Text
+- Secondary Text
+- Border Color
+- Primary Button
+- Content Background
+- Layout Background
+- Active Sidebar Item
+
+### Theme Editor UI
+- Base theme selection (Dark/Light)
+- Color pickers for each customizable property
+- Real-time preview
+- Apply and Reset buttons
+- Hex color input support
+
+### User Experience
+- Non-destructive (doesn't modify built-in themes)
+- Persistent across sessions
+- Easy to reset to defaults
+- Visual preview before applying
+
+## Technical Details
+
+### Architecture
+- Uses Freelens's dependency injection system
+- Integrates with existing theme system
+- Follows existing code patterns
+- Type-safe with TypeScript
+
+### Theme Resolution
+1. User selects "Custom" theme
+2. System reads `customThemeColors` and `customThemeBase` from preferences
+3. Custom theme injectable merges custom colors with base theme
+4. Theme is applied to the application
+
+## Testing
+
+### Manual Testing Steps
+1. Open Preferences → Application → Theme
+2. Select "Custom" from theme dropdown
+3. Click "Custom Theme" section
+4. Change some colors using color pickers
+5. Click "Apply Custom Theme"
+6. Verify theme changes in the application
+7. Restart application and verify persistence
+
+## Future Enhancements
+- Export/import custom themes
+- Theme sharing
+- More color properties
+- Preset custom themes
+- Gradient support
+
+## Related Issue
+Closes: freelensapp/freelens#1280

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/custom-theme-editor.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/custom-theme-editor.tsx
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { withInjectables } from "@ogre-tools/injectable-react";
+import { observer } from "mobx-react";
+import React, { useState } from "react";
+import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
+import { Input } from "../../../../../../renderer/components/input";
+import { Button } from "../../../../../../renderer/components/button";
+import { Select } from "../../../../../../renderer/components/select";
+import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";
+import { defaultThemeInjectable } from "../../../../../../renderer/themes/default-theme.injectable";
+
+import type { UserPreferencesState } from "../../../../../user-preferences/common/state.injectable";
+import type { LensTheme } from "../../../../../../renderer/themes/lens-theme";
+
+interface Dependencies {
+  state: UserPreferencesState;
+  defaultTheme: LensTheme;
+}
+
+// Common theme colors that users might want to customize
+const customizableColors = [
+  { key: "primary", label: "Primary Color", description: "Main accent color" },
+  { key: "mainBackground", label: "Main Background", description: "Application background" },
+  { key: "sidebarBackground", label: "Sidebar Background", description: "Left sidebar background" },
+  { key: "textColorPrimary", label: "Primary Text", description: "Main text color" },
+  { key: "textColorSecondary", label: "Secondary Text", description: "Secondary text color" },
+  { key: "borderColor", label: "Border Color", description: "Border and divider color" },
+  { key: "buttonPrimaryBackground", label: "Primary Button", description: "Primary button background" },
+  { key: "contentColor", label: "Content Background", description: "Content area background" },
+  { key: "layoutBackground", label: "Layout Background", description: "Layout background" },
+  { key: "sidebarActiveColor", label: "Active Sidebar Item", description: "Active sidebar item color" },
+];
+
+const NonInjectedCustomThemeEditor = observer(({ state, defaultTheme }: Dependencies) => {
+  const [selectedBase, setSelectedBase] = useState<"dark" | "light">(
+    state.customThemeBase || "dark"
+  );
+  
+  const [customColors, setCustomColors] = useState<Record<string, string>>(
+    state.customThemeColors || {}
+  );
+
+  const baseThemeOptions = [
+    { value: "dark", label: "Dark Theme" },
+    { value: "light", label: "Light Theme" },
+  ];
+
+  const handleColorChange = (colorKey: string, value: string) => {
+    setCustomColors((prev) => ({
+      ...prev,
+      [colorKey]: value,
+    }));
+  };
+
+  const handleSave = () => {
+    state.customThemeColors = customColors;
+    state.customThemeBase = selectedBase;
+    state.colorTheme = "Custom";
+  };
+
+  const handleReset = () => {
+    setCustomColors({});
+    setSelectedBase("dark");
+    state.customThemeColors = {};
+    state.customThemeBase = "dark";
+  };
+
+  const handleBaseChange = (option: { value: string; label: string } | null) => {
+    if (option) {
+      setSelectedBase(option.value as "dark" | "light");
+    }
+  };
+
+  return (
+    <section id="custom-theme-editor">
+      <SubTitle title="Custom Theme" />
+      
+      <div style={{ marginBottom: "20px" }}>
+        <label style={{ display: "block", marginBottom: "8px", fontWeight: 500 }}>
+          Base Theme
+        </label>
+        <Select
+          id="base-theme-select"
+          options={baseThemeOptions}
+          value={selectedBase}
+          onChange={handleBaseChange}
+          themeName="lens"
+        />
+      </div>
+
+      <div style={{ marginBottom: "20px" }}>
+        <label style={{ display: "block", marginBottom: "12px", fontWeight: 500 }}>
+          Custom Colors
+        </label>
+        
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
+            gap: "16px",
+          }}
+        >
+          {customizableColors.map(({ key, label, description }) => (
+            <div key={key} style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+              <div style={{ flex: 1 }}>
+                <label style={{ display: "block", fontSize: "14px", marginBottom: "4px" }}>
+                  {label}
+                </label>
+                <span style={{ fontSize: "12px", color: "#888" }}>{description}</span>
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <input
+                  type="color"
+                  value={customColors[key] || getDefaultColor(key, selectedBase)}
+                  onChange={(e) => handleColorChange(key, e.target.value)}
+                  style={{
+                    width: "40px",
+                    height: "40px",
+                    border: "none",
+                    borderRadius: "4px",
+                    cursor: "pointer",
+                  }}
+                />
+                <Input
+                  value={customColors[key] || getDefaultColor(key, selectedBase)}
+                  onChange={(value) => handleColorChange(key, value)}
+                  placeholder="#00a7a0"
+                  style={{ width: "100px" }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", gap: "12px", marginTop: "20px" }}>
+        <Button variant="primary" onClick={handleSave}>
+          Apply Custom Theme
+        </Button>
+        <Button variant="default" onClick={handleReset}>
+          Reset to Defaults
+        </Button>
+      </div>
+
+      <div
+        style={{
+          marginTop: "20px",
+          padding: "16px",
+          borderRadius: "8px",
+          backgroundColor: customColors.mainBackground || getDefaultColor("mainBackground", selectedBase),
+          border: `1px solid ${customColors.borderColor || getDefaultColor("borderColor", selectedBase)}`,
+        }}
+      >
+        <h4
+          style={{
+            color: customColors.textColorPrimary || getDefaultColor("textColorPrimary", selectedBase),
+            marginBottom: "12px",
+          }}
+        >
+          Preview
+        </h4>
+        <p
+          style={{
+            color: customColors.textColorSecondary || getDefaultColor("textColorSecondary", selectedBase),
+          }}
+        >
+          This is how your custom theme will look. The colors will be applied to the entire application.
+        </p>
+        <Button
+          variant="primary"
+          style={{
+            marginTop: "12px",
+            backgroundColor: customColors.buttonPrimaryBackground || getDefaultColor("buttonPrimaryBackground", selectedBase),
+          }}
+        >
+          Sample Button
+        </Button>
+      </div>
+    </section>
+  );
+});
+
+function getDefaultColor(key: string, base: "dark" | "light"): string {
+  const darkDefaults: Record<string, string> = {
+    primary: "#00a7a0",
+    mainBackground: "#1e2124",
+    sidebarBackground: "#36393e",
+    textColorPrimary: "#8e9297",
+    textColorSecondary: "#a0a0a0",
+    borderColor: "#4c5053",
+    buttonPrimaryBackground: "#00a7a0",
+    contentColor: "#262b2f",
+    layoutBackground: "#2e3136",
+    sidebarActiveColor: "#ffffff",
+  };
+
+  const lightDefaults: Record<string, string> = {
+    primary: "#00a7a0",
+    mainBackground: "#f1f1f1",
+    sidebarBackground: "#e8e8e8",
+    textColorPrimary: "#555555",
+    textColorSecondary: "#51575d",
+    borderColor: "#c9cfd3",
+    buttonPrimaryBackground: "#00a7a0",
+    contentColor: "#ffffff",
+    layoutBackground: "#e8e8e8",
+    sidebarActiveColor: "#ffffff",
+  };
+
+  const defaults = base === "light" ? lightDefaults : darkDefaults;
+  return defaults[key] || "#000000";
+}
+
+export const CustomThemeEditor = withInjectables(NonInjectedCustomThemeEditor)({
+  getProps: (di) => ({
+    state: di.inject(userPreferencesStateInjectable),
+    defaultTheme: di.inject(defaultThemeInjectable),
+  }),
+});
+
+export default CustomThemeEditor;

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/custom-theme-preference-block.injectable.ts
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/custom-theme-preference-block.injectable.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getInjectable } from "@ogre-tools/injectable";
+import { preferenceItemInjectionToken } from "../../preference-item-injection-token";
+import { CustomThemeEditor } from "./custom-theme-editor";
+
+const customThemePreferenceBlockInjectable = getInjectable({
+  id: "custom-theme-preference-item",
+
+  instantiate: () => ({
+    kind: "block" as const,
+    id: "custom-theme",
+    parentId: "application-page",
+    orderNumber: 11, // After theme selector
+    Component: CustomThemeEditor,
+  }),
+
+  injectionToken: preferenceItemInjectionToken,
+});
+
+export default customThemePreferenceBlockInjectable;

--- a/packages/core/src/features/user-preferences/common/custom-theme-colors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/custom-theme-colors.injectable.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getInjectable } from "@ogre-tools/injectable";
+import { userPreferenceDescriptorInjectionToken } from "./token";
+
+export interface CustomThemeColors {
+  primary?: string;
+  mainBackground?: string;
+  sidebarBackground?: string;
+  textColorPrimary?: string;
+  [key: string]: string | undefined;
+}
+
+export interface CustomThemePreference {
+  customThemeColors: CustomThemeColors;
+  customThemeBase: "dark" | "light";
+}
+
+const customThemeColorsPreferenceDescriptorInjectable = getInjectable({
+  id: "custom-theme-colors-preference-descriptor",
+
+  instantiate: () => ({
+    id: "customThemeColors",
+    defaultValue: {},
+    migrations: [
+      {
+        version: 1,
+        migrate: (value: unknown) => ({
+          customThemeColors: value as CustomThemeColors || {},
+          customThemeBase: "dark" as const,
+        }),
+      },
+    ],
+  }),
+
+  injectionToken: userPreferenceDescriptorInjectionToken,
+});
+
+const customThemeBasePreferenceDescriptorInjectable = getInjectable({
+  id: "custom-theme-base-preference-descriptor",
+
+  instantiate: () => ({
+    id: "customThemeBase",
+    defaultValue: "dark" as const,
+  }),
+
+  injectionToken: userPreferenceDescriptorInjectionToken,
+});
+
+export default customThemeColorsPreferenceDescriptorInjectable;
+export { customThemeBasePreferenceDescriptorInjectable };

--- a/packages/core/src/renderer/themes/custom-theme.injectable.ts
+++ b/packages/core/src/renderer/themes/custom-theme.injectable.ts
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getInjectable } from "@ogre-tools/injectable";
+import { lensThemeDeclarationInjectionToken } from "./declaration";
+import userPreferencesStateInjectable from "../../../features/user-preferences/common/state.injectable";
+
+import type { LensTheme } from "./lens-theme";
+
+const customThemeInjectable = getInjectable({
+  id: "custom-theme",
+  instantiate: (di) => {
+    const userPreferences = di.inject(userPreferencesStateInjectable);
+    
+    // Get custom colors from user preferences
+    const customColors = userPreferences.customThemeColors || {};
+    const baseTheme = userPreferences.customThemeBase || "dark";
+    
+    // Base theme colors (dark or light)
+    const baseColors = baseTheme === "light" 
+      ? getLightBaseColors() 
+      : getDarkBaseColors();
+    
+    // Merge custom colors with base colors
+    const mergedColors = { ...baseColors, ...customColors };
+    
+    const theme: LensTheme = {
+      name: "Custom",
+      type: baseTheme as "dark" | "light",
+      description: "User customized theme",
+      author: "User",
+      monacoTheme: baseTheme === "light" ? "vs" : "clouds-midnight",
+      colors: mergedColors,
+      terminalColors: {},
+      isDefault: false,
+    };
+
+    return theme;
+  },
+  
+  injectionToken: lensThemeDeclarationInjectionToken,
+});
+
+function getDarkBaseColors() {
+  return {
+    blue: "#00a7a0",
+    magenta: "#c93dce",
+    golden: "#ffc63d",
+    halfGray: "#87909c80",
+    primary: "#00a7a0",
+    textColorPrimary: "#8e9297",
+    textColorSecondary: "#a0a0a0",
+    textColorTertiary: "#909ba6",
+    textColorAccent: "#ffffff",
+    textColorDimmed: "#8e92978c",
+    borderColor: "#4c5053",
+    borderFaintColor: "#373a3e",
+    mainBackground: "#1e2124",
+    secondaryBackground: "#1e2125",
+    contentColor: "#262b2f",
+    layoutBackground: "#2e3136",
+    layoutTabsBackground: "#252729",
+    layoutTabsActiveColor: "#ffffff",
+    layoutTabsLineColor: "#87909c80",
+    sidebarBackground: "#36393e",
+    sidebarLogoBackground: "#414448",
+    sidebarActiveColor: "#ffffff",
+    sidebarSubmenuActiveColor: "#ffffff",
+    sidebarItemHoverBackground: "#3a3e44",
+    badgeBackgroundColor: "#ffba44",
+    buttonPrimaryBackground: "#00a7a0",
+    buttonDefaultBackground: "#414448",
+    buttonLightBackground: "#f1f1f1",
+    buttonAccentBackground: "#e85555",
+    buttonDisabledBackground: "#5e6165",
+    tableBgcStripe: "#2c3135",
+    tableBgcSelected: "#2c3e50",
+    tableHeaderBackground: "#36393e",
+    tableHeaderColor: "#8e9297",
+    tableSelectedRowColor: "#ffffff",
+    helmLogoBackground: "#ffffff",
+    helmStableRepo: "#00a7a0",
+    helmIncubatorRepo: "#ffc63d",
+    helmDescriptionHr: "#4c5053",
+    helmDescriptionBlockquoteColor: "#8e9297",
+    helmDescriptionBlockquoteBackground: "#2e3136",
+    helmDescriptionBlockquoteBorder: "#4c5053",
+    helmDescriptionH1: "#ffffff",
+    helmDescriptionH2: "#ffffff",
+    helmDescriptionH3: "#ffffff",
+    helmDescriptionH4: "#ffffff",
+    helmDescriptionH5: "#ffffff",
+    helmDescriptionH6: "#ffffff",
+    helmDescriptionParagraph: "#8e9297",
+    helmDescriptionListItem: "#8e9297",
+    helmDescriptionLink: "#00a7a0",
+    helmDescriptionLinkHover: "#00c4bc",
+    helmDescriptionCode: "#00a7a0",
+    helmDescriptionCodeBackground: "#2e3136",
+    helmDescriptionPre: "#8e9297",
+    helmDescriptionPreBackground: "#2e3136",
+    helmDescriptionTableBorder: "#4c5053",
+    helmDescriptionTableBackground: "#2e3136",
+    helmDescriptionTableRowEven: "#36393e",
+    helmDescriptionTableRowOdd: "#2e3136",
+    helmDescriptionTableHeader: "#36393e",
+    helmDescriptionTableHeaderColor: "#ffffff",
+    helmDescriptionTableCell: "#8e9297",
+  };
+}
+
+function getLightBaseColors() {
+  return {
+    blue: "#00a7a0",
+    magenta: "#c93dce",
+    golden: "#ffc63d",
+    halfGray: "#87909c80",
+    primary: "#00a7a0",
+    textColorPrimary: "#555555",
+    textColorSecondary: "#51575d",
+    textColorTertiary: "#555555",
+    textColorAccent: "#222222",
+    textColorDimmed: "#5557598c",
+    borderColor: "#c9cfd3",
+    borderFaintColor: "#dfdfdf",
+    mainBackground: "#f1f1f1",
+    secondaryBackground: "#f2f3f5",
+    contentColor: "#ffffff",
+    layoutBackground: "#e8e8e8",
+    layoutTabsBackground: "#f8f8f8",
+    layoutTabsActiveColor: "#333333",
+    layoutTabsLineColor: "#87909c80",
+    sidebarBackground: "#e8e8e8",
+    sidebarLogoBackground: "#f1f1f1",
+    sidebarActiveColor: "#ffffff",
+    sidebarSubmenuActiveColor: "#00a7a0",
+    sidebarItemHoverBackground: "#f0f2f5",
+    badgeBackgroundColor: "#ffba44",
+    buttonPrimaryBackground: "#00a7a0",
+    buttonDefaultBackground: "#414448",
+    buttonLightBackground: "#f1f1f1",
+    buttonAccentBackground: "#e85555",
+    buttonDisabledBackground: "#c9cfd3",
+    tableBgcStripe: "#f8f8f8",
+    tableBgcSelected: "#e3f2fd",
+    tableHeaderBackground: "#e8e8e8",
+    tableHeaderColor: "#555555",
+    tableSelectedRowColor: "#333333",
+    helmLogoBackground: "#ffffff",
+    helmStableRepo: "#00a7a0",
+    helmIncubatorRepo: "#ffc63d",
+    helmDescriptionHr: "#c9cfd3",
+    helmDescriptionBlockquoteColor: "#555555",
+    helmDescriptionBlockquoteBackground: "#f1f1f1",
+    helmDescriptionBlockquoteBorder: "#c9cfd3",
+    helmDescriptionH1: "#222222",
+    helmDescriptionH2: "#222222",
+    helmDescriptionH3: "#222222",
+    helmDescriptionH4: "#222222",
+    helmDescriptionH5: "#222222",
+    helmDescriptionH6: "#222222",
+    helmDescriptionParagraph: "#555555",
+    helmDescriptionListItem: "#555555",
+    helmDescriptionLink: "#00a7a0",
+    helmDescriptionLinkHover: "#00c4bc",
+    helmDescriptionCode: "#00a7a0",
+    helmDescriptionCodeBackground: "#f1f1f1",
+    helmDescriptionPre: "#555555",
+    helmDescriptionPreBackground: "#f1f1f1",
+    helmDescriptionTableBorder: "#c9cfd3",
+    helmDescriptionTableBackground: "#ffffff",
+    helmDescriptionTableRowEven: "#f8f8f8",
+    helmDescriptionTableRowOdd: "#ffffff",
+    helmDescriptionTableHeader: "#e8e8e8",
+    helmDescriptionTableHeaderColor: "#555555",
+    helmDescriptionTableCell: "#555555",
+  };
+}
+
+export default customThemeInjectable;


### PR DESCRIPTION
This commit adds support for custom themes, allowing users to:
- Customize theme colors through the preferences UI
- Choose between dark and light base themes
- Customize 10+ color properties including primary, background, text, and border colors
- Preview custom themes before applying
- Persist custom theme settings across sessions

Changes:
- Add custom-theme.injectable.ts for dynamic theme generation
- Add custom-theme-colors.injectable.ts for preference handling
- Add custom-theme-editor.tsx with color picker UI
- Add custom-theme-preference-block.injectable.ts to register UI component
- Add CUSTOM_THEME_IMPLEMENTATION.md documentation

Closes #1280