### PR TITLE
fix: category menu item text is hard to read

### DIFF
--- a/packages/core/src/renderer/components/catalog/catalog-tree.module.scss
+++ b/packages/core/src/renderer/components/catalog/catalog-tree.module.scss
@@ -21,6 +21,10 @@
   }
 }
 
+.selected {
+  color: white;
+}
+
 .content {
   min-height: 26px;
   line-height: 1.3;


### PR DESCRIPTION
## Description

- Text inside the active menu item in catalog menu component is quite hard to read due to poor contrast. This PR updates the text color of this component to white to increase readability.
- Environment:
  - Macbook Pro 2021 (M1 Pro)
  - MacOS Tahoe 26.3.1

## Test Evidence

Before
<img width="1624" height="1061" alt="SCR-20260320-ildj" src="https://github.com/user-attachments/assets/573416cf-8b68-4d26-b062-ad8d02d62eb5" />

After
<img width="1284" height="942" alt="SCR-20260320-ikrd" src="https://github.com/user-attachments/assets/5483664a-fc25-40ef-9c5c-640cd1805919" />
