### PR TITLE
Test only 1 extension  during integration tests on Windows

### DIFF
--- a/freelens/integration/__tests__/extensions.tests.ts
+++ b/freelens/integration/__tests__/extensions.tests.ts
@@ -30,15 +30,16 @@ describe("extensions page tests", () => {
 
   const extensions = process.env.EXTENSION_PATH
     ? [process.env.EXTENSION_PATH]
-    : [
-        "@freelensapp/example-extension",
-        "@freelensapp/example-extension@1.3.0",
-        "@freelensapp/extension-example@1.2.0",
-        "@freelensapp/extension-example@1.0.0",
-        "@freelensapp/freelens-node-pod-menu",
-        "@freelensapp/freelens-node-pod-menu@1.1.0",
-        "@freelensapp/freelens-node-pod-menu@1.0.0",
-      ];
+    : process.platform === "win32"
+      ? ["@freelensapp/example-extension"]
+      : [
+          "@freelensapp/example-extension",
+          "@freelensapp/example-extension@1.8.0",
+          "@freelensapp/example-extension@1.6.2",
+          "@freelensapp/example-extension@1.5.3",
+          "@freelensapp/example-extension@1.4.2",
+          "@freelensapp/example-extension@1.3.0",
+        ];
 
   it.each(extensions)(
     "installs an extension %s",

--- a/packages/generate-license/src/index.js
+++ b/packages/generate-license/src/index.js
@@ -8,6 +8,7 @@
 
 import { getDependencies, getLicenseText } from "@quantco/pnpm-licenses/dist/api.mjs";
 import fs from "fs/promises";
+import path from "path";
 import spdxLicenseList from "spdx-license-list/full.js";
 
 function parseArgs() {
@@ -24,15 +25,63 @@ function parseArgs() {
 }
 
 async function getDependenciesFromPnpmApi(prod) {
-  return await getDependencies(
-    { prod },
-    {
-      stdin: false,
-      inputFile: undefined,
-      stdout: true,
-      outputFile: undefined,
-    },
-  );
+  const previousStoreDir = process.env.npm_config_store_dir;
+
+  if (previousStoreDir?.trim()) {
+    process.env.npm_config_store_dir = await normalizeStoreDir(previousStoreDir.trim());
+  }
+
+  try {
+    return await getDependencies(
+      { prod },
+      {
+        stdin: false,
+        inputFile: undefined,
+        stdout: true,
+        outputFile: undefined,
+      },
+    );
+  } finally {
+    if (previousStoreDir === undefined) {
+      delete process.env.npm_config_store_dir;
+    } else {
+      process.env.npm_config_store_dir = previousStoreDir;
+    }
+  }
+}
+
+async function findProjectTopDir() {
+  let currentDir = process.cwd();
+
+  while (true) {
+    const workspaceConfigPath = path.join(currentDir, "pnpm-workspace.yaml");
+
+    try {
+      await fs.access(workspaceConfigPath);
+
+      return currentDir;
+    } catch {
+      // Keep walking up the directory tree.
+    }
+
+    const parentDir = path.dirname(currentDir);
+
+    if (parentDir === currentDir) {
+      return process.cwd();
+    }
+
+    currentDir = parentDir;
+  }
+}
+
+async function normalizeStoreDir(storeDir) {
+  if (path.isAbsolute(storeDir)) {
+    return storeDir;
+  }
+
+  const projectTopDir = await findProjectTopDir();
+
+  return path.resolve(projectTopDir, storeDir);
 }
 
 async function main() {

--- a/packages/generate-license/src/index.js
+++ b/packages/generate-license/src/index.js
@@ -7,14 +7,8 @@
  */
 
 import { getDependencies, getLicenseText } from "@quantco/pnpm-licenses/dist/api.mjs";
-import { execFile } from "child_process";
 import fs from "fs/promises";
-import os from "os";
-import path from "path";
 import spdxLicenseList from "spdx-license-list/full.js";
-import { promisify } from "util";
-
-const execFileAsync = promisify(execFile);
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -29,105 +23,16 @@ function parseArgs() {
   };
 }
 
-function parseStoreDirFromModulesYaml(content) {
-  try {
-    const parsed = JSON.parse(content);
-
-    if (parsed && typeof parsed.storeDir === "string" && parsed.storeDir.trim()) {
-      return parsed.storeDir.trim();
-    }
-  } catch {
-    // .modules.yaml can be YAML or JSON; use a text fallback when JSON parse fails.
-  }
-
-  const yamlMatch = content.match(/^\s*storeDir:\s*["']?(.+?)["']?\s*$/m);
-
-  return yamlMatch?.[1]?.trim() ?? null;
-}
-
-async function detectStoreDirFromInstalledModules() {
-  let currentDir = process.cwd();
-
-  while (true) {
-    const modulesYamlPath = path.join(currentDir, "node_modules", ".modules.yaml");
-
-    try {
-      const modulesYamlContent = await fs.readFile(modulesYamlPath, "utf8");
-      const detectedStoreDir = parseStoreDirFromModulesYaml(modulesYamlContent);
-
-      if (detectedStoreDir) {
-        return detectedStoreDir;
-      }
-    } catch {
-      // Keep walking up the directory tree.
-    }
-
-    const parentDir = path.dirname(currentDir);
-
-    if (parentDir === currentDir) {
-      return null;
-    }
-
-    currentDir = parentDir;
-  }
-}
-
-async function detectPnpmStoreDir() {
-  const detectedFromModules = await detectStoreDirFromInstalledModules();
-
-  if (detectedFromModules) {
-    return detectedFromModules;
-  }
-
-  const envStoreDir = process.env.npm_config_store_dir;
-
-  if (envStoreDir?.trim()) {
-    return envStoreDir.trim();
-  }
-
-  const { stdout: configStoreDir } = await execFileAsync("pnpm", ["config", "get", "store-dir", "--json"]);
-  const parsedConfigStoreDir = JSON.parse(configStoreDir);
-
-  if (typeof parsedConfigStoreDir === "string" && parsedConfigStoreDir.trim()) {
-    return parsedConfigStoreDir.trim();
-  }
-
-  const { stdout: storePath } = await execFileAsync("pnpm", ["store", "path", "--silent"]);
-
-  if (!storePath.trim()) {
-    throw new Error("Could not detect pnpm store directory");
-  }
-
-  return storePath.trim();
-}
-
-async function getDependenciesUsingDetectedStoreDir(prod) {
-  const storeDir = await detectPnpmStoreDir();
-  const licensesArgs = [`--config.store-dir=${storeDir}`, "licenses", "list", "--json"];
-
-  if (prod) {
-    licensesArgs.splice(licensesArgs.length - 1, 0, "--prod");
-  }
-
-  const { stdout: dependenciesJson } = await execFileAsync("pnpm", licensesArgs, { maxBuffer: 1024 * 1024 * 64 });
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "generate-license-"));
-  const inputFile = path.join(tempDir, "dependencies.json");
-
-  try {
-    await fs.writeFile(inputFile, dependenciesJson, "utf8");
-
-    return await getDependencies(
-      { prod },
-      {
-        stdin: false,
-        inputFile,
-        stdout: true,
-        outputFile: undefined,
-      },
-    );
-  } finally {
-    await fs.rm(tempDir, { recursive: true, force: true });
-  }
+async function getDependenciesFromPnpmApi(prod) {
+  return await getDependencies(
+    { prod },
+    {
+      stdin: false,
+      inputFile: undefined,
+      stdout: true,
+      outputFile: undefined,
+    },
+  );
 }
 
 async function main() {
@@ -145,7 +50,7 @@ async function main() {
     },
   };
 
-  const npmDependencies = await getDependenciesUsingDetectedStoreDir(prod);
+  const npmDependencies = await getDependenciesFromPnpmApi(prod);
 
   const fixedDepdencies = [];
 


### PR DESCRIPTION
Instalation of extensions is flacky on Windows so let's skip all but the latests version of the extension.

Also fixes regression in #1812 by avoiding spawning pnpm command with just patching an environment variable for pnpm.