### PR TITLE
Prometheus request method in settings

### DIFF
--- a/packages/core/src/common/cluster-types.ts
+++ b/packages/core/src/common/cluster-types.ts
@@ -111,6 +111,8 @@ export interface ClusterPreferences extends ClusterPrometheusPreferences {
  * A cluster's prometheus settings (a subset of cluster settings)
  */
 export interface ClusterPrometheusPreferences {
+  /** HTTP method for Prometheus query_range requests; defaults to POST */
+  prometheusRequestMethod?: "GET" | "POST";
   prometheus?: {
     namespace: string;
     service: string;

--- a/packages/core/src/main/get-metrics.injectable.ts
+++ b/packages/core/src/main/get-metrics.injectable.ts
@@ -29,9 +29,11 @@ async function fetchDirectMetrics(
   cluster: Cluster,
   prometheusPrefix: string,
   directUrl: string,
+  requestMethod: "GET" | "POST",
   params: URLSearchParams,
 ): Promise<unknown> {
-  const url = `${directUrl.replace(/\/+$/, "")}${prometheusPrefix}/api/v1/query_range?${params.toString()}`;
+  const queryRangePath = `${directUrl.replace(/\/+$/, "")}${prometheusPrefix}/api/v1/query_range`;
+  const url = requestMethod === "GET" ? `${queryRangePath}?${params.toString()}` : queryRangePath;
   const headers: Record<string, string> = {};
   const bearerToken = cluster.preferences.prometheus?.bearerToken;
 
@@ -39,13 +41,18 @@ async function fetchDirectMetrics(
     headers.Authorization = `Bearer ${bearerToken}`;
   }
 
+  if (requestMethod === "POST") {
+    headers["Content-Type"] = "application/x-www-form-urlencoded;charset=UTF-8";
+  }
+
   const response = await proxyFetch(url, {
-    method: "GET",
+    method: requestMethod,
     headers,
+    body: requestMethod === "POST" ? params.toString() : undefined,
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to GET ${url} for clusterId=${cluster.id}: ${response.statusText}`, {
+    throw new Error(`Failed to ${requestMethod} ${url} for clusterId=${cluster.id}: ${response.statusText}`, {
       cause: response,
     });
   }
@@ -62,6 +69,7 @@ const getMetricsInjectable = getInjectable({
 
     return async (cluster, prometheusPath, queryParams) => {
       const prometheusPrefix = cluster.preferences.prometheus?.prefix || "";
+      const requestMethod = cluster.preferences.prometheusRequestMethod === "GET" ? "GET" : "POST";
       const params = new URLSearchParams();
 
       for (const [key, value] of object.entries(queryParams)) {
@@ -71,14 +79,25 @@ const getMetricsInjectable = getInjectable({
       const directUrl = cluster.preferences.prometheus?.directUrl;
 
       if (directUrl) {
-        return fetchDirectMetrics(proxyFetch, cluster, prometheusPrefix, directUrl, params);
+        return fetchDirectMetrics(proxyFetch, cluster, prometheusPrefix, directUrl, requestMethod, params);
       }
 
-      const metricsPath = `/api/v1/namespaces/${prometheusPath}/proxy${prometheusPrefix}/api/v1/query_range?${params.toString()}`;
+      const queryRangePath = `/api/v1/namespaces/${prometheusPath}/proxy${prometheusPrefix}/api/v1/query_range`;
 
-      return k8sRequest(cluster, metricsPath, {
+      if (requestMethod === "GET") {
+        return k8sRequest(cluster, `${queryRangePath}?${params.toString()}`, {
+          timeout: 0,
+          method: "GET",
+        });
+      }
+
+      return k8sRequest(cluster, queryRangePath, {
         timeout: 0,
-        method: "GET",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        },
+        body: params.toString(),
       });
     };
   },

--- a/packages/core/src/renderer/components/cluster-settings/prometheus-setting.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/prometheus-setting.tsx
@@ -26,6 +26,7 @@ import type {
 import type { SelectOption } from "../select";
 
 type PrometheusConfig = NonNullable<ClusterPrometheusPreferences["prometheus"]>;
+type PrometheusRequestMethod = NonNullable<ClusterPrometheusPreferences["prometheusRequestMethod"]>;
 
 function buildPrometheusConfig(
   parsed: string[],
@@ -58,6 +59,19 @@ interface Dependencies {
   requestMetricsProviders: RequestMetricsProviders;
 }
 
+const requestMethodOptions: SelectOption<PrometheusRequestMethod>[] = [
+  {
+    value: "POST",
+    label: "POST",
+    isSelected: true,
+  },
+  {
+    value: "GET",
+    label: "GET",
+    isSelected: false,
+  },
+];
+
 @observer
 class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometheusSettingProps & Dependencies> {
   @observable mountpoints = "";
@@ -66,6 +80,7 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
   @observable useHttps = false; // whether to use https scheme for service proxy
   @observable directUrl = ""; // direct URL to Prometheus (bypasses K8s service proxy)
   @observable bearerToken = ""; // bearer token for Prometheus authentication
+  @observable requestMethod: PrometheusRequestMethod = "POST";
   @observable selectedOption: ProviderValue = autoDetectPrometheus;
   @observable loading = true;
   readonly initialFilesystemMountpoints = initialFilesystemMountpoints;
@@ -107,7 +122,8 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
     disposeOnUnmount(
       this,
       autorun(() => {
-        const { prometheus, prometheusProvider, filesystemMountpoints } = this.props.cluster.preferences;
+        const { prometheus, prometheusProvider, filesystemMountpoints, prometheusRequestMethod } =
+          this.props.cluster.preferences;
 
         if (prometheus) {
           const prefix = prometheus.prefix || "";
@@ -127,6 +143,8 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
           this.directUrl = "";
           this.bearerToken = "";
         }
+
+        this.requestMethod = prometheusRequestMethod === "GET" ? "GET" : "POST";
 
         if (prometheusProvider) {
           this.selectedOption =
@@ -190,6 +208,10 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
 
   onSaveMountpoints = () => {
     this.props.cluster.preferences.filesystemMountpoints = this.mountpoints;
+  };
+
+  onSaveRequestMethod = () => {
+    this.props.cluster.preferences.prometheusRequestMethod = this.requestMethod;
   };
 
   render() {
@@ -309,6 +331,27 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
           </>
         )}
         <>
+          <hr />
+          <section>
+            <SubTitle title="Prometheus request method" />
+            <Select
+              id="cluster-prometheus-request-method-input"
+              value={this.requestMethod}
+              onChange={(option) => {
+                this.requestMethod = option?.value ?? "POST";
+                this.onSaveRequestMethod();
+              }}
+              options={requestMethodOptions.map((option) => ({
+                ...option,
+                isSelected: option.value === this.requestMethod,
+              }))}
+              themeName="lens"
+            />
+            <small className="hint">
+              Select how metrics queries are sent to Prometheus. Default is POST. Switch to GET only when your
+              Prometheus/proxy setup requires it.
+            </small>
+          </section>
           <hr />
           <section>
             <SubTitle title="Filesystem mountpoints" />


### PR DESCRIPTION
This pull request introduces support for configuring the HTTP request method (GET or POST) used for Prometheus `query_range` API calls per cluster. By default, POST is used, but users can now select GET if required by their Prometheus or proxy setup. The change includes both backend logic and a new UI option in the cluster settings.

It reverts #1786 and adds an explicit setting instead to switch between GET and POST instead.

The reason is that GET method might be broken because of LB/proxy and break with 414 URL too long error or yet another so POST should stay as the default method.
