### PR TITLE
Add correct formatting for IPv6:Port tuple

### DIFF
--- a/packages/kube-object/src/specifics/endpoint.ts
+++ b/packages/kube-object/src/specifics/endpoint.ts
@@ -22,7 +22,21 @@ export function formatEndpointSubset(subset: EndpointSubset): string {
     return "";
   }
 
-  return addresses.map((address) => ports.map((port) => `${address.ip}:${port.port}`).join(", ")).join(", ");
+  return addresses
+    .map((address) =>
+      ports
+        .map((port) => {
+          // IPv6 addresses contain `:`s and to keep separation with the actual port
+          // it's supposed to be formatted `[IP]:PORT` when together in a tuple with a port
+          if (address.ip.indexOf(":") !== -1) {
+            return `[${address.ip}]:${port.port}`;
+          }
+
+          return `${address.ip}:${port.port}`;
+        })
+        .join(", "),
+    )
+    .join(", ");
 }
 
 export interface ForZone {


### PR DESCRIPTION
This implements proper IPv6:Port tuple formatting for the Endpoints listing, making it much easier to read them in the listing. IPv4 endpoints are still displayed as usual. 

I could not find any other places which show IP:Port tuples but if anyone knows of places I should check feel free to mention it.