### PR TITLE
Support pod-level resize edits

### DIFF
--- a/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
+++ b/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
@@ -22,11 +22,13 @@ import kubeconfigSyncsInjectable from "../../../features/user-preferences/common
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import kubeconfigManagerInjectable from "../../kubeconfig-manager/kubeconfig-manager.injectable";
 import computeKubeconfigDiffInjectable from "../kubeconfig-sync/compute-diff.injectable";
+import kubeconfigSyncLoggerInjectable from "../kubeconfig-sync/logger.injectable";
 import configToModelsInjectable from "../kubeconfig-sync/config-to-models.injectable";
 import kubeconfigSyncManagerInjectable from "../kubeconfig-sync/manager.injectable";
 import type { ReadStream, Stats } from "fs";
 
 import type { AsyncFnMock } from "@async-fn/jest";
+import type { Logger } from "@freelensapp/logger";
 import type { DiContainer } from "@ogre-tools/injectable";
 
 import type { CatalogEntity } from "../../../common/catalog";
@@ -493,6 +495,47 @@ describe("kubeconfig-sync.source tests", () => {
             });
           });
         });
+      });
+    });
+  });
+
+  describe("when a sync target does not exist", () => {
+    let manager: KubeconfigSyncManager;
+    let watchMock: jest.Mock;
+    let logger: jest.Mocked<Pick<Logger, "debug" | "warn" | "info" | "error">>;
+
+    beforeEach(() => {
+      logger = {
+        debug: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn(),
+      };
+
+      watchMock = jest.fn(() => getFakeWatchInstance());
+
+      di.override(kubeconfigSyncLoggerInjectable, () => logger as unknown as Logger);
+      di.override(statInjectable, () => async () => {
+        throw Object.assign(new Error("missing"), {
+          code: "ENOENT",
+        });
+      });
+      di.override(watchInjectable, () => watchMock);
+
+      manager = di.inject(kubeconfigSyncManagerInjectable);
+      manager.startSync();
+    });
+
+    it("skips missing paths without warning", async () => {
+      kubeconfigSyncs.set("/missing/config", {});
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(watchMock).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.debug).toHaveBeenCalledWith("skipping missing file/folder", {
+        filePath: "/missing/config",
       });
     });
   });

--- a/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
+++ b/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
@@ -22,13 +22,14 @@ import kubeconfigSyncsInjectable from "../../../features/user-preferences/common
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import kubeconfigManagerInjectable from "../../kubeconfig-manager/kubeconfig-manager.injectable";
 import computeKubeconfigDiffInjectable from "../kubeconfig-sync/compute-diff.injectable";
-import kubeconfigSyncLoggerInjectable from "../kubeconfig-sync/logger.injectable";
 import configToModelsInjectable from "../kubeconfig-sync/config-to-models.injectable";
+import kubeconfigSyncLoggerInjectable from "../kubeconfig-sync/logger.injectable";
 import kubeconfigSyncManagerInjectable from "../kubeconfig-sync/manager.injectable";
 import type { ReadStream, Stats } from "fs";
 
-import type { AsyncFnMock } from "@async-fn/jest";
 import type { Logger } from "@freelensapp/logger";
+
+import type { AsyncFnMock } from "@async-fn/jest";
 import type { DiContainer } from "@ogre-tools/injectable";
 
 import type { CatalogEntity } from "../../../common/catalog";
@@ -501,10 +502,14 @@ describe("kubeconfig-sync.source tests", () => {
 
   describe("when a sync target does not exist", () => {
     let manager: KubeconfigSyncManager;
+    let localDi: DiContainer;
+    let localKubeconfigSyncs: ObservableMap<string, KubeconfigSyncValue>;
     let watchMock: jest.Mock;
     let logger: jest.Mocked<Pick<Logger, "debug" | "warn" | "info" | "error">>;
 
     beforeEach(() => {
+      localDi = getDiForUnitTesting();
+      localKubeconfigSyncs = observable.map();
       logger = {
         debug: jest.fn(),
         warn: jest.fn(),
@@ -514,20 +519,21 @@ describe("kubeconfig-sync.source tests", () => {
 
       watchMock = jest.fn(() => getFakeWatchInstance());
 
-      di.override(kubeconfigSyncLoggerInjectable, () => logger as unknown as Logger);
-      di.override(statInjectable, () => async () => {
+      localDi.override(kubeconfigSyncsInjectable, () => localKubeconfigSyncs);
+      localDi.override(kubeconfigSyncLoggerInjectable, () => logger as unknown as Logger);
+      localDi.override(statInjectable, () => async () => {
         throw Object.assign(new Error("missing"), {
           code: "ENOENT",
         });
       });
-      di.override(watchInjectable, () => watchMock);
+      localDi.override(watchInjectable, () => watchMock);
 
-      manager = di.inject(kubeconfigSyncManagerInjectable);
+      manager = localDi.inject(kubeconfigSyncManagerInjectable);
       manager.startSync();
     });
 
     it("skips missing paths without warning", async () => {
-      kubeconfigSyncs.set("/missing/config", {});
+      localKubeconfigSyncs.set("/missing/config", {});
 
       await Promise.resolve();
       await Promise.resolve();

--- a/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
+++ b/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
@@ -519,6 +519,8 @@ describe("kubeconfig-sync.source tests", () => {
 
       watchMock = jest.fn(() => getFakeWatchInstance());
 
+      localDi.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");
+      localDi.override(directoryForTempInjectable, () => "/some-directory-for-temp");
       localDi.override(kubeconfigSyncsInjectable, () => localKubeconfigSyncs);
       localDi.override(kubeconfigSyncLoggerInjectable, () => logger as unknown as Logger);
       localDi.override(statInjectable, () => async () => {

--- a/packages/core/src/main/catalog-sources/kubeconfig-sync/watch-file-changes.injectable.ts
+++ b/packages/core/src/main/catalog-sources/kubeconfig-sync/watch-file-changes.injectable.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { getOrInsertWith, iter } from "@freelensapp/utilities";
+import { getOrInsertWith, isErrnoException, iter } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import GlobToRegExp from "glob-to-regexp";
 import { computed, observable } from "mobx";
@@ -147,6 +147,10 @@ const watchKubeconfigFileChangesInjectable = getInjectable({
             })
             .on("error", (error) => logger.error(`watching file/folder failed: ${error}`, { filePath }));
         } catch (error) {
+          if (isErrnoException(error) && error.code === "ENOENT") {
+            return void logger.debug(`skipping missing file/folder`, { filePath });
+          }
+
           logger.warn(`failed to start watching changes: ${error}`);
         }
       })();

--- a/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
@@ -72,6 +72,7 @@ interface PodResizePatchContainer {
 
 type PodResizePatchPayload = Record<string, unknown> & {
   spec: {
+    resources?: PodSpec["resources"];
     containers?: PodResizePatchContainer[];
     initContainers?: PodResizePatchContainer[];
   };
@@ -91,7 +92,7 @@ type PatchRequest =
     };
 
 function isPodResourcePath(path: string) {
-  return /^\/spec\/(?:containers|initContainers)\/\d+\/resources(?:\/.*)?$/.test(path);
+  return /^\/spec\/(?:resources(?:\/.*)?|(?:containers|initContainers)\/\d+\/resources(?:\/.*)?)$/.test(path);
 }
 
 function isPod(object: RawKubeObject) {
@@ -108,6 +109,7 @@ function getPodResizePatchContainer(container: Container): PodResizePatchContain
 function getPodResizePatchPayload(object: PodEditResource): PodResizePatchPayload {
   return {
     spec: {
+      resources: object.spec?.resources,
       containers: object.spec?.containers?.map(getPodResizePatchContainer),
       initContainers: object.spec?.initContainers?.map(getPodResizePatchContainer),
     },

--- a/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.test.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.test.tsx
@@ -148,6 +148,79 @@ spec:
     );
   });
 
+  it("uses the resize subresource when only pod-level resources change", async () => {
+    const firstDraft = `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+  resourceVersion: "1"
+  selfLink: ${selfLink}
+spec:
+  containers:
+    - name: main
+      image: nginx:1.0
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+`;
+    const draft = `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+  resourceVersion: "1"
+  selfLink: ${selfLink}
+spec:
+  containers:
+    - name: main
+      image: nginx:1.0
+  resources:
+    requests:
+      cpu: 150m
+      memory: 128Mi
+    limits:
+      cpu: 300m
+      memory: 256Mi
+`;
+    const { model, requestPatchKubeResource } = createModel(firstDraft, draft);
+
+    await model.save();
+
+    expect(requestPatchKubeResource).toHaveBeenCalledWith(
+      selfLink,
+      {
+        spec: {
+          resources: {
+            requests: {
+              cpu: "150m",
+              memory: "128Mi",
+            },
+            limits: {
+              cpu: "300m",
+              memory: "256Mi",
+            },
+          },
+          containers: [
+            {
+              name: "main",
+              resources: undefined,
+            },
+          ],
+          initContainers: undefined,
+        },
+      },
+      {
+        strategy: "strategic",
+        subResource: "resize",
+      },
+    );
+  });
+
   it("keeps normal json patching for non-resource pod edits", async () => {
     const firstDraft = `apiVersion: v1
 kind: Pod
@@ -221,6 +294,47 @@ spec:
       resources:
         requests:
           cpu: 200m
+`;
+    const { model, requestPatchKubeResource } = createModel(firstDraft, draft);
+
+    await model.save();
+
+    expect(requestPatchKubeResource).not.toHaveBeenCalled();
+    expect(renderToStaticMarkup(showErrorNotification.mock.calls[0][0] as React.ReactElement)).toContain(
+      "Pod resource updates must be saved separately from other pod changes",
+    );
+  });
+
+  it("rejects pod edits that mix pod-level resource resizing with other changes", async () => {
+    const firstDraft = `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+  resourceVersion: "1"
+  selfLink: ${selfLink}
+spec:
+  containers:
+    - name: main
+      image: nginx:1.0
+  resources:
+    requests:
+      cpu: 100m
+`;
+    const draft = `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+  resourceVersion: "1"
+  selfLink: ${selfLink}
+spec:
+  containers:
+    - name: main
+      image: nginx:1.1
+  resources:
+    requests:
+      cpu: 200m
 `;
     const { model, requestPatchKubeResource } = createModel(firstDraft, draft);
 

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
@@ -154,7 +154,9 @@ describe("LogSearch tests", () => {
       toString: () => "hello",
     } as Selection);
 
-    window.dispatchEvent(new KeyboardEvent("keydown", eventInit));
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", eventInit));
+    });
 
     expect(await screen.findByPlaceholderText("Search...")).toHaveValue("hello");
     expect(scrollToOverlay).toHaveBeenCalled();
@@ -189,7 +191,9 @@ describe("LogSearch tests", () => {
       toString: () => "hello",
     } as Selection);
 
-    window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true }));
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true }));
+    });
 
     expect(search).toHaveValue("o");
   });
@@ -222,7 +226,9 @@ describe("LogSearch tests", () => {
       toString: () => "",
     } as Selection);
 
-    window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true }));
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true }));
+    });
 
     expect(search).toHaveValue("o");
   });


### PR DESCRIPTION
https://kubernetes.io/blog/2026/04/27/kubernetes-v1-36-mutable-pod-resources-for-suspended-jobs/

To test:
```
apiVersion: v1
kind: Pod
metadata:
  name: shared-pool-app
  namespace: default
spec:
  volumes:
  - name: kube-api-access-8x8v9
    projected:
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          name: kube-root-ca.crt
          items:
          - key: ca.crt
            path: ca.crt
      - downwardAPI:
          items:
          - path: namespace
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
      defaultMode: 420
  containers:
  - name: main-app
    image: busybox
    command: ["sleep"]
    args: ["infinity"]
    resources: {}
    resizePolicy:
    - resourceName: cpu
      restartPolicy: NotRequired
    volumeMounts:
    - name: kube-api-access-8x8v9
      readOnly: true
      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    imagePullPolicy: IfNotPresent
  - name: sidecar
    image: busybox
    command: ["sleep"]
    args: ["infinity"]
    resources: {}
    resizePolicy:
    - resourceName: cpu
      restartPolicy: NotRequired
    volumeMounts:
    - name: kube-api-access-8x8v9
      readOnly: true
      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    imagePullPolicy: IfNotPresent
  restartPolicy: Always
  terminationGracePeriodSeconds: 30
  dnsPolicy: ClusterFirst
  serviceAccountName: default
  serviceAccount: default
  nodeName: gke-trial-cheap-cluster-default-pool-841f2a62-numw
  securityContext: {}
  schedulerName: default-scheduler
  tolerations:
  - key: node.kubernetes.io/not-ready
    operator: Exists
    effect: NoExecute
    tolerationSeconds: 300
  - key: node.kubernetes.io/unreachable
    operator: Exists
    effect: NoExecute
    tolerationSeconds: 300
  priority: 0
  enableServiceLinks: true
  preemptionPolicy: PreemptLowerPriority
  resources:
    limits:
      cpu: 200m
      memory: 200Mi
    requests:
      cpu: 200m
      memory: 200Mi
```

Than edit limits:
<img width="897" height="1113" alt="Screenshot From 2026-05-04 13-56-40" src="https://github.com/user-attachments/assets/c90b6ef5-6ffd-45d9-a714-7e8d47b09d06" />
Resut:
<img width="897" height="1113" alt="Screenshot From 2026-05-04 13-57-11" src="https://github.com/user-attachments/assets/88042047-451a-4914-867d-fc8409a571f0" />



## Summary
- detect pod-level spec.resources edits when deciding whether to use the pod resize subresource
- include pod-level resources in the strategic patch payload sent to Kubernetes
- cover pod-level-only and mixed pod edits in the edit resource model tests
