### PR TITLE
CI: Use Ubuntu on arm64 for standard workflows

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "python3 -c \"\nimport json, sys, re\ninput_data = json.load(sys.stdin)\ntool = input_data.get('tool_name', '')\nparams = input_data.get('tool_input', {})\npath = params.get('filePath', params.get('path', ''))\npatterns = [\n    r'(^|/)\\.env$',\n    r'(^|/)\\.env\\.',\n    r'\\.npmrc$',\n    r'\\.keystore$',\n    r'\\.p12$',\n    r'\\.pfx$',\n    r'\\.pem$',\n    r'\\.key$',\n    r'settings-security\\.xml$',\n    r'serviceAccountKey\\.json$',\n    r'credentials\\.json$',\n    r'heapdump\\.hprof$',\n    r'hs_err_pid\\d*\\.log$'\n]\nif any(re.search(p, path) for p in patterns):\n    print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'deny', 'permissionDecisionReason': 'Sensitive file excluded for security: ' + path}}))\n    sys.exit(0)\nprint(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow'}}))\n\""
+      }
+    ]
+  }
+}

--- a/.github/workflows/biome-migrate.yaml
+++ b/.github/workflows/biome-migrate.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/biome-migrate.yaml
+++ b/.github/workflows/biome-migrate.yaml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     environment: automated

--- a/.github/workflows/cleanup-cache.yaml
+++ b/.github/workflows/cleanup-cache.yaml
@@ -14,7 +14,7 @@ jobs:
   cleanup-cache:
     name: cleanup cache
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Cleanup cache

--- a/.github/workflows/di-registration.yaml
+++ b/.github/workflows/di-registration.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/di-registration.yaml
+++ b/.github/workflows/di-registration.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 15

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - runs-on: ubuntu-24.04-arm
+          # - runs-on: ubuntu-24.04
           #   os: linux
           #   arch: x64
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - runs-on: ubuntu-24.04
+          # - runs-on: ubuntu-24.04-arm
           #   os: linux
           #   arch: x64
 

--- a/.github/workflows/knip.yaml
+++ b/.github/workflows/knip.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/knip.yaml
+++ b/.github/workflows/knip.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 15

--- a/.github/workflows/kubectl-versions.yaml
+++ b/.github/workflows/kubectl-versions.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/kubectl-versions.yaml
+++ b/.github/workflows/kubectl-versions.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     environment: automated

--- a/.github/workflows/npm-audit.yaml
+++ b/.github/workflows/npm-audit.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/npm-audit.yaml
+++ b/.github/workflows/npm-audit.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     environment: automated

--- a/.github/workflows/npm-dedupe.yaml
+++ b/.github/workflows/npm-dedupe.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/npm-dedupe.yaml
+++ b/.github/workflows/npm-dedupe.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     environment: automated

--- a/.github/workflows/npm-licenses.yaml
+++ b/.github/workflows/npm-licenses.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 60

--- a/.github/workflows/npm-licenses.yaml
+++ b/.github/workflows/npm-licenses.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/npm-version.yaml
+++ b/.github/workflows/npm-version.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     environment: automated

--- a/.github/workflows/npm-version.yaml
+++ b/.github/workflows/npm-version.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
     permissions: write-all
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm$
     timeout-minutes: 360
 
     steps:
@@ -45,10 +45,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm$
             arch: arm64
             concurrency: linux-arm64
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm$
             arch: x64
             concurrency: linux-amd64
           - runs-on: macos-14
@@ -415,7 +415,7 @@ jobs:
       - make-draft-release
       - build-app
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm$
 
     steps:
       - name: Checkout
@@ -438,7 +438,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm$
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}
@@ -536,7 +536,7 @@ jobs:
       - make-draft-release
       - publish-github-release
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm$
     environment: apt-signing
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -431,7 +431,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     environment: publishing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
     permissions: write-all
 
-    runs-on: ubuntu-24.04-arm$
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 360
 
     steps:
@@ -45,24 +45,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04-arm$
+          - runs-on: ubuntu-24.04
+            os: linux
+            arch: x64
+            concurrency: linux-x64
+
+          - runs-on: ubuntu-24.04-arm
+            os: linux
             arch: arm64
             concurrency: linux-arm64
-          - runs-on: ubuntu-24.04-arm$
-            arch: x64
-            concurrency: linux-amd64
-          - runs-on: macos-14
+
+          - runs-on: macos-15
+            os: macos
             arch: arm64
-            concurrency: macos
-          - runs-on: macos-14
+            concurrency: macos-arm64
+
+          - runs-on: macos-15-intel
+            os: macos
             arch: x64
-            concurrency: macos
-          - runs-on: windows-2022
+            concurrency: macos-x64
+
+          - runs-on: windows-11-arm
+            os: windows
             arch: arm64
             concurrency: windows-arm64
-          - runs-on: windows-2022
+
+          - runs-on: windows-2025
+            os: windows
             arch: x64
-            concurrency: windows-amd64
+            concurrency: windows-x64
 
     runs-on: ${{ matrix.runs-on }}
     environment: signing
@@ -79,13 +90,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get -q update
-          sudo apt-get -q install -y --no-install-recommends \
-            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
@@ -186,20 +190,8 @@ jobs:
           mkdir -p $ELECTRON_HEADERS_CACHE
           curl -sSfL https://www.electronjs.org/headers/v$electron_version/node-v$electron_version-headers.tar.gz -o $ELECTRON_HEADERS_CACHE/node-v$electron_version-headers.tar.gz
 
-      - name: Enable downloading for all architectures (macOS x64, Linux arm64, Windows arm64)
-        if: runner.os == 'macOS' && matrix.arch == 'x64' || runner.os == 'Linux' && matrix.arch == 'arm64' || runner.os == 'Windows' && matrix.arch == 'arm64'
-        shell: bash
-        run: |
-          echo "DOWNLOAD_ALL_ARCHITECTURES=true" >> $GITHUB_ENV
-
       - name: Build packages
         run: pnpm --color=always --stream build
-
-      - name: Set cross-complilation environment (Linux arm64)
-        if: runner.os == 'Linux' && matrix.arch == 'arm64'
-        run: |
-          echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
 
       - name: Rebuild native packages for Electron
         run: pnpm --color=always electron-rebuild -a ${{ matrix.arch }}
@@ -415,7 +407,7 @@ jobs:
       - make-draft-release
       - build-app
 
-    runs-on: ubuntu-24.04-arm$
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout
@@ -438,7 +430,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04-arm$
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}
@@ -536,7 +528,7 @@ jobs:
       - make-draft-release
       - publish-github-release
 
-    runs-on: ubuntu-24.04-arm$
+    runs-on: ubuntu-24.04-arm
     environment: apt-signing
 
     steps:

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -19,7 +19,7 @@ jobs:
   create-tag:
     name: tag
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     environment: automated
     timeout-minutes: 10
 

--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -16,7 +16,7 @@ jobs:
   trunk:
     name: Trunk Check
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
 
     env:

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     environment: automated

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04-arm
-            arch: x64
+            arch: arm64
 
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 60

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
             arch: x64
 
     runs-on: ${{ matrix.runs-on }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 This guide helps AI agents understand the Freelens codebase, common development tasks, troubleshooting patterns, and key architectural decisions. Use this as a reference when working on the project.
 
+For local development environment setup and extra development tips, see DEVELOPMENT.md.
+
 - **`freelens/`** - Main Electron application
   - `src/main/` - Main Electron process code
   - `src/renderer/` - Renderer process (UI) code
@@ -14,6 +16,20 @@ This guide helps AI agents understand the Freelens codebase, common development 
   - `src/extensions/` - Extension system
 - **`packages/`** - Monorepo packages (utilities, components, etc.)
 - **`scripts/`** - Build and development scripts
+
+## Security
+
+Never read, display, reference, or include the contents of the following files in any response or context, even if they are open in the editor:
+
+- `.env`
+- `.env.*`
+- `.npmrc`
+- `*.jks`
+- `*.keystore`
+- `*.p12`
+- `*.pfx`
+- `*.pem`
+- `*.key`
 
 ## Build System
 
@@ -188,6 +204,9 @@ Uses pnpm workspaces for:
 4. **Use semantic search** to find examples in codebase
 5. **Follow existing patterns** - grep for similar implementations
 6. **Test changes** before committing
+7. **Run validation after file changes (especially before commit):** run `trunk check` (or `pnpm trunk check` if `trunk` is not installed locally)
+8. **For main project TypeScript and HTML files:** run `biome check` directly (or `pnpm biome check` if `biome` is not installed locally)
+9. **For other file types:** use `trunk check` (or `pnpm trunk check` if `trunk` is not installed locally)
 
 ## Getting Help
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Project Guidelines
+
+For this repository, use AGENTS.md as the canonical agent guide. Read AGENTS.md first for compatibility.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -75,7 +75,8 @@ pnpm build
 
 ### Cross compilation
 
-You can build arm64 binary on Linux amd64 or amd64 binary on MacOS arm64.
+The official binary packages are build in native environment, however you can
+build arm64 binary on Linux amd64 or amd64 binary on MacOS arm64.
 
 On Linux, install cross-compiler (macOS includes this by default):
 
@@ -113,6 +114,32 @@ pnpm build:app dmg pkg --x64
 ```
 
 ## Development Workflow
+
+### Validation before commit
+
+After changing files, especially before commit, run:
+
+```sh
+trunk check
+# or, if trunk is not installed locally
+pnpm trunk:check
+```
+
+For main project TypeScript and HTML files, you can run Biome directly:
+
+```sh
+biome check
+# or, if biome is not installed locally
+pnpm biome:check
+```
+
+For other file types, use Trunk:
+
+```sh
+trunk check
+# or, if trunk is not installed locally
+pnpm trunk:check
+```
 
 ### Daily development
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configurations to use the `ubuntu-24.04-arm` runner instead of `ubuntu-24.04` for various jobs. 