### PR TITLE
Persist linked search as a global user preference

### DIFF
--- a/packages/core/src/common/__tests__/user-store.test.ts
+++ b/packages/core/src/common/__tests__/user-store.test.ts
@@ -10,6 +10,7 @@ import userPreferencesPersistentStorageInjectable from "../../features/user-pref
 import releaseChannelInjectable from "../../features/vars/common/release-channel.injectable";
 import { getDiForUnitTesting } from "../../main/getDiForUnitTesting";
 import directoryForUserDataInjectable from "../app-paths/directory-for-user-data/directory-for-user-data.injectable";
+import readJsonSyncInjectable from "../fs/read-json-sync.injectable";
 import writeFileInjectable from "../fs/write-file.injectable";
 import writeJsonSyncInjectable from "../fs/write-json-sync.injectable";
 import { defaultColorThemePreference } from "../vars";
@@ -60,6 +61,37 @@ describe("user store tests", () => {
       state.colorTheme = "some other theme";
       resetTheme();
       expect(state.colorTheme).toBe(defaultColorThemePreference);
+    });
+
+    it("loads and stores persistentSearch as a global preference", async () => {
+      const writeJsonSync = di.inject(writeJsonSyncInjectable);
+      const readJsonSync = di.inject(readJsonSyncInjectable);
+
+      writeJsonSync("/some-directory-for-user-data/lens-user-store.json", {
+        preferences: {
+          persistentSearch: true,
+        },
+      });
+      writeJsonSync("/some-directory-for-user-data/kube_config", {});
+
+      di.inject(userPreferencesPersistentStorageInjectable).loadAndStartSyncing();
+
+      expect(state.persistentSearch).toBe(true);
+
+      state.persistentSearch = false;
+      expect(readJsonSync("/some-directory-for-user-data/lens-user-store.json")).toMatchObject({
+        preferences: {},
+      });
+      expect(
+        readJsonSync("/some-directory-for-user-data/lens-user-store.json").preferences.persistentSearch,
+      ).toBeUndefined();
+
+      state.persistentSearch = true;
+      expect(readJsonSync("/some-directory-for-user-data/lens-user-store.json")).toMatchObject({
+        preferences: {
+          persistentSearch: true,
+        },
+      });
     });
   });
 });

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -103,6 +103,10 @@ const userPreferenceDescriptorsInjectable = getInjectable({
         fromStore: (val) => val ?? false,
         toStore: (val) => (!val ? undefined : val),
       }),
+      persistentSearch: getPreferenceDescriptor<boolean>({
+        fromStore: (val) => val ?? false,
+        toStore: (val) => (!val ? undefined : val),
+      }),
       terminalCopyOnSelect: getPreferenceDescriptor<boolean>({
         fromStore: (val) => val ?? false,
         toStore: (val) => (!val ? undefined : val),

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -53,6 +53,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.openAtLogin = descriptors.openAtLogin.fromStore(preferences.openAtLogin);
         state.showTrayIcon = descriptors.showTrayIcon.fromStore(preferences.showTrayIcon);
         state.hotbarAutoHide = descriptors.hotbarAutoHide.fromStore(preferences.hotbarAutoHide);
+        state.persistentSearch = descriptors.persistentSearch.fromStore(preferences.persistentSearch);
         state.shell = descriptors.shell.fromStore(preferences.shell);
         state.syncKubeconfigEntries = descriptors.syncKubeconfigEntries.fromStore(preferences.syncKubeconfigEntries);
         state.terminalConfig = descriptors.terminalConfig.fromStore(preferences.terminalConfig);
@@ -78,6 +79,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             openAtLogin: descriptors.openAtLogin.toStore(state.openAtLogin),
             showTrayIcon: descriptors.showTrayIcon.toStore(state.showTrayIcon),
             hotbarAutoHide: descriptors.hotbarAutoHide.toStore(state.hotbarAutoHide),
+            persistentSearch: descriptors.persistentSearch.toStore(state.persistentSearch),
             shell: descriptors.shell.toStore(state.shell),
             syncKubeconfigEntries: descriptors.syncKubeconfigEntries.toStore(state.syncKubeconfigEntries),
             terminalConfig: descriptors.terminalConfig.toStore(state.terminalConfig),

--- a/packages/core/src/renderer/components/input/persistent-search-store.injectable.test.ts
+++ b/packages/core/src/renderer/components/input/persistent-search-store.injectable.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import userPreferencesStateInjectable from "../../../features/user-preferences/common/state.injectable";
+import { getDiForUnitTesting } from "../../../main/getDiForUnitTesting";
+import persistentSearchStoreInjectable from "./persistent-search-store.injectable";
+
+import type { DiContainer } from "@ogre-tools/injectable";
+
+describe("persistent search store", () => {
+  let di: DiContainer;
+  let persistentSearchStore: ReturnType<typeof persistentSearchStoreInjectable.instantiate>;
+  let userPreferencesState: Record<string, unknown>;
+
+  beforeEach(() => {
+    di = getDiForUnitTesting();
+    di.register(persistentSearchStoreInjectable);
+    persistentSearchStore = di.inject(persistentSearchStoreInjectable);
+    userPreferencesState = di.inject(userPreferencesStateInjectable) as Record<string, unknown>;
+  });
+
+  it("defaults to disabled when no stored preference exists", () => {
+    expect(persistentSearchStore.isEnabled).toBe(false);
+    expect(persistentSearchStore.getEnabled()).toBe(false);
+  });
+
+  it("persists enabling through user preferences state", () => {
+    persistentSearchStore.setEnabled(true);
+
+    expect(userPreferencesState.persistentSearch).toBe(true);
+  });
+
+  it("persists disabling through user preferences state", () => {
+    persistentSearchStore.setEnabled(true);
+    persistentSearchStore.setEnabled(false);
+
+    expect(userPreferencesState.persistentSearch).toBe(false);
+  });
+
+  it("keeps search text session-only and out of user preferences", () => {
+    const sharedSearchKey = "global:linked";
+
+    persistentSearchStore.setEnabled(true);
+    const userPreferencesBeforeSettingValue = { ...userPreferencesState };
+    persistentSearchStore.setValue(sharedSearchKey, "pods");
+
+    expect(persistentSearchStore.getValue(sharedSearchKey)).toBe("pods");
+    expect(userPreferencesState.persistentSearch).toBe(true);
+    expect(userPreferencesState[sharedSearchKey]).toBeUndefined();
+    expect({ ...userPreferencesState }).toEqual(userPreferencesBeforeSettingValue);
+  });
+});

--- a/packages/core/src/renderer/components/input/persistent-search-store.injectable.test.ts
+++ b/packages/core/src/renderer/components/input/persistent-search-store.injectable.test.ts
@@ -23,7 +23,6 @@ describe("persistent search store", () => {
 
   it("defaults to disabled when no stored preference exists", () => {
     expect(persistentSearchStore.isEnabled).toBe(false);
-    expect(persistentSearchStore.getEnabled()).toBe(false);
   });
 
   it("persists enabling through user preferences state", () => {

--- a/packages/core/src/renderer/components/input/persistent-search-store.injectable.test.ts
+++ b/packages/core/src/renderer/components/input/persistent-search-store.injectable.test.ts
@@ -4,7 +4,7 @@
  */
 
 import userPreferencesStateInjectable from "../../../features/user-preferences/common/state.injectable";
-import { getDiForUnitTesting } from "../../../main/getDiForUnitTesting";
+import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import persistentSearchStoreInjectable from "./persistent-search-store.injectable";
 
 import type { DiContainer } from "@ogre-tools/injectable";
@@ -16,7 +16,6 @@ describe("persistent search store", () => {
 
   beforeEach(() => {
     di = getDiForUnitTesting();
-    di.register(persistentSearchStoreInjectable);
     persistentSearchStore = di.inject(persistentSearchStoreInjectable);
     userPreferencesState = di.inject(userPreferencesStateInjectable) as Record<string, unknown>;
   });

--- a/packages/core/src/renderer/components/input/persistent-search-store.injectable.ts
+++ b/packages/core/src/renderer/components/input/persistent-search-store.injectable.ts
@@ -17,26 +17,12 @@ class PersistentSearchStore {
   @observable private searchValuesByNamespace = new Map<string, string>();
 
   constructor(private readonly userPreferencesState: UserPreferencesState) {
-    if (this.userPreferencesState.persistentSearch === undefined) {
-      this.userPreferencesState.persistentSearch = false;
-    }
-
     makeObservable(this);
-  }
-
-  private get persistentSearchPreference(): boolean {
-    const { persistentSearch } = this.userPreferencesState;
-
-    if (persistentSearch === undefined) {
-      throw new Error("persistentSearch should be initialized before use");
-    }
-
-    return persistentSearch;
   }
 
   @computed
   get isEnabled(): boolean {
-    return this.persistentSearchPreference;
+    return this.userPreferencesState.persistentSearch ?? false;
   }
 
   @action

--- a/packages/core/src/renderer/components/input/persistent-search-store.injectable.ts
+++ b/packages/core/src/renderer/components/input/persistent-search-store.injectable.ts
@@ -5,27 +5,43 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { action, computed, makeObservable, observable } from "mobx";
+import userPreferencesStateInjectable from "../../../features/user-preferences/common/state.injectable";
+
+import type { UserPreferencesState } from "../../../features/user-preferences/common/state.injectable";
 
 /**
  * Store for managing persistent search across views within the same namespace.
  * Search values are stored per-namespace and only in memory (session-only).
  */
 class PersistentSearchStore {
-  @observable private isEnabledFlag = false;
   @observable private searchValuesByNamespace = new Map<string, string>();
 
-  constructor() {
+  constructor(private readonly userPreferencesState: UserPreferencesState) {
+    if (this.userPreferencesState.persistentSearch === undefined) {
+      this.userPreferencesState.persistentSearch = false;
+    }
+
     makeObservable(this);
+  }
+
+  private get persistentSearchPreference(): boolean {
+    const { persistentSearch } = this.userPreferencesState;
+
+    if (persistentSearch === undefined) {
+      throw new Error("persistentSearch should be initialized before use");
+    }
+
+    return persistentSearch;
   }
 
   @computed
   get isEnabled(): boolean {
-    return this.isEnabledFlag;
+    return this.persistentSearchPreference;
   }
 
   @action
   setEnabled(enabled: boolean) {
-    this.isEnabledFlag = enabled;
+    this.userPreferencesState.persistentSearch = enabled;
   }
 
   @action
@@ -44,7 +60,7 @@ class PersistentSearchStore {
 
 const persistentSearchStoreInjectable = getInjectable({
   id: "persistent-search-store",
-  instantiate: () => new PersistentSearchStore(),
+  instantiate: (di) => new PersistentSearchStore(di.inject(userPreferencesStateInjectable)),
 });
 
 export default persistentSearchStoreInjectable;

--- a/packages/core/src/renderer/components/input/persistent-search-store.injectable.ts
+++ b/packages/core/src/renderer/components/input/persistent-search-store.injectable.ts
@@ -52,10 +52,6 @@ class PersistentSearchStore {
   getValue(namespace: string): string {
     return this.searchValuesByNamespace.get(namespace) || "";
   }
-
-  getEnabled(): boolean {
-    return this.isEnabled;
-  }
 }
 
 const persistentSearchStoreInjectable = getInjectable({


### PR DESCRIPTION
It fixes #1871

This persists the linked search toggle as a remembered user preference across app restarts.

The existing search behavior during a session stays the same. Search text is still session-only and is not written to user preferences. The only thing that is now remembered is whether linked search is enabled or disabled, so people who prefer one mode do not need to keep switching it back after restarting Freelens.