### PR TITLE
feat: add custom accent color preference

### DIFF
--- a/packages/core/src/common/__tests__/user-store.test.ts
+++ b/packages/core/src/common/__tests__/user-store.test.ts
@@ -54,12 +54,17 @@ describe("user store tests", () => {
 
       state.colorTheme = "light";
       expect(state.colorTheme).toBe("light");
+
+      state.customAccentColor = "#ff00aa";
+      expect(state.customAccentColor).toBe("#ff00aa");
     });
 
     it("correctly resets theme to default value", async () => {
       state.colorTheme = "some other theme";
+      state.customAccentColor = "#ff00aa";
       resetTheme();
       expect(state.colorTheme).toBe(defaultColorThemePreference);
+      expect(state.customAccentColor).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
@@ -4,10 +4,12 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Button } from "@freelensapp/button";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
 import { defaultColorThemePreference } from "../../../../../../common/vars";
+import { Input } from "../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
 import { lensThemeDeclarationInjectionToken } from "../../../../../../renderer/themes/declaration";
@@ -32,6 +34,12 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
       label: theme.name,
     })),
   ];
+  const accentColor = state.customAccentColor ?? "";
+  const [accentColorInput, setAccentColorInput] = React.useState(accentColor);
+
+  React.useEffect(() => {
+    setAccentColorInput(accentColor);
+  }, [accentColor]);
 
   return (
     <section id="appearance">
@@ -43,6 +51,45 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
         onChange={(value) => (state.colorTheme = value?.value ?? defaultColorThemePreference)}
         themeName="lens"
       />
+      <div className="mt-6">
+        <SubTitle title="Accent color" />
+        <div className="flex items-center gap-3">
+          <input
+            aria-label="Accent color"
+            type="color"
+            value={accentColor || "#00a7a0"}
+            onChange={(event) => {
+              setAccentColorInput(event.target.value);
+              state.customAccentColor = event.target.value;
+            }}
+          />
+          <Input
+            aria-label="Accent color hex"
+            theme="round-black"
+            placeholder="#00a7a0"
+            value={accentColorInput}
+            onChange={(nextValue) => {
+              const value = nextValue.trim();
+
+              setAccentColorInput(value);
+
+              if (!value) {
+                state.customAccentColor = undefined;
+              } else if (/^#[0-9a-fA-F]{6}$/.test(value)) {
+                state.customAccentColor = value;
+              }
+            }}
+          />
+          <Button
+            primary
+            label="Reset"
+            onClick={() => {
+              setAccentColorInput("");
+              state.customAccentColor = undefined;
+            }}
+          />
+        </div>
+      </div>
     </section>
   );
 });

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -51,6 +51,10 @@ const userPreferenceDescriptorsInjectable = getInjectable({
         fromStore: (val) => val || defaultColorThemePreference,
         toStore: (val) => (!val || val === defaultColorThemePreference ? undefined : val),
       }),
+      customAccentColor: getPreferenceDescriptor<string | undefined>({
+        fromStore: (val) => (isHexColor(val) ? val : undefined),
+        toStore: (val) => (isHexColor(val) ? val : undefined),
+      }),
       terminalTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || "",
         toStore: (val) => val || undefined,
@@ -153,5 +157,9 @@ const userPreferenceDescriptorsInjectable = getInjectable({
     } as const;
   },
 });
+
+function isHexColor(value: unknown): value is string {
+  return typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value);
+}
 
 export default userPreferenceDescriptorsInjectable;

--- a/packages/core/src/features/user-preferences/common/reset-theme.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/reset-theme.injectable.ts
@@ -19,6 +19,7 @@ const resetThemeInjectable = getInjectable({
 
     return action(() => {
       state.colorTheme = preferenceDescriptors.colorTheme.fromStore(undefined);
+      state.customAccentColor = preferenceDescriptors.customAccentColor.fromStore(undefined);
     });
   },
 });

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -39,6 +39,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.allowErrorReporting = descriptors.allowErrorReporting.fromStore(preferences.allowErrorReporting);
         state.allowUntrustedCAs = descriptors.allowUntrustedCAs.fromStore(preferences.allowUntrustedCAs);
         state.colorTheme = descriptors.colorTheme.fromStore(preferences.colorTheme);
+        state.customAccentColor = descriptors.customAccentColor.fromStore(preferences.customAccentColor);
         state.downloadBinariesPath = descriptors.downloadBinariesPath.fromStore(preferences.downloadBinariesPath);
         state.downloadKubectlBinaries = descriptors.downloadKubectlBinaries.fromStore(
           preferences.downloadKubectlBinaries,
@@ -66,6 +67,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             allowErrorReporting: descriptors.allowErrorReporting.toStore(state.allowErrorReporting),
             allowUntrustedCAs: descriptors.allowUntrustedCAs.toStore(state.allowUntrustedCAs),
             colorTheme: descriptors.colorTheme.toStore(state.colorTheme),
+            customAccentColor: descriptors.customAccentColor.toStore(state.customAccentColor),
             downloadBinariesPath: descriptors.downloadBinariesPath.toStore(state.downloadBinariesPath),
             downloadKubectlBinaries: descriptors.downloadKubectlBinaries.toStore(state.downloadKubectlBinaries),
             downloadMirror: descriptors.downloadMirror.toStore(state.downloadMirror),

--- a/packages/core/src/renderer/themes/apply-lens-theme.injectable.ts
+++ b/packages/core/src/renderer/themes/apply-lens-theme.injectable.ts
@@ -8,6 +8,7 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { object } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import resetThemeInjectable from "../../features/user-preferences/common/reset-theme.injectable";
+import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
 
 import type { LensTheme } from "./lens-theme";
 
@@ -18,6 +19,7 @@ const applyLensThemeInjectable = getInjectable({
   instantiate: (di): ApplyLensTheme => {
     const logger = di.inject(loggerInjectionToken);
     const resetTheme = di.inject(resetThemeInjectable);
+    const userPreferencesState = di.inject(userPreferencesStateInjectable);
 
     return (theme) => {
       try {
@@ -26,6 +28,8 @@ const applyLensThemeInjectable = getInjectable({
         for (const [name, value] of colors) {
           document.documentElement.style.setProperty(`--${name}`, value);
         }
+
+        applyCustomAccentColor(userPreferencesState.customAccentColor);
 
         // Adding universal theme flag which can be used in component styles
         document.body.classList.toggle("theme-light", theme.type === "light");
@@ -37,5 +41,24 @@ const applyLensThemeInjectable = getInjectable({
   },
   causesSideEffects: true,
 });
+
+const accentColorVariables = [
+  "primary",
+  "textColorAccent",
+  "buttonPrimaryBackground",
+  "colorInfo",
+  "helmStableRepo",
+  "menuActiveBackground",
+];
+
+function applyCustomAccentColor(accentColor: string | undefined) {
+  if (!accentColor) {
+    return;
+  }
+
+  for (const variableName of accentColorVariables) {
+    document.documentElement.style.setProperty(`--${variableName}`, accentColor);
+  }
+}
 
 export default applyLensThemeInjectable;

--- a/packages/core/src/renderer/themes/setup-apply-active-theme.injectable.ts
+++ b/packages/core/src/renderer/themes/setup-apply-active-theme.injectable.ts
@@ -7,6 +7,7 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import { reaction } from "mobx";
 import initializeSystemThemeTypeInjectable from "../../features/theme/system-type/renderer/initialize.injectable";
+import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
 import initUserStoreInjectable from "../../features/user-preferences/renderer/load-storage.injectable";
 import { beforeFrameStartsSecondInjectionToken } from "../before-frame-starts/tokens";
 import activeThemeInjectable from "./active.injectable";
@@ -18,10 +19,15 @@ const setupApplyActiveThemeInjectable = getInjectable({
     run: () => {
       const activeTheme = di.inject(activeThemeInjectable);
       const applyLensTheme = di.inject(applyLensThemeInjectable);
+      const userPreferencesState = di.inject(userPreferencesStateInjectable);
 
-      reaction(() => activeTheme.get(), applyLensTheme, {
-        fireImmediately: true,
-      });
+      reaction(
+        () => [activeTheme.get(), userPreferencesState.customAccentColor] as const,
+        ([theme]) => applyLensTheme(theme),
+        {
+          fireImmediately: true,
+        },
+      );
     },
     runAfter: [initializeSystemThemeTypeInjectable, initUserStoreInjectable],
   }),


### PR DESCRIPTION
## Summary
- Add a user preference for a custom accent color in Application > Theme.
- Persist and validate the custom accent color in the user preferences store.
- Re-apply the active theme whenever the accent color changes and override core accent CSS variables such as primary, textColorAccent, buttonPrimaryBackground, colorInfo, helmStableRepo, and menuActiveBackground.
- Reset the custom accent color when the theme is reset and cover it in the user-store test.

Closes #1280

## Validation
- git diff --check

## Notes
- I could not run the full pnpm test/build suite in this local environment because pnpm is not installed and corepack is blocked from writing its package-manager cache here.