### PR TITLE
Add custom accent color preference

### DIFF
--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss
@@ -1,0 +1,24 @@
+.accentColor {
+  margin-top: 16px;
+}
+
+.accentColorRow {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
+.accentColorPicker {
+  background: transparent;
+  border: 1px solid var(--inputControlBorder);
+  border-radius: 4px;
+  cursor: pointer;
+  height: 32px;
+  padding: 2px;
+  width: 48px;
+}
+
+.accentColorValue {
+  color: var(--textColorSecondary);
+  min-width: 72px;
+}

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
@@ -4,14 +4,19 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Button } from "@freelensapp/button";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
 import { defaultColorThemePreference } from "../../../../../../common/vars";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
+import activeThemeInjectable from "../../../../../../renderer/themes/active.injectable";
 import { lensThemeDeclarationInjectionToken } from "../../../../../../renderer/themes/declaration";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";
+import styles from "./theme.module.scss";
+
+import type { IComputedValue } from "mobx";
 
 import type { LensTheme } from "../../../../../../renderer/themes/lens-theme";
 import type { UserPreferencesState } from "../../../../../user-preferences/common/state.injectable";
@@ -19,9 +24,10 @@ import type { UserPreferencesState } from "../../../../../user-preferences/commo
 interface Dependencies {
   state: UserPreferencesState;
   themes: LensTheme[];
+  activeTheme: IComputedValue<LensTheme>;
 }
 
-const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
+const NonInjectedTheme = observer(({ state, themes, activeTheme }: Dependencies) => {
   const themeOptions = [
     {
       value: defaultColorThemePreference,
@@ -32,6 +38,7 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
       label: theme.name,
     })),
   ];
+  const accentColor = state.customAccentColor ?? activeTheme.get().colors.primary;
 
   return (
     <section id="appearance">
@@ -43,6 +50,26 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
         onChange={(value) => (state.colorTheme = value?.value ?? defaultColorThemePreference)}
         themeName="lens"
       />
+      <div className={styles.accentColor}>
+        <SubTitle title="Accent color" />
+        <div className={styles.accentColorRow}>
+          <input
+            id="custom-accent-color-input"
+            aria-label="Accent color"
+            className={styles.accentColorPicker}
+            type="color"
+            value={accentColor}
+            onChange={(event) => (state.customAccentColor = event.currentTarget.value)}
+          />
+          <span className={styles.accentColorValue}>{accentColor}</span>
+          <Button
+            plain
+            label="Reset"
+            disabled={!state.customAccentColor}
+            onClick={() => (state.customAccentColor = undefined)}
+          />
+        </div>
+      </div>
     </section>
   );
 });
@@ -51,5 +78,6 @@ export const Theme = withInjectables<Dependencies>(NonInjectedTheme, {
   getProps: (di) => ({
     state: di.inject(userPreferencesStateInjectable),
     themes: di.injectMany(lensThemeDeclarationInjectionToken),
+    activeTheme: di.inject(activeThemeInjectable),
   }),
 });

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -32,6 +32,9 @@ import type {
 
 export type PreferenceDescriptors = ReturnType<(typeof userPreferenceDescriptorsInjectable)["instantiate"]>;
 
+const normalizeHexColor = (value: string | undefined) =>
+  value && /^#[0-9a-fA-F]{6}$/.test(value) ? value.toLowerCase() : undefined;
+
 const userPreferenceDescriptorsInjectable = getInjectable({
   id: "user-preference-descriptors",
   instantiate: (di) => {
@@ -50,6 +53,10 @@ const userPreferenceDescriptorsInjectable = getInjectable({
       colorTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || defaultColorThemePreference,
         toStore: (val) => (!val || val === defaultColorThemePreference ? undefined : val),
+      }),
+      customAccentColor: getPreferenceDescriptor<string | undefined>({
+        fromStore: normalizeHexColor,
+        toStore: normalizeHexColor,
       }),
       terminalTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || "",

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -39,6 +39,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.allowErrorReporting = descriptors.allowErrorReporting.fromStore(preferences.allowErrorReporting);
         state.allowUntrustedCAs = descriptors.allowUntrustedCAs.fromStore(preferences.allowUntrustedCAs);
         state.colorTheme = descriptors.colorTheme.fromStore(preferences.colorTheme);
+        state.customAccentColor = descriptors.customAccentColor.fromStore(preferences.customAccentColor);
         state.downloadBinariesPath = descriptors.downloadBinariesPath.fromStore(preferences.downloadBinariesPath);
         state.downloadKubectlBinaries = descriptors.downloadKubectlBinaries.fromStore(
           preferences.downloadKubectlBinaries,
@@ -67,6 +68,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             allowErrorReporting: descriptors.allowErrorReporting.toStore(state.allowErrorReporting),
             allowUntrustedCAs: descriptors.allowUntrustedCAs.toStore(state.allowUntrustedCAs),
             colorTheme: descriptors.colorTheme.toStore(state.colorTheme),
+            customAccentColor: descriptors.customAccentColor.toStore(state.customAccentColor),
             downloadBinariesPath: descriptors.downloadBinariesPath.toStore(state.downloadBinariesPath),
             downloadKubectlBinaries: descriptors.downloadKubectlBinaries.toStore(state.downloadKubectlBinaries),
             downloadMirror: descriptors.downloadMirror.toStore(state.downloadMirror),

--- a/packages/core/src/renderer/themes/active.injectable.ts
+++ b/packages/core/src/renderer/themes/active.injectable.ts
@@ -8,10 +8,26 @@ import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { computed } from "mobx";
 import lensColorThemePreferenceInjectable from "../../features/user-preferences/common/lens-color-theme.injectable";
+import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
 import { lensThemeDeclarationInjectionToken } from "./declaration";
 import defaultLensThemeInjectable from "./default-theme.injectable";
 import systemThemeConfigurationInjectable from "./system-theme.injectable";
 import lensThemesInjectable from "./themes.injectable";
+
+import type { LensTheme } from "./lens-theme";
+
+const applyAccentColor = (theme: LensTheme, accentColor: string): LensTheme => ({
+  ...theme,
+  colors: {
+    ...theme.colors,
+    blue: accentColor,
+    primary: accentColor,
+    colorInfo: accentColor,
+    buttonPrimaryBackground: accentColor,
+    helmStableRepo: accentColor,
+    menuActiveBackground: accentColor,
+  },
+});
 
 const activeThemeInjectable = getInjectable({
   id: "active-theme",
@@ -21,20 +37,26 @@ const activeThemeInjectable = getInjectable({
     const lensColorThemePreference = di.inject(lensColorThemePreferenceInjectable);
     const systemThemeConfiguration = di.inject(systemThemeConfigurationInjectable);
     const defaultLensTheme = di.inject(defaultLensThemeInjectable);
+    const state = di.inject(userPreferencesStateInjectable);
 
     return computed(() => {
       const pref = lensColorThemePreference.get();
+      const getTheme = () => {
+        if (pref.useSystemTheme) {
+          const systemThemeType = systemThemeConfiguration.get();
+          const matchingTheme = themeDecls.find((theme) => theme.type === systemThemeType);
 
-      if (pref.useSystemTheme) {
-        const systemThemeType = systemThemeConfiguration.get();
-        const matchingTheme = themeDecls.find((theme) => theme.type === systemThemeType);
+          assert(matchingTheme, `Missing theme declaration for system theme "${systemThemeType}"`);
 
-        assert(matchingTheme, `Missing theme declaration for system theme "${systemThemeType}"`);
+          return matchingTheme;
+        }
 
-        return matchingTheme;
-      }
+        return lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
+      };
 
-      return lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
+      const theme = getTheme();
+
+      return state.customAccentColor ? applyAccentColor(theme, state.customAccentColor) : theme;
     });
   },
 });


### PR DESCRIPTION
Closes #1280

## Summary
- add an Accent color control to the Application theme preferences
- persist a custom accent color in user preferences
- apply the accent color over the active light/dark/system theme for primary UI accents

## Verification
- `corepack pnpm dlx @biomejs/biome@2.4.13 check packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts packages/core/src/features/user-preferences/common/storage.injectable.ts packages/core/src/renderer/themes/active.injectable.ts`

Note: I also tried `corepack pnpm --filter @freelensapp/core build`; it currently fails before this change can be isolated because workspace `dist` packages such as `@freelensapp/logger/dist`, `@freelensapp/kube-object/dist`, and `@freelensapp/messaging/dist` are not built in a fresh checkout.