### PR TITLE
Less verbose logs

### DIFF
--- a/packages/core/src/common/k8s-api/__tests__/api-manager.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/api-manager.test.ts
@@ -8,6 +8,7 @@ import { KubeApi } from "@freelensapp/kube-api";
 import { maybeKubeApiInjectable } from "@freelensapp/kube-api-specifics";
 import { KubeObject } from "@freelensapp/kube-object";
 import {
+  logDebugInjectionToken,
   logErrorInjectionToken,
   loggerInjectionToken,
   logInfoInjectionToken,
@@ -70,6 +71,7 @@ describe("ApiManager", () => {
       const fallbackApiBase = "/apis/extensions/v1beta1/foo";
       const kubeApi = new TestApi(
         {
+          logDebug: di.inject(logDebugInjectionToken),
           logError: di.inject(logErrorInjectionToken),
           logInfo: di.inject(logInfoInjectionToken),
           logWarn: di.inject(logWarningInjectionToken),
@@ -160,6 +162,7 @@ describe("ApiManager", () => {
               return Object.assign(
                 new KubeApi(
                   {
+                    logDebug: di.inject(logDebugInjectionToken),
                     logError: di.inject(logErrorInjectionToken),
                     logInfo: di.inject(logInfoInjectionToken),
                     logWarn: di.inject(logWarningInjectionToken),

--- a/packages/core/src/common/k8s-api/__tests__/kube-api-version-detection.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/kube-api-version-detection.test.ts
@@ -8,7 +8,12 @@ import asyncFn from "@async-fn/jest";
 import { HorizontalPodAutoscalerApi } from "@freelensapp/kube-api";
 import { ingressApiInjectable, maybeKubeApiInjectable } from "@freelensapp/kube-api-specifics";
 import { Ingress } from "@freelensapp/kube-object";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { flushPromises } from "@freelensapp/test-utils";
 import setupAutoRegistrationInjectable from "../../../renderer/before-frame-starts/runnables/setup-auto-registration.injectable";
 import hostedClusterInjectable from "../../../renderer/cluster-frame-context/hosted-cluster.injectable";
@@ -802,6 +807,7 @@ describe("KubeApi", () => {
     beforeEach(async () => {
       horizontalPodAutoscalerApi = new HorizontalPodAutoscalerApi(
         {
+          logDebug: di.inject(logDebugInjectionToken),
           logError: di.inject(logErrorInjectionToken),
           logInfo: di.inject(logInfoInjectionToken),
           logWarn: di.inject(logWarningInjectionToken),

--- a/packages/core/src/common/k8s-api/create-kube-api-for-cluster.injectable.ts
+++ b/packages/core/src/common/k8s-api/create-kube-api-for-cluster.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { KubeApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import { apiKubePrefix } from "../vars";
 import isDevelopmentInjectable from "../vars/is-development.injectable";
@@ -41,6 +46,7 @@ const createKubeApiForClusterInjectable = getInjectable({
     const apiBase = di.inject(apiBaseInjectable);
     const isDevelopment = di.inject(isDevelopmentInjectable);
     const createKubeJsonApi = di.inject(createKubeJsonApiInjectable);
+    const logDebug = di.inject(logDebugInjectionToken);
     const logError = di.inject(logErrorInjectionToken);
     const logInfo = di.inject(logInfoInjectionToken);
     const logWarn = di.inject(logWarningInjectionToken);
@@ -72,6 +78,7 @@ const createKubeApiForClusterInjectable = getInjectable({
 
       return new KubeApi(
         {
+          logDebug,
           logError,
           logInfo,
           logWarn,

--- a/packages/core/src/common/k8s-api/create-kube-api-for-remote-cluster.injectable.ts
+++ b/packages/core/src/common/k8s-api/create-kube-api-for-remote-cluster.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { KubeApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import { Agent } from "https";
 import isDevelopmentInjectable from "../vars/is-development.injectable";
@@ -58,6 +63,7 @@ const createKubeApiForRemoteClusterInjectable = getInjectable({
   instantiate: (di): CreateKubeApiForRemoteCluster => {
     const isDevelopment = di.inject(isDevelopmentInjectable);
     const createKubeJsonApi = di.inject(createKubeJsonApiInjectable);
+    const logDebug = di.inject(logDebugInjectionToken);
     const logError = di.inject(logErrorInjectionToken);
     const logInfo = di.inject(logInfoInjectionToken);
     const logWarn = di.inject(logWarningInjectionToken);
@@ -122,6 +128,7 @@ const createKubeApiForRemoteClusterInjectable = getInjectable({
 
       return new KubeApi(
         {
+          logDebug,
           logError,
           logInfo,
           logWarn,

--- a/packages/core/src/common/k8s-api/create-kube-api.injectable.ts
+++ b/packages/core/src/common/k8s-api/create-kube-api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { maybeKubeApiInjectable } from "@freelensapp/kube-api-specifics";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 
 import type { DerivedKubeApiOptions, KubeApiDependencies } from "@freelensapp/kube-api";
@@ -18,6 +23,7 @@ const createKubeApiInjectable = getInjectable({
   id: "create-kube-api",
   instantiate: (di): CreateKubeApi => {
     const deps: KubeApiDependencies = {
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/core/src/extensions/common-api/k8s-api.ts
+++ b/packages/core/src/extensions/common-api/k8s-api.ts
@@ -24,6 +24,7 @@ import {
   getLegacyGlobalDiForExtensionApi,
 } from "@freelensapp/legacy-global-di";
 import {
+  logDebugInjectionToken,
   logErrorInjectionToken,
   loggerInjectionToken,
   logInfoInjectionToken,
@@ -63,6 +64,7 @@ const getKubeApiDeps = (): KubeApiDependencies => {
   const di = getLegacyGlobalDiForExtensionApi();
 
   return {
+    logDebug: di.inject(logDebugInjectionToken),
     logError: di.inject(logErrorInjectionToken),
     logInfo: di.inject(logInfoInjectionToken),
     logWarn: di.inject(logWarningInjectionToken),

--- a/packages/core/src/renderer/before-frame-starts/runnables/setup-auto-crd-api-creations.injectable.ts
+++ b/packages/core/src/renderer/before-frame-starts/runnables/setup-auto-crd-api-creations.injectable.ts
@@ -7,7 +7,12 @@
 import { KubeApi } from "@freelensapp/kube-api";
 import { maybeKubeApiInjectable } from "@freelensapp/kube-api-specifics";
 import { KubeObject } from "@freelensapp/kube-object";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import { reaction } from "mobx";
 import { customResourceDefinitionApiInjectionToken } from "../../../common/k8s-api/api-manager/crd-api-token";
@@ -50,6 +55,7 @@ const toCrdApiInjectable = (crd: CustomResourceDefinition) =>
 
       return new KubeApi(
         {
+          logDebug: di.inject(logDebugInjectionToken),
           logError: di.inject(logErrorInjectionToken),
           logInfo: di.inject(logInfoInjectionToken),
           logWarn: di.inject(logWarningInjectionToken),

--- a/packages/core/src/renderer/components/dock/terminal/terminal.ts
+++ b/packages/core/src/renderer/components/dock/terminal/terminal.ts
@@ -200,14 +200,14 @@ export class Terminal {
   };
 
   setFontSize = (fontSize: number) => {
-    this.dependencies.logger.info(`[TERMINAL]: set fontSize to ${fontSize}`);
+    this.dependencies.logger.debug(`[TERMINAL]: set fontSize to ${fontSize}`);
 
     this.xterm.options.fontSize = fontSize;
     this.fit();
   };
 
   setFontFamily = (fontFamily: string) => {
-    this.dependencies.logger.info(`[TERMINAL]: set fontFamily to ${fontFamily}`);
+    this.dependencies.logger.debug(`[TERMINAL]: set fontFamily to ${fontFamily}`);
 
     this.xterm.options.fontFamily = fontFamily;
     this.fit();

--- a/packages/core/src/renderer/components/monaco-editor/monaco-editor.tsx
+++ b/packages/core/src/renderer/components/monaco-editor/monaco-editor.tsx
@@ -191,7 +191,7 @@ class NonInjectedMonacoEditor extends React.Component<MonacoEditorProps & Depend
   componentDidMount() {
     try {
       this.createEditor();
-      this.logger.info(`[MONACO]: editor did mount`, this.logMetadata);
+      this.logger.debug(`[MONACO]: editor did mount`, this.logMetadata);
     } catch (error) {
       this.logger.error(`[MONACO]: mounting failed: ${error}`, this.logMetadata);
     }
@@ -224,7 +224,7 @@ class NonInjectedMonacoEditor extends React.Component<MonacoEditorProps & Depend
       ...this.options,
     });
 
-    this.logger.info(`[MONACO]: editor created for language=${language}, theme=${theme}`, this.logMetadata);
+    this.logger.debug(`[MONACO]: editor created for language=${language}, theme=${theme}`, this.logMetadata);
     this.validateLazy(); // validate initial value
     this.restoreViewState(this.model); // restore previous state if any
 

--- a/packages/core/src/renderer/kube-watch-api/kube-watch-api.ts
+++ b/packages/core/src/renderer/kube-watch-api/kube-watch-api.ts
@@ -39,7 +39,7 @@ class WatchCount {
   public inc(store: SubscribableStore): number {
     const newCount = getOrInsert(this.#data, store, 0) + 1;
 
-    this.dependencies.logger.info(`[KUBE-WATCH-API]: inc() count for ${store.api.apiBase} is now ${newCount}`);
+    this.dependencies.logger.debug(`[KUBE-WATCH-API]: inc() count for ${store.api.apiBase} is now ${newCount}`);
     this.#data.set(store, newCount);
 
     return newCount;
@@ -58,7 +58,7 @@ class WatchCount {
       throw new Error(`Cannot dec count more times than it has been inc: ${store.api.kind}`);
     }
 
-    this.dependencies.logger.info(`[KUBE-WATCH-API]: dec() count for ${store.api.apiBase} is now ${newCount}`);
+    this.dependencies.logger.debug(`[KUBE-WATCH-API]: dec() count for ${store.api.apiBase} is now ${newCount}`);
     this.#data.set(store, newCount);
 
     return newCount;

--- a/packages/utility-features/kube-api-specifics/src/specifics/cluster-role-binding.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/cluster-role-binding.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ClusterRoleBindingApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const clusterRoleBindingApiInjectable = getInjectable({
     );
 
     return new ClusterRoleBindingApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/cluster-role.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/cluster-role.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ClusterRoleApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const clusterRoleApiInjectable = getInjectable({
     );
 
     return new ClusterRoleApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/cluster.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/cluster.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ClusterApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -18,6 +23,7 @@ export const clusterApiInjectable = getInjectable({
     assert(di.inject(storesAndApisCanBeCreatedInjectionToken), "clusterApi is only available in certain environments");
 
     return new ClusterApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/component-status.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/component-status.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ComponentStatusApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const componentStatusApiInjectable = getInjectable({
     );
 
     return new ComponentStatusApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/config-map.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/config-map.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ConfigMapApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const configMapApiInjectable = getInjectable({
     );
 
     return new ConfigMapApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/cron-job.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/cron-job.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { CronJobApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -19,6 +24,7 @@ export const cronJobApiInjectable = getInjectable({
 
     return new CronJobApi(
       {
+        logDebug: di.inject(logDebugInjectionToken),
         logError: di.inject(logErrorInjectionToken),
         logInfo: di.inject(logInfoInjectionToken),
         logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/custom-resource-definition.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/custom-resource-definition.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { CustomResourceDefinitionApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const customResourceDefinitionApiInjectable = getInjectable({
     );
 
     return new CustomResourceDefinitionApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/daemon-set.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/daemon-set.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { DaemonSetApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const daemonSetApiInjectable = getInjectable({
     );
 
     return new DaemonSetApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/deployment.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/deployment.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { DeploymentApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const deploymentApiInjectable = getInjectable({
     );
 
     return new DeploymentApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/endpoint-slice.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/endpoint-slice.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { EndpointSliceApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const endpointSliceApiInjectable = getInjectable({
     );
 
     return new EndpointSliceApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/endpoint.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/endpoint.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { EndpointsApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const endpointsApiInjectable = getInjectable({
     );
 
     return new EndpointsApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/event.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/event.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { KubeEventApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const kubeEventApiInjectable = getInjectable({
     );
 
     return new KubeEventApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/horizontal-pod-autoscaler.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/horizontal-pod-autoscaler.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { HorizontalPodAutoscalerApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const horizontalPodAutoscalerApiInjectable = getInjectable({
     );
 
     return new HorizontalPodAutoscalerApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/ingress-class.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/ingress-class.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { IngressClassApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const ingressClassApiInjectable = getInjectable({
     );
 
     return new IngressClassApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/ingress.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/ingress.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { IngressApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -18,6 +23,7 @@ export const ingressApiInjectable = getInjectable({
     assert(di.inject(storesAndApisCanBeCreatedInjectionToken), "ingressApi is only available in certain environments");
 
     return new IngressApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/job.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/job.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { JobApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -19,6 +24,7 @@ export const jobApiInjectable = getInjectable({
 
     return new JobApi(
       {
+        logDebug: di.inject(logDebugInjectionToken),
         logError: di.inject(logErrorInjectionToken),
         logInfo: di.inject(logInfoInjectionToken),
         logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/lease.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/lease.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { LeaseApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -18,6 +23,7 @@ export const leaseApiInjectable = getInjectable({
     assert(di.inject(storesAndApisCanBeCreatedInjectionToken), "leaseApi is only available in certain environments");
 
     return new LeaseApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/limit-range.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/limit-range.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { LimitRangeApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const limitRangeApiInjectable = getInjectable({
     );
 
     return new LimitRangeApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/mutating-webhook-configuration-api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/mutating-webhook-configuration-api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { MutatingWebhookConfigurationApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const mutatingWebhookConfigurationApiInjectable = getInjectable({
     );
 
     return new MutatingWebhookConfigurationApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/namespace.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/namespace.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { NamespaceApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -22,6 +27,7 @@ export const namespaceApiInjectable = getInjectable({
     );
 
     return new NamespaceApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/network-policy.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/network-policy.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { NetworkPolicyApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const networkPolicyApiInjectable = getInjectable({
     );
 
     return new NetworkPolicyApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/node-metrics.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/node-metrics.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { NodeMetricsApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const nodeMetricsApiInjectable = getInjectable({
     );
 
     return new NodeMetricsApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/node.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/node.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { NodeApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -18,6 +23,7 @@ export const nodeApiInjectable = getInjectable({
     assert(di.inject(storesAndApisCanBeCreatedInjectionToken), "nodeApi is only available in certain environments");
 
     return new NodeApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/persistent-volume-claim.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/persistent-volume-claim.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { PersistentVolumeClaimApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const persistentVolumeClaimApiInjectable = getInjectable({
     );
 
     return new PersistentVolumeClaimApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/persistent-volume.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/persistent-volume.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { PersistentVolumeApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const persistentVolumeApiInjectable = getInjectable({
     );
 
     return new PersistentVolumeApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/pod-disruption-budget.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/pod-disruption-budget.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { PodDisruptionBudgetApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -22,6 +27,7 @@ export const podDisruptionBudgetApiInjectable = getInjectable({
 
     return new PodDisruptionBudgetApi(
       {
+        logDebug: di.inject(logDebugInjectionToken),
         logError: di.inject(logErrorInjectionToken),
         logInfo: di.inject(logInfoInjectionToken),
         logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/pod-metrics.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/pod-metrics.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { PodMetricsApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const podMetricsApiInjectable = getInjectable({
     );
 
     return new PodMetricsApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/pod-security-policy.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/pod-security-policy.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { PodSecurityPolicyApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const podSecurityPolicyApiInjectable = getInjectable({
     );
 
     return new PodSecurityPolicyApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/pod.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/pod.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { PodApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -19,6 +24,7 @@ export const podApiInjectable = getInjectable({
     assert(di.inject(storesAndApisCanBeCreatedInjectionToken), "podApi is only available in certain environments");
 
     return new PodApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/priority-class.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/priority-class.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { PriorityClassApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const priorityClassApiInjectable = getInjectable({
     );
 
     return new PriorityClassApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/replica-set.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/replica-set.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ReplicaSetApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const replicaSetApiInjectable = getInjectable({
     );
 
     return new ReplicaSetApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/replication-controller.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/replication-controller.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ReplicationControllerApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const replicationControllerApiInjectable = getInjectable({
     );
 
     return new ReplicationControllerApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/resource-quota.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/resource-quota.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ResourceQuotaApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const resourceQuotaApiInjectable = getInjectable({
     );
 
     return new ResourceQuotaApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/role-binding.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/role-binding.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { RoleBindingApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const roleBindingApiInjectable = getInjectable({
     );
 
     return new RoleBindingApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/role.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/role.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { RoleApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -18,6 +23,7 @@ export const roleApiInjectable = getInjectable({
     assert(di.inject(storesAndApisCanBeCreatedInjectionToken), "roleApi is only available in certain environments");
 
     return new RoleApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/runtime-class.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/runtime-class.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { RuntimeClassApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const runtimeClassApiInjectable = getInjectable({
     );
 
     return new RuntimeClassApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/secret.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/secret.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { SecretApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -18,6 +23,7 @@ export const secretApiInjectable = getInjectable({
     assert(di.inject(storesAndApisCanBeCreatedInjectionToken), "secretApi is only available in certain environments");
 
     return new SecretApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/self-subject-rules-reviews.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/self-subject-rules-reviews.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { SelfSubjectRulesReviewApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const selfSubjectRulesReviewApiInjectable = getInjectable({
     );
 
     return new SelfSubjectRulesReviewApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/service-account.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/service-account.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ServiceAccountApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const serviceAccountApiInjectable = getInjectable({
     );
 
     return new ServiceAccountApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/service.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/service.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ServiceApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -18,6 +23,7 @@ export const serviceApiInjectable = getInjectable({
     assert(di.inject(storesAndApisCanBeCreatedInjectionToken), "serviceApi is only available in certain environments");
 
     return new ServiceApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/stateful-set.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/stateful-set.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { StatefulSetApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const statefulSetApiInjectable = getInjectable({
     );
 
     return new StatefulSetApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/storage-class.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/storage-class.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { StorageClassApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const storageClassApiInjectable = getInjectable({
     );
 
     return new StorageClassApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/validating-webhook-configuration-api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/validating-webhook-configuration-api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { ValidatingWebhookConfigurationApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const validatingWebhookConfigurationApiInjectable = getInjectable({
     );
 
     return new ValidatingWebhookConfigurationApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api-specifics/src/specifics/vertical-pod-autoscaler.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/vertical-pod-autoscaler.api.injectable.ts
@@ -5,7 +5,12 @@
  */
 
 import { VerticalPodAutoscalerApi } from "@freelensapp/kube-api";
-import { logErrorInjectionToken, logInfoInjectionToken, logWarningInjectionToken } from "@freelensapp/logger";
+import {
+  logDebugInjectionToken,
+  logErrorInjectionToken,
+  logInfoInjectionToken,
+  logWarningInjectionToken,
+} from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
@@ -21,6 +26,7 @@ export const verticalPodAutoscalerApiInjectable = getInjectable({
     );
 
     return new VerticalPodAutoscalerApi({
+      logDebug: di.inject(logDebugInjectionToken),
       logError: di.inject(logErrorInjectionToken),
       logInfo: di.inject(logInfoInjectionToken),
       logWarn: di.inject(logWarningInjectionToken),

--- a/packages/utility-features/kube-api/src/kube-api.test.ts
+++ b/packages/utility-features/kube-api/src/kube-api.test.ts
@@ -241,6 +241,7 @@ describe("KubeApi", () => {
 
     beforeEach(() => {
       api = new PodApi({
+        logDebug: logger.debug,
         logError: logger.error,
         logInfo: logger.info,
         logWarn: logger.error,
@@ -463,6 +464,7 @@ describe("KubeApi", () => {
 
     beforeEach(() => {
       api = new PodApi({
+        logDebug: logger.debug,
         logError: logger.error,
         logInfo: logger.info,
         logWarn: logger.error,
@@ -823,6 +825,7 @@ describe("KubeApi", () => {
 
     beforeEach(() => {
       api = new PodApi({
+        logDebug: logger.debug,
         logError: logger.error,
         logInfo: logger.info,
         logWarn: logger.error,
@@ -955,6 +958,7 @@ describe("KubeApi", () => {
 
     beforeEach(() => {
       api = new PodApi({
+        logDebug: logger.debug,
         logError: logger.error,
         logInfo: logger.info,
         logWarn: logger.error,
@@ -1088,6 +1092,7 @@ describe("KubeApi", () => {
 
     beforeEach(() => {
       api = new PodApi({
+        logDebug: logger.debug,
         logError: logger.error,
         logInfo: logger.info,
         logWarn: logger.error,

--- a/packages/utility-features/kube-api/src/kube-api.ts
+++ b/packages/utility-features/kube-api/src/kube-api.ts
@@ -336,6 +336,7 @@ export interface DeleteResourceDescriptor extends ResourceDescriptor {
 }
 
 export interface KubeApiDependencies {
+  logDebug: LogFunction;
   logInfo: LogFunction;
   logWarn: LogFunction;
   logError: LogFunction;
@@ -826,7 +827,7 @@ export class KubeApi<
     const watchUrl = this.getWatchUrl(namespace);
 
     abortController.signal.addEventListener("abort", () => {
-      this.dependencies.logInfo(`watch (${watchId}) aborted ${watchUrl}`);
+      this.dependencies.logDebug(`watch (${watchId}) aborted ${watchUrl}`);
       clearTimeout(timedRetry);
     });
 
@@ -835,7 +836,7 @@ export class KubeApi<
       signal: abortController.signal,
     });
 
-    this.dependencies.logInfo(`watch (${watchId}) ${retry === true ? "retried" : "started"} ${watchUrl}`);
+    this.dependencies.logDebug(`watch (${watchId}) ${retry === true ? "retried" : "started"} ${watchUrl}`);
 
     responsePromise
       .then((response) => {
@@ -863,7 +864,7 @@ export class KubeApi<
               // Close current request
               abortController.abort();
 
-              this.dependencies.logInfo(`Watch timeout set, but not retried, retrying now`);
+              this.dependencies.logDebug(`Watch timeout set, but not retried, retrying now`);
 
               requestRetried = true;
 
@@ -899,7 +900,7 @@ export class KubeApi<
               return;
             }
 
-            this.dependencies.logInfo(`watch (${watchId}) ${eventName} ${watchUrl}`);
+            this.dependencies.logDebug(`watch (${watchId}) ${eventName} ${watchUrl}`);
 
             requestRetried = true;
 


### PR DESCRIPTION
This pull request introduces support for debug-level logging throughout the Kube API and related features, ensuring that debug logs can be injected and used consistently. It also refactors several logger calls from info-level to debug-level to reduce log verbosity for routine operations.