### PR TITLE
Fixes for Bad Request on Helm install

### DIFF
--- a/packages/core/src/main/helm/helm-service/install-helm-chart.injectable.ts
+++ b/packages/core/src/main/helm/helm-service/install-helm-chart.injectable.ts
@@ -8,14 +8,12 @@ import { getInjectable } from "@ogre-tools/injectable";
 import kubeconfigManagerInjectable from "../../kubeconfig-manager/kubeconfig-manager.injectable";
 import installHelmChartInjectable from "../install-helm-chart.injectable";
 
-import type { JsonObject } from "type-fest";
-
 import type { Cluster } from "../../../common/cluster/cluster";
 
 export interface InstallChartArgs {
   chart: string;
-  values: JsonObject;
-  name: string;
+  values: string;
+  name?: string;
   namespace: string;
   version: string;
   forceConflicts?: boolean;

--- a/packages/core/src/main/helm/install-helm-chart.injectable.ts
+++ b/packages/core/src/main/helm/install-helm-chart.injectable.ts
@@ -5,19 +5,16 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import { dump } from "js-yaml";
 import tempy from "tempy";
 import removePathInjectable from "../../common/fs/remove.injectable";
 import writeFileInjectable from "../../common/fs/write-file.injectable";
 import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
 import execHelmInjectable from "./exec-helm/exec-helm.injectable";
 
-import type { JsonValue } from "type-fest";
-
 export interface InstallHelmChartData {
   chart: string;
-  values: JsonValue;
-  name: string;
+  values: string;
+  name?: string;
   namespace: string;
   version: string;
   kubeconfigPath: string;
@@ -45,7 +42,7 @@ const installHelmChartInjectable = getInjectable({
     return async ({ chart, kubeconfigPath, name, namespace, values, version, forceConflicts }) => {
       const valuesFilePath = tempy.file({ name: "values.yaml" });
 
-      await writeFile(valuesFilePath, dump(values));
+      await writeFile(valuesFilePath, values);
 
       const args = ["install"];
 

--- a/packages/core/src/main/routes/helm/releases/install-chart-route.injectable.ts
+++ b/packages/core/src/main/routes/helm/releases/install-chart-route.injectable.ts
@@ -14,7 +14,7 @@ import type { InstallChartArgs } from "../../../helm/helm-service/install-helm-c
 
 const installChartArgsValidator = Joi.object<InstallChartArgs, true, InstallChartArgs>({
   chart: Joi.string().required(),
-  values: Joi.object().required().unknown(true),
+  values: Joi.string().required(),
   name: Joi.string(),
   namespace: Joi.string().required(),
   version: Joi.string().required(),


### PR DESCRIPTION
Fixes #1887

This pull request updates the way Helm chart installation values are handled, changing their type from a generic object to a YAML string. This simplifies value handling and aligns the API with how Helm expects values to be provided.