### PR TITLE
Persist log viewer preferences globally

### DIFF
--- a/packages/core/src/common/__tests__/user-store.test.ts
+++ b/packages/core/src/common/__tests__/user-store.test.ts
@@ -97,7 +97,6 @@ describe("user store tests", () => {
     it("loads and stores logViewerPreferences as a global preference", async () => {
       const writeJsonSync = di.inject(writeJsonSyncInjectable);
       const readJsonSync = di.inject(readJsonSyncInjectable);
-      const userPreferencesState = state as Record<string, unknown>;
 
       writeJsonSync("/some-directory-for-user-data/lens-user-store.json", {
         preferences: {
@@ -111,13 +110,13 @@ describe("user store tests", () => {
 
       di.inject(userPreferencesPersistentStorageInjectable).loadAndStartSyncing();
 
-      expect(userPreferencesState.logViewerPreferences).toEqual({
+      expect(state.logViewerPreferences).toEqual({
         showTimestamps: true,
         showPrevious: false,
         showWordWrap: false,
       });
 
-      userPreferencesState.logViewerPreferences = {
+      state.logViewerPreferences = {
         showTimestamps: false,
         showPrevious: true,
         showWordWrap: false,
@@ -132,7 +131,7 @@ describe("user store tests", () => {
         },
       });
 
-      userPreferencesState.logViewerPreferences = {
+      state.logViewerPreferences = {
         showTimestamps: false,
         showPrevious: false,
         showWordWrap: true,

--- a/packages/core/src/common/__tests__/user-store.test.ts
+++ b/packages/core/src/common/__tests__/user-store.test.ts
@@ -93,5 +93,54 @@ describe("user store tests", () => {
         },
       });
     });
+
+    it("loads and stores logViewerPreferences as a global preference", async () => {
+      const writeJsonSync = di.inject(writeJsonSyncInjectable);
+      const readJsonSync = di.inject(readJsonSyncInjectable);
+      const userPreferencesState = state as Record<string, unknown>;
+
+      writeJsonSync("/some-directory-for-user-data/lens-user-store.json", {
+        preferences: {
+          logViewerPreferences: {
+            showTimestamps: true,
+            showWordWrap: false,
+          },
+        },
+      });
+      writeJsonSync("/some-directory-for-user-data/kube_config", {});
+
+      di.inject(userPreferencesPersistentStorageInjectable).loadAndStartSyncing();
+
+      expect(userPreferencesState.logViewerPreferences).toEqual({
+        showTimestamps: true,
+        showPrevious: false,
+        showWordWrap: false,
+      });
+
+      userPreferencesState.logViewerPreferences = {
+        showTimestamps: false,
+        showPrevious: true,
+        showWordWrap: false,
+      };
+
+      expect(readJsonSync("/some-directory-for-user-data/lens-user-store.json")).toMatchObject({
+        preferences: {
+          logViewerPreferences: {
+            showPrevious: true,
+            showWordWrap: false,
+          },
+        },
+      });
+
+      userPreferencesState.logViewerPreferences = {
+        showTimestamps: false,
+        showPrevious: false,
+        showWordWrap: true,
+      };
+
+      expect(
+        readJsonSync("/some-directory-for-user-data/lens-user-store.json").preferences.logViewerPreferences,
+      ).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -12,9 +12,9 @@ import { defaultColorThemePreference } from "../../../common/vars";
 import currentTimezoneInjectable from "../../../common/vars/current-timezone.injectable";
 import {
   ClusterPageMenuOrder,
-  defaultLogViewerPreferences,
   defaultEditorConfig,
   defaultExtensionRegistryUrlLocation,
+  defaultLogViewerPreferences,
   defaultPackageMirror,
   defaultTerminalConfig,
   getPreferenceDescriptor,
@@ -115,9 +115,13 @@ const userPreferenceDescriptorsInjectable = getInjectable({
           ...val,
         }),
         toStore: (val) => {
-          const storedValue = Object.fromEntries(
-            Object.entries(val).filter(([key, value]) => defaultLogViewerPreferences[key as keyof LogViewerPreferences] !== value),
-          ) as Partial<LogViewerPreferences>;
+          const storedValue: Partial<LogViewerPreferences> = {};
+
+          for (const key of Object.keys(defaultLogViewerPreferences) as (keyof LogViewerPreferences)[]) {
+            if (val[key] !== defaultLogViewerPreferences[key]) {
+              storedValue[key] = val[key];
+            }
+          }
 
           return Object.keys(storedValue).length > 0 ? storedValue : undefined;
         },

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -12,6 +12,7 @@ import { defaultColorThemePreference } from "../../../common/vars";
 import currentTimezoneInjectable from "../../../common/vars/current-timezone.injectable";
 import {
   ClusterPageMenuOrder,
+  defaultLogViewerPreferences,
   defaultEditorConfig,
   defaultExtensionRegistryUrlLocation,
   defaultPackageMirror,
@@ -27,6 +28,7 @@ import type {
   ExtensionRegistry,
   KubeconfigSyncEntry,
   KubeconfigSyncValue,
+  LogViewerPreferences,
   TerminalConfig,
 } from "./preferences-helpers";
 
@@ -106,6 +108,19 @@ const userPreferenceDescriptorsInjectable = getInjectable({
       persistentSearch: getPreferenceDescriptor<boolean>({
         fromStore: (val) => val ?? false,
         toStore: (val) => (!val ? undefined : val),
+      }),
+      logViewerPreferences: getPreferenceDescriptor<Partial<LogViewerPreferences>, LogViewerPreferences>({
+        fromStore: (val) => ({
+          ...defaultLogViewerPreferences,
+          ...val,
+        }),
+        toStore: (val) => {
+          const storedValue = Object.fromEntries(
+            Object.entries(val).filter(([key, value]) => defaultLogViewerPreferences[key as keyof LogViewerPreferences] !== value),
+          ) as Partial<LogViewerPreferences>;
+
+          return Object.keys(storedValue).length > 0 ? storedValue : undefined;
+        },
       }),
       terminalCopyOnSelect: getPreferenceDescriptor<boolean>({
         fromStore: (val) => val ?? false,

--- a/packages/core/src/features/user-preferences/common/preferences-helpers.ts
+++ b/packages/core/src/features/user-preferences/common/preferences-helpers.ts
@@ -20,6 +20,18 @@ export interface TerminalConfig {
   fontFamily: string;
 }
 
+export interface LogViewerPreferences {
+  showTimestamps: boolean;
+  showPrevious: boolean;
+  showWordWrap: boolean;
+}
+
+export const defaultLogViewerPreferences: LogViewerPreferences = {
+  showTimestamps: false,
+  showPrevious: false,
+  showWordWrap: true,
+};
+
 export const defaultTerminalConfig: TerminalConfig = {
   fontSize: defaultFontSize,
   fontFamily: defaultTerminalFontFamily,

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -54,6 +54,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.showTrayIcon = descriptors.showTrayIcon.fromStore(preferences.showTrayIcon);
         state.hotbarAutoHide = descriptors.hotbarAutoHide.fromStore(preferences.hotbarAutoHide);
         state.persistentSearch = descriptors.persistentSearch.fromStore(preferences.persistentSearch);
+        state.logViewerPreferences = descriptors.logViewerPreferences.fromStore(preferences.logViewerPreferences);
         state.shell = descriptors.shell.fromStore(preferences.shell);
         state.syncKubeconfigEntries = descriptors.syncKubeconfigEntries.fromStore(preferences.syncKubeconfigEntries);
         state.terminalConfig = descriptors.terminalConfig.fromStore(preferences.terminalConfig);
@@ -80,6 +81,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             showTrayIcon: descriptors.showTrayIcon.toStore(state.showTrayIcon),
             hotbarAutoHide: descriptors.hotbarAutoHide.toStore(state.hotbarAutoHide),
             persistentSearch: descriptors.persistentSearch.toStore(state.persistentSearch),
+            logViewerPreferences: descriptors.logViewerPreferences.toStore(state.logViewerPreferences),
             shell: descriptors.shell.toStore(state.shell),
             syncKubeconfigEntries: descriptors.syncKubeconfigEntries.toStore(state.syncKubeconfigEntries),
             terminalConfig: descriptors.terminalConfig.toStore(state.terminalConfig),

--- a/packages/core/src/renderer/components/dock/logs/__test__/controls.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/controls.test.tsx
@@ -9,63 +9,34 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
-import { SearchStore } from "../../../../search-store/search-store";
 import { renderFor } from "../../../test-utils/renderFor";
 import { LogControls } from "../controls";
 import { LogTabViewModel } from "../logs-view-model";
 import { dockerPod } from "./pod.mock";
+import {
+  createMockLogTabViewModel,
+  getDefaultOnePodLogTabData,
+  initializeDefaultLogViewerPreferences,
+} from "./test-utils";
 
 import type { UserEvent } from "@testing-library/user-event";
+
+import type { LogViewerPreferences } from "../../../../../features/user-preferences/common/preferences-helpers";
 import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { TabId } from "../../dock/store";
 import type { LogTabViewModelDependencies } from "../logs-view-model";
 
-function mockLogTabViewModel(
-  tabId: TabId,
-  userPreferencesState: UserPreferencesState,
-  deps: Partial<LogTabViewModelDependencies>,
-): LogTabViewModel {
-  return new LogTabViewModel(tabId, {
-    getLogs: jest.fn(),
-    getLogsWithoutTimestamps: jest.fn(),
-    getTimestampSplitLogs: jest.fn(() => []),
-    getLogTabData: jest.fn(),
-    setLogTabData: jest.fn(),
-    loadLogs: jest.fn(),
-    reloadLogs: jest.fn(),
-    renameTab: jest.fn(),
-    stopLoadingLogs: jest.fn(),
-    getPodById: jest.fn(),
-    getPodsByOwnerId: jest.fn(),
-    areLogsPresent: jest.fn(),
-    searchStore: new SearchStore(),
-    downloadLogs: jest.fn(),
-    downloadAllLogs: jest.fn(),
-    userPreferencesState,
-    ...deps,
-  });
-}
-
 function getOnePodViewModel(
   tabId: TabId,
   userPreferencesState: UserPreferencesState,
-  logViewerPreferences: {
-    showTimestamps: boolean;
-    showPrevious: boolean;
-    showWordWrap: boolean;
-  },
+  logViewerPreferences: LogViewerPreferences,
   deps: Partial<LogTabViewModelDependencies> = {},
 ): LogTabViewModel {
   const selectedPod = dockerPod;
 
-  return mockLogTabViewModel(tabId, userPreferencesState, {
-    getLogTabData: () => ({
-      selectedPodId: selectedPod.getId(),
-      selectedContainer: selectedPod.getContainers()[0].name,
-      namespace: selectedPod.getNs(),
-      ...logViewerPreferences,
-    }),
+  return createMockLogTabViewModel(tabId, userPreferencesState, {
+    getLogTabData: () => getDefaultOnePodLogTabData(logViewerPreferences),
     getPodById: (id) => {
       if (id === selectedPod.getId()) {
         return selectedPod;
@@ -89,11 +60,7 @@ describe("LogControls", () => {
     render = renderFor(di);
     user = userEvent.setup();
     userPreferencesState = di.inject(userPreferencesStateInjectable);
-    userPreferencesState.logViewerPreferences = {
-      showTimestamps: false,
-      showPrevious: false,
-      showWordWrap: true,
-    };
+    initializeDefaultLogViewerPreferences(userPreferencesState);
     model = getOnePodViewModel("foobar", userPreferencesState, {
       showTimestamps: false,
       showPrevious: false,
@@ -102,11 +69,7 @@ describe("LogControls", () => {
   });
 
   it("toggles timestamps through log viewer preferences", async () => {
-    const updateLogPreferencesSpy = jest.fn();
-
-    Object.assign(model as object, {
-      updateLogPreferences: updateLogPreferencesSpy,
-    });
+    const updateLogPreferencesSpy = jest.spyOn(model, "updateLogPreferences");
 
     render(<LogControls model={model} />);
 
@@ -116,11 +79,7 @@ describe("LogControls", () => {
   });
 
   it("toggles word wrap through log viewer preferences", async () => {
-    const updateLogPreferencesSpy = jest.fn();
-
-    Object.assign(model as object, {
-      updateLogPreferences: updateLogPreferencesSpy,
-    });
+    const updateLogPreferencesSpy = jest.spyOn(model, "updateLogPreferences");
 
     render(<LogControls model={model} />);
 
@@ -130,12 +89,8 @@ describe("LogControls", () => {
   });
 
   it("toggles previous container through log viewer preferences and reloads logs", async () => {
-    const updateLogPreferencesSpy = jest.fn();
+    const updateLogPreferencesSpy = jest.spyOn(model, "updateLogPreferences");
     const reloadLogsSpy = jest.spyOn(model, "reloadLogs");
-
-    Object.assign(model as object, {
-      updateLogPreferences: updateLogPreferencesSpy,
-    });
 
     render(<LogControls model={model} />);
 

--- a/packages/core/src/renderer/components/dock/logs/__test__/controls.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/controls.test.tsx
@@ -68,35 +68,42 @@ describe("LogControls", () => {
     });
   });
 
-  it("toggles timestamps through log viewer preferences", async () => {
-    const updateLogPreferencesSpy = jest.spyOn(model, "updateLogPreferences");
-
+  it("updates the saved timestamp preference when toggled", async () => {
     render(<LogControls model={model} />);
 
     await user.click(await screen.findByText("Show timestamps"));
 
-    expect(updateLogPreferencesSpy).toHaveBeenCalledWith({ showTimestamps: true });
+    expect(userPreferencesState.logViewerPreferences).toEqual({
+      showTimestamps: true,
+      showPrevious: false,
+      showWordWrap: true,
+    });
   });
 
-  it("toggles word wrap through log viewer preferences", async () => {
-    const updateLogPreferencesSpy = jest.spyOn(model, "updateLogPreferences");
-
+  it("updates the saved word wrap preference when toggled", async () => {
     render(<LogControls model={model} />);
 
     await user.click(await screen.findByText("Word wrap"));
 
-    expect(updateLogPreferencesSpy).toHaveBeenCalledWith({ showWordWrap: false });
+    expect(userPreferencesState.logViewerPreferences).toEqual({
+      showTimestamps: false,
+      showPrevious: false,
+      showWordWrap: false,
+    });
   });
 
-  it("toggles previous container through log viewer preferences and reloads logs", async () => {
-    const updateLogPreferencesSpy = jest.spyOn(model, "updateLogPreferences");
+  it("updates the saved previous-container preference before reloading logs", async () => {
     const reloadLogsSpy = jest.spyOn(model, "reloadLogs");
 
     render(<LogControls model={model} />);
 
     await user.click(await screen.findByText("Show previous terminated container"));
 
-    expect(updateLogPreferencesSpy).toHaveBeenCalledWith({ showPrevious: true });
-    expect(reloadLogsSpy).toHaveBeenCalled();
+    expect(userPreferencesState.logViewerPreferences).toEqual({
+      showTimestamps: false,
+      showPrevious: true,
+      showWordWrap: true,
+    });
+    expect(reloadLogsSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/renderer/components/dock/logs/__test__/controls.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/controls.test.tsx
@@ -7,6 +7,7 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
+import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import { SearchStore } from "../../../../search-store/search-store";
 import { renderFor } from "../../../test-utils/renderFor";
@@ -15,12 +16,16 @@ import { LogTabViewModel } from "../logs-view-model";
 import { dockerPod } from "./pod.mock";
 
 import type { UserEvent } from "@testing-library/user-event";
-
+import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { TabId } from "../../dock/store";
 import type { LogTabViewModelDependencies } from "../logs-view-model";
 
-function mockLogTabViewModel(tabId: TabId, deps: Partial<LogTabViewModelDependencies>): LogTabViewModel {
+function mockLogTabViewModel(
+  tabId: TabId,
+  userPreferencesState: UserPreferencesState,
+  deps: Partial<LogTabViewModelDependencies>,
+): LogTabViewModel {
   return new LogTabViewModel(tabId, {
     getLogs: jest.fn(),
     getLogsWithoutTimestamps: jest.fn(),
@@ -37,25 +42,29 @@ function mockLogTabViewModel(tabId: TabId, deps: Partial<LogTabViewModelDependen
     searchStore: new SearchStore(),
     downloadLogs: jest.fn(),
     downloadAllLogs: jest.fn(),
+    userPreferencesState,
     ...deps,
   });
 }
 
 function getOnePodViewModel(
   tabId: TabId,
-  showWordWrap: boolean,
+  userPreferencesState: UserPreferencesState,
+  logViewerPreferences: {
+    showTimestamps: boolean;
+    showPrevious: boolean;
+    showWordWrap: boolean;
+  },
   deps: Partial<LogTabViewModelDependencies> = {},
 ): LogTabViewModel {
   const selectedPod = dockerPod;
 
-  return mockLogTabViewModel(tabId, {
+  return mockLogTabViewModel(tabId, userPreferencesState, {
     getLogTabData: () => ({
       selectedPodId: selectedPod.getId(),
       selectedContainer: selectedPod.getContainers()[0].name,
       namespace: selectedPod.getNs(),
-      showPrevious: false,
-      showTimestamps: false,
-      showWordWrap,
+      ...logViewerPreferences,
     }),
     getPodById: (id) => {
       if (id === selectedPod.getId()) {
@@ -71,33 +80,68 @@ function getOnePodViewModel(
 describe("LogControls", () => {
   let render: DiRender;
   let user: UserEvent;
+  let model: LogTabViewModel;
+  let userPreferencesState: UserPreferencesState;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
 
     render = renderFor(di);
     user = userEvent.setup();
+    userPreferencesState = di.inject(userPreferencesStateInjectable);
+    userPreferencesState.logViewerPreferences = {
+      showTimestamps: false,
+      showPrevious: false,
+      showWordWrap: true,
+    };
+    model = getOnePodViewModel("foobar", userPreferencesState, {
+      showTimestamps: false,
+      showPrevious: false,
+      showWordWrap: true,
+    });
   });
 
-  it("enables word wrap when it is currently disabled", async () => {
-    const model = getOnePodViewModel("foobar", false);
-    const updateLogTabDataSpy = jest.spyOn(model, "updateLogTabData");
+  it("toggles timestamps through log viewer preferences", async () => {
+    const updateLogPreferencesSpy = jest.fn();
+
+    Object.assign(model as object, {
+      updateLogPreferences: updateLogPreferencesSpy,
+    });
+
+    render(<LogControls model={model} />);
+
+    await user.click(await screen.findByText("Show timestamps"));
+
+    expect(updateLogPreferencesSpy).toHaveBeenCalledWith({ showTimestamps: true });
+  });
+
+  it("toggles word wrap through log viewer preferences", async () => {
+    const updateLogPreferencesSpy = jest.fn();
+
+    Object.assign(model as object, {
+      updateLogPreferences: updateLogPreferencesSpy,
+    });
 
     render(<LogControls model={model} />);
 
     await user.click(await screen.findByText("Word wrap"));
 
-    expect(updateLogTabDataSpy).toHaveBeenCalledWith({ showWordWrap: true });
+    expect(updateLogPreferencesSpy).toHaveBeenCalledWith({ showWordWrap: false });
   });
 
-  it("disables word wrap when it is currently enabled", async () => {
-    const model = getOnePodViewModel("foobar", true);
-    const updateLogTabDataSpy = jest.spyOn(model, "updateLogTabData");
+  it("toggles previous container through log viewer preferences and reloads logs", async () => {
+    const updateLogPreferencesSpy = jest.fn();
+    const reloadLogsSpy = jest.spyOn(model, "reloadLogs");
+
+    Object.assign(model as object, {
+      updateLogPreferences: updateLogPreferencesSpy,
+    });
 
     render(<LogControls model={model} />);
 
-    await user.click(await screen.findByText("Word wrap"));
+    await user.click(await screen.findByText("Show previous terminated container"));
 
-    expect(updateLogTabDataSpy).toHaveBeenCalledWith({ showWordWrap: false });
+    expect(updateLogPreferencesSpy).toHaveBeenCalledWith({ showPrevious: true });
+    expect(reloadLogsSpy).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/renderer/components/dock/logs/__test__/create-logs-tab.injectable.test.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/create-logs-tab.injectable.test.ts
@@ -11,6 +11,7 @@ import getLogTabDataInjectable from "../get-log-tab-data.injectable";
 import getRandomIdForPodLogsTabInjectable from "../get-random-id-for-pod-logs-tab.injectable";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+
 import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
 
 describe("create logs tab", () => {

--- a/packages/core/src/renderer/components/dock/logs/__test__/create-logs-tab.injectable.test.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/create-logs-tab.injectable.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
+import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
+import createLogsTabInjectable from "../create-logs-tab.injectable";
+import getLogTabDataInjectable from "../get-log-tab-data.injectable";
+import getRandomIdForPodLogsTabInjectable from "../get-random-id-for-pod-logs-tab.injectable";
+
+import type { DiContainer } from "@ogre-tools/injectable";
+import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
+
+describe("create logs tab", () => {
+  let di: DiContainer;
+  let userPreferencesState: UserPreferencesState;
+
+  beforeEach(() => {
+    di = getDiForUnitTesting();
+    di.override(getRandomIdForPodLogsTabInjectable, () => () => "test-id");
+
+    userPreferencesState = di.inject(userPreferencesStateInjectable);
+  });
+
+  it("uses global log viewer preferences as the default tab state", () => {
+    userPreferencesState.logViewerPreferences = {
+      showTimestamps: true,
+      showPrevious: true,
+      showWordWrap: false,
+    };
+
+    const createLogsTab = di.inject(createLogsTabInjectable);
+    const getLogTabData = di.inject(getLogTabDataInjectable);
+    const tabId = createLogsTab("Pod some-pod", {
+      namespace: "default",
+      selectedPodId: "pod-1",
+      selectedContainer: "container-1",
+    });
+
+    expect(getLogTabData(tabId)).toMatchObject({
+      namespace: "default",
+      selectedPodId: "pod-1",
+      selectedContainer: "container-1",
+      showTimestamps: true,
+      showPrevious: true,
+      showWordWrap: false,
+    });
+  });
+});

--- a/packages/core/src/renderer/components/dock/logs/__test__/list.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/list.test.tsx
@@ -6,6 +6,7 @@
 
 import "@testing-library/jest-dom";
 import React from "react";
+import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import { SearchStore } from "../../../../search-store/search-store";
 import { renderFor } from "../../../test-utils/renderFor";
@@ -13,6 +14,7 @@ import { LogList } from "../list";
 import { LogTabViewModel } from "../logs-view-model";
 import { dockerPod } from "./pod.mock";
 
+import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { TabId } from "../../dock/store";
 import type { LogTabViewModelDependencies } from "../logs-view-model";
@@ -31,7 +33,11 @@ jest.mock("../../../virtual-list", () => {
   };
 });
 
-function mockLogTabViewModel(tabId: TabId, deps: Partial<LogTabViewModelDependencies>): LogTabViewModel {
+function mockLogTabViewModel(
+  tabId: TabId,
+  userPreferencesState: UserPreferencesState,
+  deps: Partial<LogTabViewModelDependencies>,
+): LogTabViewModel {
   return new LogTabViewModel(tabId, {
     getLogs: jest.fn(),
     getLogsWithoutTimestamps: jest.fn(),
@@ -48,14 +54,15 @@ function mockLogTabViewModel(tabId: TabId, deps: Partial<LogTabViewModelDependen
     searchStore: new SearchStore(),
     downloadLogs: jest.fn(),
     downloadAllLogs: jest.fn(),
+    userPreferencesState,
     ...deps,
   });
 }
 
-function getOnePodViewModel(tabId: TabId, showWordWrap: boolean): LogTabViewModel {
+function getOnePodViewModel(tabId: TabId, userPreferencesState: UserPreferencesState, showWordWrap: boolean): LogTabViewModel {
   const selectedPod = dockerPod;
 
-  return mockLogTabViewModel(tabId, {
+  return mockLogTabViewModel(tabId, userPreferencesState, {
     getLogTabData: () => ({
       selectedPodId: selectedPod.getId(),
       selectedContainer: selectedPod.getContainers()[0].name,
@@ -77,23 +84,30 @@ function getOnePodViewModel(tabId: TabId, showWordWrap: boolean): LogTabViewMode
 
 describe("LogList", () => {
   let render: DiRender;
+  let userPreferencesState: UserPreferencesState;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
 
     render = renderFor(di);
     virtualListMock.mockClear();
+    userPreferencesState = di.inject(userPreferencesStateInjectable);
+    userPreferencesState.logViewerPreferences = {
+      showTimestamps: false,
+      showPrevious: false,
+      showWordWrap: true,
+    };
   });
 
   it("does not add wordWrap class when showWordWrap is disabled", () => {
-    const model = getOnePodViewModel("foobar", false);
+    const model = getOnePodViewModel("foobar", userPreferencesState, false);
     const { container } = render(<LogList model={model} />);
 
     expect(container.querySelector(".LogRow.wordWrap")).not.toBeInTheDocument();
   });
 
   it("adds wordWrap class when showWordWrap is enabled", () => {
-    const model = getOnePodViewModel("foobar", true);
+    const model = getOnePodViewModel("foobar", userPreferencesState, true);
     const { container } = render(<LogList model={model} />);
 
     expect(container.querySelector(".LogRow.wordWrap")).toBeInTheDocument();

--- a/packages/core/src/renderer/components/dock/logs/__test__/list.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/list.test.tsx
@@ -8,16 +8,19 @@ import "@testing-library/jest-dom";
 import React from "react";
 import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
-import { SearchStore } from "../../../../search-store/search-store";
 import { renderFor } from "../../../test-utils/renderFor";
 import { LogList } from "../list";
 import { LogTabViewModel } from "../logs-view-model";
 import { dockerPod } from "./pod.mock";
+import {
+  createMockLogTabViewModel,
+  getDefaultOnePodLogTabData,
+  initializeDefaultLogViewerPreferences,
+} from "./test-utils";
 
 import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { TabId } from "../../dock/store";
-import type { LogTabViewModelDependencies } from "../logs-view-model";
 
 const virtualListMock = jest.fn();
 
@@ -33,44 +36,15 @@ jest.mock("../../../virtual-list", () => {
   };
 });
 
-function mockLogTabViewModel(
+function getOnePodViewModel(
   tabId: TabId,
   userPreferencesState: UserPreferencesState,
-  deps: Partial<LogTabViewModelDependencies>,
+  showWordWrap: boolean,
 ): LogTabViewModel {
-  return new LogTabViewModel(tabId, {
-    getLogs: jest.fn(),
-    getLogsWithoutTimestamps: jest.fn(),
-    getTimestampSplitLogs: jest.fn(() => []),
-    getLogTabData: jest.fn(),
-    setLogTabData: jest.fn(),
-    loadLogs: jest.fn(),
-    reloadLogs: jest.fn(),
-    renameTab: jest.fn(),
-    stopLoadingLogs: jest.fn(),
-    getPodById: jest.fn(),
-    getPodsByOwnerId: jest.fn(),
-    areLogsPresent: jest.fn(() => false),
-    searchStore: new SearchStore(),
-    downloadLogs: jest.fn(),
-    downloadAllLogs: jest.fn(),
-    userPreferencesState,
-    ...deps,
-  });
-}
-
-function getOnePodViewModel(tabId: TabId, userPreferencesState: UserPreferencesState, showWordWrap: boolean): LogTabViewModel {
   const selectedPod = dockerPod;
 
-  return mockLogTabViewModel(tabId, userPreferencesState, {
-    getLogTabData: () => ({
-      selectedPodId: selectedPod.getId(),
-      selectedContainer: selectedPod.getContainers()[0].name,
-      namespace: selectedPod.getNs(),
-      showPrevious: false,
-      showTimestamps: false,
-      showWordWrap,
-    }),
+  return createMockLogTabViewModel(tabId, userPreferencesState, {
+    getLogTabData: () => getDefaultOnePodLogTabData({ showWordWrap }),
     getLogsWithoutTimestamps: () => ["Regular log line"],
     getPodById: (id) => {
       if (id === selectedPod.getId()) {
@@ -92,11 +66,7 @@ describe("LogList", () => {
     render = renderFor(di);
     virtualListMock.mockClear();
     userPreferencesState = di.inject(userPreferencesStateInjectable);
-    userPreferencesState.logViewerPreferences = {
-      showTimestamps: false,
-      showPrevious: false,
-      showWordWrap: true,
-    };
+    initializeDefaultLogViewerPreferences(userPreferencesState);
   });
 
   it("does not add wordWrap class when showWordWrap is disabled", () => {

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
@@ -13,44 +13,23 @@ import directoryForUserDataInjectable from "../../../../../common/app-paths/dire
 import fsInjectable from "../../../../../common/fs/fs.injectable";
 import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
-import { SearchStore } from "../../../../search-store/search-store";
 import { renderFor } from "../../../test-utils/renderFor";
 import callForLogsInjectable from "../call-for-logs.injectable";
 import { LogTabViewModel } from "../logs-view-model";
 import { LogResourceSelector } from "../resource-selector";
 import { deploymentPod1, deploymentPod2, dockerPod } from "./pod.mock";
+import {
+  createMockLogTabViewModel,
+  getDefaultOnePodLogTabData,
+  initializeDefaultLogViewerPreferences,
+} from "./test-utils";
 
 import type { UserEvent } from "@testing-library/user-event";
+
 import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { TabId } from "../../dock/store";
 import type { LogTabViewModelDependencies } from "../logs-view-model";
-
-function mockLogTabViewModel(
-  tabId: TabId,
-  userPreferencesState: UserPreferencesState,
-  deps: Partial<LogTabViewModelDependencies>,
-): LogTabViewModel {
-  return new LogTabViewModel(tabId, {
-    getLogs: jest.fn(),
-    getLogsWithoutTimestamps: jest.fn(),
-    getTimestampSplitLogs: jest.fn(),
-    getLogTabData: jest.fn(),
-    setLogTabData: jest.fn(),
-    loadLogs: jest.fn(),
-    reloadLogs: jest.fn(),
-    renameTab: jest.fn(),
-    stopLoadingLogs: jest.fn(),
-    getPodById: jest.fn(),
-    getPodsByOwnerId: jest.fn(),
-    searchStore: new SearchStore(),
-    areLogsPresent: jest.fn(),
-    downloadLogs: jest.fn(),
-    downloadAllLogs: jest.fn(),
-    userPreferencesState,
-    ...deps,
-  });
-}
 
 function getOnePodViewModel(
   tabId: TabId,
@@ -59,15 +38,8 @@ function getOnePodViewModel(
 ): LogTabViewModel {
   const selectedPod = dockerPod;
 
-  return mockLogTabViewModel(tabId, userPreferencesState, {
-    getLogTabData: () => ({
-      selectedPodId: selectedPod.getId(),
-      selectedContainer: selectedPod.getContainers()[0].name,
-      namespace: selectedPod.getNs(),
-      showPrevious: false,
-      showTimestamps: false,
-      showWordWrap: false,
-    }),
+  return createMockLogTabViewModel(tabId, userPreferencesState, {
+    getLogTabData: () => getDefaultOnePodLogTabData(),
     getPodById: (id) => {
       if (id === selectedPod.getId()) {
         return selectedPod;
@@ -87,19 +59,18 @@ const getFewPodsTabData = (
   const selectedPod = deploymentPod1;
   const anotherPod = deploymentPod2;
 
-  return mockLogTabViewModel(tabId, userPreferencesState, {
+  return createMockLogTabViewModel(tabId, userPreferencesState, {
     getLogTabData: () => ({
+      ...getDefaultOnePodLogTabData({
+        selectedPodId: selectedPod.getId(),
+        selectedContainer: selectedPod.getContainers()[0].name,
+        namespace: selectedPod.getNs(),
+      }),
       owner: {
         uid: "uuid",
         kind: "Deployment",
         name: "super-deployment",
       },
-      selectedPodId: selectedPod.getId(),
-      selectedContainer: selectedPod.getContainers()[0].name,
-      namespace: selectedPod.getNs(),
-      showPrevious: false,
-      showTimestamps: false,
-      showWordWrap: false,
     }),
     getPodById: (id) => {
       if (id === selectedPod.getId()) {
@@ -142,11 +113,7 @@ describe("<LogResourceSelector />", () => {
 
     user = userEvent.setup();
     userPreferencesState = di.inject(userPreferencesStateInjectable);
-    userPreferencesState.logViewerPreferences = {
-      showTimestamps: false,
-      showPrevious: false,
-      showWordWrap: true,
-    };
+    initializeDefaultLogViewerPreferences(userPreferencesState);
   });
 
   describe("with one pod", () => {

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
@@ -11,6 +11,7 @@ import assert from "assert";
 import * as selectEvent from "react-select-event";
 import directoryForUserDataInjectable from "../../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import fsInjectable from "../../../../../common/fs/fs.injectable";
+import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import { SearchStore } from "../../../../search-store/search-store";
 import { renderFor } from "../../../test-utils/renderFor";
@@ -20,12 +21,16 @@ import { LogResourceSelector } from "../resource-selector";
 import { deploymentPod1, deploymentPod2, dockerPod } from "./pod.mock";
 
 import type { UserEvent } from "@testing-library/user-event";
-
+import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { TabId } from "../../dock/store";
 import type { LogTabViewModelDependencies } from "../logs-view-model";
 
-function mockLogTabViewModel(tabId: TabId, deps: Partial<LogTabViewModelDependencies>): LogTabViewModel {
+function mockLogTabViewModel(
+  tabId: TabId,
+  userPreferencesState: UserPreferencesState,
+  deps: Partial<LogTabViewModelDependencies>,
+): LogTabViewModel {
   return new LogTabViewModel(tabId, {
     getLogs: jest.fn(),
     getLogsWithoutTimestamps: jest.fn(),
@@ -42,14 +47,19 @@ function mockLogTabViewModel(tabId: TabId, deps: Partial<LogTabViewModelDependen
     areLogsPresent: jest.fn(),
     downloadLogs: jest.fn(),
     downloadAllLogs: jest.fn(),
+    userPreferencesState,
     ...deps,
   });
 }
 
-function getOnePodViewModel(tabId: TabId, deps: Partial<LogTabViewModelDependencies> = {}): LogTabViewModel {
+function getOnePodViewModel(
+  tabId: TabId,
+  userPreferencesState: UserPreferencesState,
+  deps: Partial<LogTabViewModelDependencies> = {},
+): LogTabViewModel {
   const selectedPod = dockerPod;
 
-  return mockLogTabViewModel(tabId, {
+  return mockLogTabViewModel(tabId, userPreferencesState, {
     getLogTabData: () => ({
       selectedPodId: selectedPod.getId(),
       selectedContainer: selectedPod.getContainers()[0].name,
@@ -69,11 +79,15 @@ function getOnePodViewModel(tabId: TabId, deps: Partial<LogTabViewModelDependenc
   });
 }
 
-const getFewPodsTabData = (tabId: TabId, deps: Partial<LogTabViewModelDependencies> = {}): LogTabViewModel => {
+const getFewPodsTabData = (
+  tabId: TabId,
+  userPreferencesState: UserPreferencesState,
+  deps: Partial<LogTabViewModelDependencies> = {},
+): LogTabViewModel => {
   const selectedPod = deploymentPod1;
   const anotherPod = deploymentPod2;
 
-  return mockLogTabViewModel(tabId, {
+  return mockLogTabViewModel(tabId, userPreferencesState, {
     getLogTabData: () => ({
       owner: {
         uid: "uuid",
@@ -112,6 +126,7 @@ const getFewPodsTabData = (tabId: TabId, deps: Partial<LogTabViewModelDependenci
 describe("<LogResourceSelector />", () => {
   let render: DiRender;
   let user: UserEvent;
+  let userPreferencesState: UserPreferencesState;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -126,13 +141,19 @@ describe("<LogResourceSelector />", () => {
     ensureDirSync("/tmp");
 
     user = userEvent.setup();
+    userPreferencesState = di.inject(userPreferencesStateInjectable);
+    userPreferencesState.logViewerPreferences = {
+      showTimestamps: false,
+      showPrevious: false,
+      showWordWrap: true,
+    };
   });
 
   describe("with one pod", () => {
     let model: LogTabViewModel;
 
     beforeEach(() => {
-      model = getOnePodViewModel("foobar");
+      model = getOnePodViewModel("foobar", userPreferencesState);
     });
 
     it("renders w/o errors", () => {
@@ -162,7 +183,7 @@ describe("<LogResourceSelector />", () => {
 
     beforeEach(() => {
       renameTab = jest.fn();
-      model = getFewPodsTabData("foobar", { renameTab });
+      model = getFewPodsTabData("foobar", userPreferencesState, { renameTab });
     });
 
     it("renders sibling pods in dropdown", async () => {

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
@@ -7,6 +7,7 @@
 import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
+import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import { SearchStore } from "../../../../search-store/search-store";
 import { renderFor } from "../../../test-utils/renderFor";
@@ -15,12 +16,16 @@ import { LogSearch } from "../search";
 import { dockerPod } from "./pod.mock";
 
 import type { UserEvent } from "@testing-library/user-event";
-
+import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { TabId } from "../../dock/store";
 import type { LogTabViewModelDependencies } from "../logs-view-model";
 
-function mockLogTabViewModel(tabId: TabId, deps: Partial<LogTabViewModelDependencies>): LogTabViewModel {
+function mockLogTabViewModel(
+  tabId: TabId,
+  userPreferencesState: UserPreferencesState,
+  deps: Partial<LogTabViewModelDependencies>,
+): LogTabViewModel {
   return new LogTabViewModel(tabId, {
     getLogs: jest.fn(),
     getLogsWithoutTimestamps: jest.fn(),
@@ -37,14 +42,19 @@ function mockLogTabViewModel(tabId: TabId, deps: Partial<LogTabViewModelDependen
     searchStore: new SearchStore(),
     downloadLogs: jest.fn(),
     downloadAllLogs: jest.fn(),
+    userPreferencesState,
     ...deps,
   });
 }
 
-const getOnePodViewModel = (tabId: TabId, deps: Partial<LogTabViewModelDependencies> = {}): LogTabViewModel => {
+const getOnePodViewModel = (
+  tabId: TabId,
+  userPreferencesState: UserPreferencesState,
+  deps: Partial<LogTabViewModelDependencies> = {},
+): LogTabViewModel => {
   const selectedPod = dockerPod;
 
-  return mockLogTabViewModel(tabId, {
+  return mockLogTabViewModel(tabId, userPreferencesState, {
     getLogTabData: () => ({
       selectedPodId: selectedPod.getId(),
       selectedContainer: selectedPod.getContainers()[0].name,
@@ -67,6 +77,7 @@ const getOnePodViewModel = (tabId: TabId, deps: Partial<LogTabViewModelDependenc
 describe("LogSearch tests", () => {
   let render: DiRender;
   let user: UserEvent;
+  let userPreferencesState: UserPreferencesState;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -74,6 +85,12 @@ describe("LogSearch tests", () => {
     render = renderFor(di);
 
     user = userEvent.setup();
+    userPreferencesState = di.inject(userPreferencesStateInjectable);
+    userPreferencesState.logViewerPreferences = {
+      showTimestamps: false,
+      showPrevious: false,
+      showWordWrap: true,
+    };
   });
 
   afterEach(() => {
@@ -81,7 +98,7 @@ describe("LogSearch tests", () => {
   });
 
   it("renders w/o errors", () => {
-    const model = getOnePodViewModel("foobar");
+    const model = getOnePodViewModel("foobar", userPreferencesState);
     const { container } = render(<LogSearch model={model} scrollToOverlay={jest.fn()} />);
 
     expect(container).toBeInstanceOf(HTMLElement);
@@ -89,7 +106,7 @@ describe("LogSearch tests", () => {
 
   it("should scroll to new active overlay when clicking the previous button", async () => {
     const scrollToOverlay = jest.fn();
-    const model = getOnePodViewModel("foobar", {
+    const model = getOnePodViewModel("foobar", userPreferencesState, {
       getLogsWithoutTimestamps: () => ["hello", "world"],
     });
 
@@ -103,7 +120,7 @@ describe("LogSearch tests", () => {
 
   it("should scroll to new active overlay when clicking the next button", async () => {
     const scrollToOverlay = jest.fn();
-    const model = getOnePodViewModel("foobar", {
+    const model = getOnePodViewModel("foobar", userPreferencesState, {
       getLogsWithoutTimestamps: () => ["hello", "world"],
     });
 
@@ -117,7 +134,7 @@ describe("LogSearch tests", () => {
 
   it("next and previous should be disabled initially", async () => {
     const scrollToOverlay = jest.fn();
-    const model = getOnePodViewModel("foobar", {
+    const model = getOnePodViewModel("foobar", userPreferencesState, {
       getLogsWithoutTimestamps: () => ["hello", "world"],
     });
 
@@ -133,7 +150,7 @@ describe("LogSearch tests", () => {
     { label: "cmd+f", eventInit: { key: "f", metaKey: true } },
   ])("should prefill search on $label when selection is inside pod logs list", async ({ eventInit }) => {
     const scrollToOverlay = jest.fn();
-    const model = getOnePodViewModel("foobar", {
+    const model = getOnePodViewModel("foobar", userPreferencesState, {
       getLogsWithoutTimestamps: () => ["hello", "world"],
     });
 
@@ -164,7 +181,7 @@ describe("LogSearch tests", () => {
 
   it("should not prefill search on ctrl+f when selection is outside pod logs list", async () => {
     const scrollToOverlay = jest.fn();
-    const model = getOnePodViewModel("foobar", {
+    const model = getOnePodViewModel("foobar", userPreferencesState, {
       getLogsWithoutTimestamps: () => ["hello", "world"],
     });
 
@@ -200,7 +217,7 @@ describe("LogSearch tests", () => {
 
   it("should keep existing query on ctrl+f when selection is empty", async () => {
     const scrollToOverlay = jest.fn();
-    const model = getOnePodViewModel("foobar", {
+    const model = getOnePodViewModel("foobar", userPreferencesState, {
       getLogsWithoutTimestamps: () => ["hello", "world"],
     });
 

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
@@ -9,43 +9,22 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
-import { SearchStore } from "../../../../search-store/search-store";
 import { renderFor } from "../../../test-utils/renderFor";
 import { LogTabViewModel } from "../logs-view-model";
 import { LogSearch } from "../search";
 import { dockerPod } from "./pod.mock";
+import {
+  createMockLogTabViewModel,
+  getDefaultOnePodLogTabData,
+  initializeDefaultLogViewerPreferences,
+} from "./test-utils";
 
 import type { UserEvent } from "@testing-library/user-event";
+
 import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { TabId } from "../../dock/store";
 import type { LogTabViewModelDependencies } from "../logs-view-model";
-
-function mockLogTabViewModel(
-  tabId: TabId,
-  userPreferencesState: UserPreferencesState,
-  deps: Partial<LogTabViewModelDependencies>,
-): LogTabViewModel {
-  return new LogTabViewModel(tabId, {
-    getLogs: jest.fn(),
-    getLogsWithoutTimestamps: jest.fn(),
-    getTimestampSplitLogs: jest.fn(),
-    getLogTabData: jest.fn(),
-    setLogTabData: jest.fn(),
-    loadLogs: jest.fn(),
-    reloadLogs: jest.fn(),
-    renameTab: jest.fn(),
-    stopLoadingLogs: jest.fn(),
-    getPodById: jest.fn(),
-    getPodsByOwnerId: jest.fn(),
-    areLogsPresent: jest.fn(),
-    searchStore: new SearchStore(),
-    downloadLogs: jest.fn(),
-    downloadAllLogs: jest.fn(),
-    userPreferencesState,
-    ...deps,
-  });
-}
 
 const getOnePodViewModel = (
   tabId: TabId,
@@ -54,15 +33,8 @@ const getOnePodViewModel = (
 ): LogTabViewModel => {
   const selectedPod = dockerPod;
 
-  return mockLogTabViewModel(tabId, userPreferencesState, {
-    getLogTabData: () => ({
-      selectedPodId: selectedPod.getId(),
-      selectedContainer: selectedPod.getContainers()[0].name,
-      namespace: selectedPod.getNs(),
-      showPrevious: false,
-      showTimestamps: false,
-      showWordWrap: false,
-    }),
+  return createMockLogTabViewModel(tabId, userPreferencesState, {
+    getLogTabData: () => getDefaultOnePodLogTabData(),
     getPodById: (id) => {
       if (id === selectedPod.getId()) {
         return selectedPod;
@@ -86,11 +58,7 @@ describe("LogSearch tests", () => {
 
     user = userEvent.setup();
     userPreferencesState = di.inject(userPreferencesStateInjectable);
-    userPreferencesState.logViewerPreferences = {
-      showTimestamps: false,
-      showPrevious: false,
-      showWordWrap: true,
-    };
+    initializeDefaultLogViewerPreferences(userPreferencesState);
   });
 
   afterEach(() => {

--- a/packages/core/src/renderer/components/dock/logs/__test__/logs-view-model.test.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/logs-view-model.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
+import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
+import { createMockLogTabViewModel, getDefaultOnePodLogTabData } from "./test-utils";
+
+import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
+
+describe("LogTabViewModel", () => {
+  let userPreferencesState: UserPreferencesState;
+
+  beforeEach(() => {
+    const di = getDiForUnitTesting();
+
+    userPreferencesState = di.inject(userPreferencesStateInjectable);
+  });
+
+  it("updates the saved log viewer preferences and the current tab data", () => {
+    const setLogTabData = jest.fn();
+    const model = createMockLogTabViewModel("tab-id", userPreferencesState, {
+      getLogTabData: () => getDefaultOnePodLogTabData(),
+      setLogTabData,
+    });
+
+    model.updateLogPreferences({ showTimestamps: true });
+
+    expect(userPreferencesState.logViewerPreferences).toEqual({
+      showTimestamps: true,
+      showPrevious: false,
+      showWordWrap: true,
+    });
+    expect(setLogTabData).toHaveBeenCalledWith("tab-id", {
+      ...getDefaultOnePodLogTabData(),
+      showTimestamps: true,
+    });
+  });
+});

--- a/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
@@ -25,7 +25,7 @@ export function getDefaultOnePodLogTabData(overrides: Partial<LogTabData> = {}):
     namespace: dockerPod.getNs(),
     showPrevious: false,
     showTimestamps: false,
-    showWordWrap: false,
+    showWordWrap: true,
     ...overrides,
   };
 }

--- a/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
@@ -45,7 +45,7 @@ export function createMockLogTabViewModel(
     stopLoadingLogs: jest.fn(),
     getPodById: jest.fn(),
     getPodsByOwnerId: jest.fn(),
-    areLogsPresent: jest.fn(),
+    areLogsPresent: jest.fn(() => false),
     searchStore: new SearchStore(),
     downloadLogs: jest.fn(),
     downloadAllLogs: jest.fn(),

--- a/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
@@ -23,9 +23,7 @@ export function getDefaultOnePodLogTabData(overrides: Partial<LogTabData> = {}):
     selectedPodId: dockerPod.getId(),
     selectedContainer: dockerPod.getContainers()[0].name,
     namespace: dockerPod.getNs(),
-    showPrevious: false,
-    showTimestamps: false,
-    showWordWrap: true,
+    ...defaultLogViewerPreferences,
     ...overrides,
   };
 }

--- a/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { defaultLogViewerPreferences } from "../../../../../features/user-preferences/common/preferences-helpers";
+import { SearchStore } from "../../../../search-store/search-store";
+import { LogTabViewModel } from "../logs-view-model";
+import { dockerPod } from "./pod.mock";
+
+import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
+import type { TabId } from "../../dock/store";
+import type { LogTabViewModelDependencies } from "../logs-view-model";
+import type { LogTabData } from "../tab-store";
+
+export function initializeDefaultLogViewerPreferences(userPreferencesState: UserPreferencesState) {
+  userPreferencesState.logViewerPreferences = { ...defaultLogViewerPreferences };
+}
+
+export function getDefaultOnePodLogTabData(overrides: Partial<LogTabData> = {}): LogTabData {
+  return {
+    selectedPodId: dockerPod.getId(),
+    selectedContainer: dockerPod.getContainers()[0].name,
+    namespace: dockerPod.getNs(),
+    showPrevious: false,
+    showTimestamps: false,
+    showWordWrap: false,
+    ...overrides,
+  };
+}
+
+export function createMockLogTabViewModel(
+  tabId: TabId,
+  userPreferencesState: UserPreferencesState,
+  deps: Partial<LogTabViewModelDependencies>,
+) {
+  return new LogTabViewModel(tabId, {
+    getLogs: jest.fn(() => []),
+    getLogsWithoutTimestamps: jest.fn(() => []),
+    getTimestampSplitLogs: jest.fn(() => []),
+    getLogTabData: jest.fn(),
+    setLogTabData: jest.fn(),
+    loadLogs: jest.fn(),
+    reloadLogs: jest.fn(),
+    renameTab: jest.fn(),
+    stopLoadingLogs: jest.fn(),
+    getPodById: jest.fn(),
+    getPodsByOwnerId: jest.fn(),
+    areLogsPresent: jest.fn(),
+    searchStore: new SearchStore(),
+    downloadLogs: jest.fn(),
+    downloadAllLogs: jest.fn(),
+    userPreferencesState,
+    ...deps,
+  });
+}

--- a/packages/core/src/renderer/components/dock/logs/controls.tsx
+++ b/packages/core/src/renderer/components/dock/logs/controls.tsx
@@ -3,11 +3,6 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-/**
- * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
- * Licensed under MIT License. See LICENSE in root directory for more information.
- */
 
 import { observer } from "mobx-react";
 import React from "react";

--- a/packages/core/src/renderer/components/dock/logs/controls.tsx
+++ b/packages/core/src/renderer/components/dock/logs/controls.tsx
@@ -34,16 +34,16 @@ export const LogControls = observer(({ model }: LogControlsProps) => {
   const since = logs.length ? logs[0][0] : null;
 
   const toggleTimestamps = () => {
-    model.updateLogTabData({ showTimestamps: !showTimestamps });
+    model.updateLogPreferences({ showTimestamps: !showTimestamps });
   };
 
   const togglePrevious = () => {
-    model.updateLogTabData({ showPrevious: !previous });
+    model.updateLogPreferences({ showPrevious: !previous });
     model.reloadLogs();
   };
 
   const toggleWordWrap = () => {
-    model.updateLogTabData({ showWordWrap: !showWordWrap });
+    model.updateLogPreferences({ showWordWrap: !showWordWrap });
   };
 
   return (

--- a/packages/core/src/renderer/components/dock/logs/create-logs-tab.injectable.ts
+++ b/packages/core/src/renderer/components/dock/logs/create-logs-tab.injectable.ts
@@ -6,6 +6,8 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { runInAction } from "mobx";
+import { defaultLogViewerPreferences } from "../../../../features/user-preferences/common/preferences-helpers";
+import userPreferencesStateInjectable from "../../../../features/user-preferences/common/state.injectable";
 import createDockTabInjectable from "../dock/create-dock-tab.injectable";
 import { TabKind } from "../dock/store";
 import getRandomIdForPodLogsTabInjectable from "./get-random-id-for-pod-logs-tab.injectable";
@@ -13,6 +15,7 @@ import setLogTabDataInjectable from "./set-log-tab-data.injectable";
 
 import type { DockTab, DockTabCreate, TabId } from "../dock/store";
 import type { LogTabData } from "./tab-store";
+import type { UserPreferencesState } from "../../../../features/user-preferences/common/state.injectable";
 
 export type CreateLogsTabData = Pick<LogTabData, "owner" | "selectedPodId" | "selectedContainer" | "namespace"> &
   Omit<Partial<LogTabData>, "owner" | "selectedPodId" | "selectedContainer" | "namespace">;
@@ -21,10 +24,11 @@ interface Dependencies {
   createDockTab: (rawTabDesc: DockTabCreate, addNumber?: boolean) => DockTab;
   setLogTabData: (tabId: string, data: LogTabData) => void;
   getRandomId: () => string;
+  userPreferencesState: UserPreferencesState;
 }
 
 const createLogsTab =
-  ({ createDockTab, setLogTabData, getRandomId }: Dependencies) =>
+  ({ createDockTab, setLogTabData, getRandomId, userPreferencesState }: Dependencies) =>
   (title: string, data: CreateLogsTabData): TabId => {
     const id = `log-tab-${getRandomId()}`;
 
@@ -38,9 +42,7 @@ const createLogsTab =
         false,
       );
       setLogTabData(id, {
-        showTimestamps: false,
-        showPrevious: false,
-        showWordWrap: true,
+        ...(userPreferencesState.logViewerPreferences ?? defaultLogViewerPreferences),
         ...data,
       });
     });
@@ -56,6 +58,7 @@ const createLogsTabInjectable = getInjectable({
       createDockTab: di.inject(createDockTabInjectable),
       setLogTabData: di.inject(setLogTabDataInjectable),
       getRandomId: di.inject(getRandomIdForPodLogsTabInjectable),
+      userPreferencesState: di.inject(userPreferencesStateInjectable),
     }),
 });
 

--- a/packages/core/src/renderer/components/dock/logs/create-logs-tab.injectable.ts
+++ b/packages/core/src/renderer/components/dock/logs/create-logs-tab.injectable.ts
@@ -13,9 +13,9 @@ import { TabKind } from "../dock/store";
 import getRandomIdForPodLogsTabInjectable from "./get-random-id-for-pod-logs-tab.injectable";
 import setLogTabDataInjectable from "./set-log-tab-data.injectable";
 
+import type { UserPreferencesState } from "../../../../features/user-preferences/common/state.injectable";
 import type { DockTab, DockTabCreate, TabId } from "../dock/store";
 import type { LogTabData } from "./tab-store";
-import type { UserPreferencesState } from "../../../../features/user-preferences/common/state.injectable";
 
 export type CreateLogsTabData = Pick<LogTabData, "owner" | "selectedPodId" | "selectedContainer" | "namespace"> &
   Omit<Partial<LogTabData>, "owner" | "selectedPodId" | "selectedContainer" | "namespace">;

--- a/packages/core/src/renderer/components/dock/logs/create-logs-tab.injectable.ts
+++ b/packages/core/src/renderer/components/dock/logs/create-logs-tab.injectable.ts
@@ -41,6 +41,7 @@ const createLogsTab =
         },
         false,
       );
+      // Apply saved log preferences first so explicit tab data can override them.
       setLogTabData(id, {
         ...(userPreferencesState.logViewerPreferences ?? defaultLogViewerPreferences),
         ...data,

--- a/packages/core/src/renderer/components/dock/logs/logs-view-model.injectable.ts
+++ b/packages/core/src/renderer/components/dock/logs/logs-view-model.injectable.ts
@@ -5,6 +5,7 @@
  */
 
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import userPreferencesStateInjectable from "../../../../features/user-preferences/common/state.injectable";
 import searchStoreInjectable from "../../../search-store/search-store.injectable";
 import getPodByIdInjectable from "../../workloads-pods/get-pod-by-id.injectable";
 import getPodsByOwnerIdInjectable from "../../workloads-pods/get-pods-by-owner-id.injectable";
@@ -48,6 +49,7 @@ const logsViewModelInjectable = getInjectable({
       downloadLogs: di.inject(downloadLogsInjectable),
       downloadAllLogs: di.inject(downloadAllLogsInjectable),
       searchStore: di.inject(searchStoreInjectable),
+      userPreferencesState: di.inject(userPreferencesStateInjectable),
     }),
 
   lifecycle: lifecycleEnum.keyedSingleton({

--- a/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
+++ b/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
@@ -7,6 +7,7 @@
 import { isDefined } from "@freelensapp/utilities";
 import assert from "assert";
 import { computed } from "mobx";
+import { defaultLogViewerPreferences } from "../../../../features/user-preferences/common/preferences-helpers";
 
 import type { ResourceDescriptor } from "@freelensapp/kube-api";
 import type { Pod, PodLogsQuery } from "@freelensapp/kube-object";
@@ -92,8 +93,12 @@ export class LogTabViewModel {
   };
 
   updateLogPreferences = (partialPreferences: Partial<LogViewerPreferences>) => {
+    // Update the current tab and the saved defaults for future log tabs only.
+    const logViewerPreferences =
+      this.dependencies.userPreferencesState.logViewerPreferences ?? defaultLogViewerPreferences;
+
     this.dependencies.userPreferencesState.logViewerPreferences = {
-      ...this.dependencies.userPreferencesState.logViewerPreferences,
+      ...logViewerPreferences,
       ...partialPreferences,
     };
 

--- a/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
+++ b/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
@@ -92,16 +92,12 @@ export class LogTabViewModel {
   };
 
   updateLogPreferences = (partialPreferences: Partial<LogViewerPreferences>) => {
-    const data = this.logTabData.get();
-
-    assert(data, "Can only update preferences once data is set");
-
     this.dependencies.userPreferencesState.logViewerPreferences = {
       ...this.dependencies.userPreferencesState.logViewerPreferences,
       ...partialPreferences,
     };
 
-    this.dependencies.setLogTabData(this.tabId, { ...data, ...partialPreferences });
+    this.updateLogTabData(partialPreferences);
   };
 
   loadLogs = () => this.dependencies.loadLogs(this.tabId, this.pod, this.logTabData);

--- a/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
+++ b/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
@@ -13,6 +13,8 @@ import type { Pod, PodLogsQuery } from "@freelensapp/kube-object";
 
 import type { IComputedValue } from "mobx";
 
+import type { LogViewerPreferences } from "../../../../features/user-preferences/common/preferences-helpers";
+import type { UserPreferencesState } from "../../../../features/user-preferences/common/state.injectable";
 import type { SearchStore } from "../../../search-store/search-store";
 import type { GetPodById } from "../../workloads-pods/get-pod-by-id.injectable";
 import type { GetPodsByOwnerId } from "../../workloads-pods/get-pods-by-owner-id.injectable";
@@ -40,6 +42,7 @@ export interface LogTabViewModelDependencies {
   downloadLogs: (filename: string, logs: string[]) => void;
   downloadAllLogs: (params: ResourceDescriptor, query: PodLogsQuery) => Promise<void>;
   searchStore: SearchStore;
+  userPreferencesState: UserPreferencesState;
 }
 
 export class LogTabViewModel {
@@ -86,6 +89,19 @@ export class LogTabViewModel {
     assert(data, "Can only update data once it is set");
 
     this.dependencies.setLogTabData(this.tabId, { ...data, ...partialData });
+  };
+
+  updateLogPreferences = (partialPreferences: Partial<LogViewerPreferences>) => {
+    const data = this.logTabData.get();
+
+    assert(data, "Can only update preferences once data is set");
+
+    this.dependencies.userPreferencesState.logViewerPreferences = {
+      ...this.dependencies.userPreferencesState.logViewerPreferences,
+      ...partialPreferences,
+    };
+
+    this.dependencies.setLogTabData(this.tabId, { ...data, ...partialPreferences });
   };
 
   loadLogs = () => this.dependencies.loadLogs(this.tabId, this.pod, this.logTabData);


### PR DESCRIPTION
Closes #1854 

This PR ensures that the logs viewer preferences (show timestamps, word wrap, and previous container logs) are persisted to storage.

When a preference is changed, the current logs tab updates immediately and the new value is persisted to storage. Other already open logs tabs are not kept in sync with that change. That could be added later if the community requests it, but for now this behavior feels more natural, at least to me.

As mentioned in the issue, some friction is expected when users are debugging and forget that they previously enabled the show previous terminated container preference. Still, that seems like a reasonable trade-off for the improved UX overall.