### PR TITLE
feat: add custom theme color preferences

### DIFF
--- a/packages/core/src/common/__tests__/user-store.test.ts
+++ b/packages/core/src/common/__tests__/user-store.test.ts
@@ -93,5 +93,45 @@ describe("user store tests", () => {
         },
       });
     });
+
+    it("loads and stores custom theme colors", async () => {
+      const writeJsonSync = di.inject(writeJsonSyncInjectable);
+      const readJsonSync = di.inject(readJsonSyncInjectable);
+
+      writeJsonSync("/some-directory-for-user-data/lens-user-store.json", {
+        preferences: {
+          customThemeColors: {
+            primary: "#ff00aa",
+          },
+        },
+      });
+      writeJsonSync("/some-directory-for-user-data/kube_config", {});
+
+      di.inject(userPreferencesPersistentStorageInjectable).loadAndStartSyncing();
+
+      expect(state.customThemeColors).toEqual({
+        primary: "#ff00aa",
+      });
+
+      state.customThemeColors = {
+        primary: "#112233",
+        buttonPrimaryBackground: "#445566",
+      };
+
+      expect(readJsonSync("/some-directory-for-user-data/lens-user-store.json")).toMatchObject({
+        preferences: {
+          customThemeColors: {
+            primary: "#112233",
+            buttonPrimaryBackground: "#445566",
+          },
+        },
+      });
+
+      state.customThemeColors = {};
+
+      expect(
+        readJsonSync("/some-directory-for-user-data/lens-user-store.json").preferences.customThemeColors,
+      ).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss
@@ -1,0 +1,22 @@
+.colorGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px 16px;
+  margin: 16px 0;
+}
+
+.colorRow {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(96px, 1fr) 40px auto;
+}
+
+.colorRow input {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  height: 32px;
+  padding: 0;
+  width: 40px;
+}

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
@@ -4,16 +4,22 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Button } from "@freelensapp/button";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
 import { defaultColorThemePreference } from "../../../../../../common/vars";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
+import {
+  CUSTOMIZABLE_THEME_COLOR_NAMES,
+  toColorInputValue,
+} from "../../../../../../renderer/themes/custom-theme-colors";
 import { lensThemeDeclarationInjectionToken } from "../../../../../../renderer/themes/declaration";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";
+import styles from "./theme.module.scss";
 
-import type { LensTheme } from "../../../../../../renderer/themes/lens-theme";
+import type { LensColorName, LensTheme } from "../../../../../../renderer/themes/lens-theme";
 import type { UserPreferencesState } from "../../../../../user-preferences/common/state.injectable";
 
 interface Dependencies {
@@ -21,7 +27,24 @@ interface Dependencies {
   themes: LensTheme[];
 }
 
+const colorLabels: Partial<Record<LensColorName, string>> = {
+  primary: "Primary",
+  buttonPrimaryBackground: "Primary button",
+  menuActiveBackground: "Menu active",
+  sidebarSubmenuActiveColor: "Sidebar active",
+  sidebarActiveColor: "Sidebar item",
+  layoutTabsActiveColor: "Active tab",
+  textColorAccent: "Accent text",
+  colorInfo: "Info",
+  colorSuccess: "Success",
+  colorWarning: "Warning",
+  colorError: "Error",
+};
+
 const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
+  const selectedTheme =
+    themes.find((theme) => theme.name === state.colorTheme) ?? themes.find((theme) => theme.isDefault) ?? themes[0];
+  const customThemeColors = state.customThemeColors ?? {};
   const themeOptions = [
     {
       value: defaultColorThemePreference,
@@ -33,6 +56,19 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
     })),
   ];
 
+  const setCustomColor = (name: LensColorName, value: string) => {
+    state.customThemeColors = {
+      ...customThemeColors,
+      [name]: value,
+    };
+  };
+
+  const resetCustomColor = (name: LensColorName) => {
+    const { [name]: _removed, ...nextCustomThemeColors } = customThemeColors;
+
+    state.customThemeColors = nextCustomThemeColors;
+  };
+
   return (
     <section id="appearance">
       <SubTitle title="Theme" />
@@ -42,6 +78,34 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
         value={state.colorTheme}
         onChange={(value) => (state.colorTheme = value?.value ?? defaultColorThemePreference)}
         themeName="lens"
+      />
+      <div className={styles.colorGrid}>
+        {CUSTOMIZABLE_THEME_COLOR_NAMES.map((name) => {
+          const baseValue = selectedTheme?.colors[name] ?? "#000000";
+          const inputValue = customThemeColors[name] ?? baseValue;
+
+          return (
+            <label className={styles.colorRow} key={name}>
+              <span>{colorLabels[name] ?? name}</span>
+              <input
+                aria-label={colorLabels[name] ?? name}
+                type="color"
+                value={toColorInputValue(inputValue)}
+                onChange={(event) => setCustomColor(name, event.target.value)}
+              />
+              <Button
+                disabled={!customThemeColors[name]}
+                label="Reset"
+                onClick={() => resetCustomColor(name)}
+              />
+            </label>
+          );
+        })}
+      </div>
+      <Button
+        disabled={!Object.keys(customThemeColors).length}
+        label="Reset theme colors"
+        onClick={() => (state.customThemeColors = {})}
       />
     </section>
   );

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -51,6 +51,10 @@ const userPreferenceDescriptorsInjectable = getInjectable({
         fromStore: (val) => val || defaultColorThemePreference,
         toStore: (val) => (!val || val === defaultColorThemePreference ? undefined : val),
       }),
+      customThemeColors: getPreferenceDescriptor<Record<string, string>>({
+        fromStore: (val) => val ?? {},
+        toStore: (val) => (Object.keys(val).length ? val : undefined),
+      }),
       terminalTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || "",
         toStore: (val) => val || undefined,

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -39,6 +39,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.allowErrorReporting = descriptors.allowErrorReporting.fromStore(preferences.allowErrorReporting);
         state.allowUntrustedCAs = descriptors.allowUntrustedCAs.fromStore(preferences.allowUntrustedCAs);
         state.colorTheme = descriptors.colorTheme.fromStore(preferences.colorTheme);
+        state.customThemeColors = descriptors.customThemeColors.fromStore(preferences.customThemeColors);
         state.downloadBinariesPath = descriptors.downloadBinariesPath.fromStore(preferences.downloadBinariesPath);
         state.downloadKubectlBinaries = descriptors.downloadKubectlBinaries.fromStore(
           preferences.downloadKubectlBinaries,
@@ -67,6 +68,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             allowErrorReporting: descriptors.allowErrorReporting.toStore(state.allowErrorReporting),
             allowUntrustedCAs: descriptors.allowUntrustedCAs.toStore(state.allowUntrustedCAs),
             colorTheme: descriptors.colorTheme.toStore(state.colorTheme),
+            customThemeColors: descriptors.customThemeColors.toStore(state.customThemeColors),
             downloadBinariesPath: descriptors.downloadBinariesPath.toStore(state.downloadBinariesPath),
             downloadKubectlBinaries: descriptors.downloadKubectlBinaries.toStore(state.downloadKubectlBinaries),
             downloadMirror: descriptors.downloadMirror.toStore(state.downloadMirror),

--- a/packages/core/src/renderer/themes/active.injectable.ts
+++ b/packages/core/src/renderer/themes/active.injectable.ts
@@ -8,10 +8,14 @@ import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { computed } from "mobx";
 import lensColorThemePreferenceInjectable from "../../features/user-preferences/common/lens-color-theme.injectable";
+import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
+import { mergeCustomThemeColors } from "./custom-theme-colors";
 import { lensThemeDeclarationInjectionToken } from "./declaration";
 import defaultLensThemeInjectable from "./default-theme.injectable";
 import systemThemeConfigurationInjectable from "./system-theme.injectable";
 import lensThemesInjectable from "./themes.injectable";
+
+import type { LensTheme } from "./lens-theme";
 
 const activeThemeInjectable = getInjectable({
   id: "active-theme",
@@ -21,6 +25,12 @@ const activeThemeInjectable = getInjectable({
     const lensColorThemePreference = di.inject(lensColorThemePreferenceInjectable);
     const systemThemeConfiguration = di.inject(systemThemeConfigurationInjectable);
     const defaultLensTheme = di.inject(defaultLensThemeInjectable);
+    const state = di.inject(userPreferencesStateInjectable);
+
+    const applyCustomColors = (theme: LensTheme): LensTheme => ({
+      ...theme,
+      colors: mergeCustomThemeColors(theme, state.customThemeColors),
+    });
 
     return computed(() => {
       const pref = lensColorThemePreference.get();
@@ -31,10 +41,10 @@ const activeThemeInjectable = getInjectable({
 
         assert(matchingTheme, `Missing theme declaration for system theme "${systemThemeType}"`);
 
-        return matchingTheme;
+        return applyCustomColors(matchingTheme);
       }
 
-      return lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
+      return applyCustomColors(lensThemes.get(pref.lensThemeId) ?? defaultLensTheme);
     });
   },
 });

--- a/packages/core/src/renderer/themes/custom-theme-colors.test.ts
+++ b/packages/core/src/renderer/themes/custom-theme-colors.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { mergeCustomThemeColors, toColorInputValue } from "./custom-theme-colors";
+
+import type { LensTheme } from "./lens-theme";
+
+describe("custom theme colors", () => {
+  const baseTheme: LensTheme = {
+    name: "Test",
+    type: "dark",
+    description: "Test theme",
+    author: "Freelens",
+    monacoTheme: "vs-dark",
+    colors: {
+      primary: "#00a7a0",
+      buttonPrimaryBackground: "#00a7a0",
+      menuActiveBackground: "#00a7a0",
+      sidebarSubmenuActiveColor: "#ffffff",
+    } as LensTheme["colors"],
+    terminalColors: {},
+  };
+
+  it("applies valid custom color overrides", () => {
+    const colors = mergeCustomThemeColors(baseTheme, {
+      primary: "#ff00aa",
+      buttonPrimaryBackground: "#112233",
+    });
+
+    expect(colors.primary).toBe("#ff00aa");
+    expect(colors.buttonPrimaryBackground).toBe("#112233");
+    expect(colors.menuActiveBackground).toBe("#00a7a0");
+  });
+
+  it("ignores unknown color names and invalid color values", () => {
+    const colors = mergeCustomThemeColors(baseTheme, {
+      primary: "red",
+      notAThemeColor: "#abcdef",
+    });
+
+    expect(colors.primary).toBe("#00a7a0");
+    expect(colors).not.toHaveProperty("notAThemeColor");
+  });
+
+  it("normalizes theme color values for color inputs", () => {
+    expect(toColorInputValue("#abc")).toBe("#aabbcc");
+    expect(toColorInputValue("#abcdef80")).toBe("#abcdef");
+    expect(toColorInputValue("#123456")).toBe("#123456");
+    expect(toColorInputValue("currentColor")).toBe("#000000");
+  });
+});

--- a/packages/core/src/renderer/themes/custom-theme-colors.ts
+++ b/packages/core/src/renderer/themes/custom-theme-colors.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import type { LensColorName, LensTheme } from "./lens-theme";
+
+export type CustomThemeColors = Partial<Record<LensColorName, string>>;
+
+export const CUSTOMIZABLE_THEME_COLOR_NAMES = [
+  "primary",
+  "buttonPrimaryBackground",
+  "menuActiveBackground",
+  "sidebarSubmenuActiveColor",
+  "sidebarActiveColor",
+  "layoutTabsActiveColor",
+  "textColorAccent",
+  "colorInfo",
+  "colorSuccess",
+  "colorWarning",
+  "colorError",
+] as const satisfies readonly LensColorName[];
+
+const themeColorPattern = /^#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+const colorInputPattern = /^#[0-9a-f]{6}$/i;
+
+export const isValidThemeColorValue = (value: unknown): value is string =>
+  typeof value === "string" && themeColorPattern.test(value);
+
+export const toColorInputValue = (value: unknown): string => {
+  if (!isValidThemeColorValue(value)) {
+    return "#000000";
+  }
+
+  if (colorInputPattern.test(value)) {
+    return value;
+  }
+
+  if (value.length === 4) {
+    return `#${value[1]}${value[1]}${value[2]}${value[2]}${value[3]}${value[3]}`;
+  }
+
+  return value.slice(0, 7);
+};
+
+export const mergeCustomThemeColors = (
+  theme: LensTheme,
+  customThemeColors: Record<string, unknown> | undefined,
+): LensTheme["colors"] => {
+  const colors = { ...theme.colors };
+
+  if (!customThemeColors) {
+    return colors;
+  }
+
+  for (const [name, value] of Object.entries(customThemeColors)) {
+    if (name in colors && isValidThemeColorValue(value)) {
+      colors[name as LensColorName] = value;
+    }
+  }
+
+  return colors;
+};


### PR DESCRIPTION
## Summary

Adds custom theme color overrides in Application > Theme preferences.

- Stores custom theme colors in user preferences
- Applies valid overrides to the active theme at runtime
- Adds color picker controls and reset actions for common theme colors
- Covers persistence and theme-color merge behavior with unit tests

Addresses #1280.

## Validation

- `npx --yes -p node@24 -p pnpm@10.33.4 pnpm test:unit -- custom-theme-colors.test.ts user-store.test.ts`
- `npx --yes -p node@24 -p pnpm@10.33.4 pnpm build`

The build completes with existing Sass deprecation warnings in unrelated stylesheets.
