### PR TITLE
Stop using Pod Ready=False as a proxy for pod issues

### DIFF
--- a/packages/kube-object/src/specifics/pod.test.ts
+++ b/packages/kube-object/src/specifics/pod.test.ts
@@ -551,5 +551,22 @@ describe("Pods", () => {
 
       expect(pod.hasIssues()).toStrictEqual(false);
     });
+
+    it("should return false if a succeeded pod has a readiness gate that is not ready", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.status.phase = "Succeeded";
+      pod.spec.readinessGates = [{ conditionType: "example.com/ready" }];
+      pod.status.conditions.push({
+        type: "example.com/ready",
+        status: "False",
+        lastProbeTime: 1,
+        lastTransitionTime: "longer ago",
+      });
+
+      expect(pod.hasIssues()).toStrictEqual(false);
+    });
   });
 });

--- a/packages/kube-object/src/specifics/pod.test.ts
+++ b/packages/kube-object/src/specifics/pod.test.ts
@@ -532,6 +532,36 @@ describe("Pods", () => {
       expect(pod.hasIssues()).toStrictEqual(true);
     });
 
+    it("should return true if a current phase failed", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.status.phase = "Failed";
+
+      expect(pod.hasIssues()).toStrictEqual(true);
+    });
+
+    it("should return true if a current phase is pending", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.status.phase = "Pending";
+
+      expect(pod.hasIssues()).toStrictEqual(true);
+    });
+
+    it("should return true if a current phase is unknown", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.status.phase = "Unknown";
+
+      expect(pod.hasIssues()).toStrictEqual(true);
+    });
+
     it("should return false if a current phase is running", () => {
       const pod = getDummyPod({ running: 1 });
 

--- a/packages/kube-object/src/specifics/pod.test.ts
+++ b/packages/kube-object/src/specifics/pod.test.ts
@@ -207,8 +207,8 @@ describe("Pods", () => {
       expect(pod.getRestartsCount()).toStrictEqual(sum(running) + sum(dead));
     });
 
-    it("hasIssues should return false", () => {
-      expect(pod.hasIssues()).toStrictEqual(false);
+    it("hasIssues should return true if a regular container terminated unsuccessfully", () => {
+      expect(pod.hasIssues()).toStrictEqual(dead > 0);
     });
   });
 
@@ -252,7 +252,7 @@ describe("Pods", () => {
   });
 
   describe("hasIssues", () => {
-    it("should return true if a condition isn't ready", () => {
+    it("should return false if only the Ready condition is false", () => {
       const pod = getDummyPod({ running: 1 });
 
       pod.status?.conditions.push({
@@ -260,6 +260,210 @@ describe("Pods", () => {
         status: "foobar",
         lastProbeTime: 1,
         lastTransitionTime: "longer ago",
+      });
+
+      expect(pod.hasIssues()).toStrictEqual(false);
+    });
+
+    it("should return false if the only unready containers completed successfully", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.status.conditions.push({
+        type: "Ready",
+        status: "False",
+        reason: "ContainersNotReady",
+        message: "containers with unready status: [step-git-clone, step-build-go-binaries]",
+        lastProbeTime: 1,
+        lastTransitionTime: "longer ago",
+      });
+
+      pod.spec.containers.push(
+        {
+          image: "dummy",
+          imagePullPolicy: "Always",
+          name: "step-git-clone",
+        },
+        {
+          image: "dummy",
+          imagePullPolicy: "Always",
+          name: "step-build-go-binaries",
+        },
+      );
+      pod.status.containerStatuses?.push(
+        {
+          image: "dummy",
+          imageID: "dummy",
+          name: "step-git-clone",
+          ready: false,
+          restartCount: 0,
+          state: {
+            terminated: {
+              exitCode: 0,
+              finishedAt: "later",
+              reason: "Completed",
+              startedAt: "before",
+            },
+          },
+        },
+        {
+          image: "dummy",
+          imageID: "dummy",
+          name: "step-build-go-binaries",
+          ready: false,
+          restartCount: 0,
+          state: {
+            terminated: {
+              exitCode: 0,
+              finishedAt: "later",
+              reason: "Completed",
+              startedAt: "before",
+            },
+          },
+        },
+      );
+
+      expect(pod.hasIssues()).toStrictEqual(false);
+    });
+
+    it("should return true if a running pod has an unready container", () => {
+      const pod = getDummyPod({ running: 1 });
+      const firstStatus = pod.status?.containerStatuses?.[0];
+
+      assert(pod.status);
+      assert(firstStatus);
+
+      pod.status.phase = "Running";
+      pod.status.conditions.push({
+        type: "Ready",
+        status: "False",
+        reason: "ContainersNotReady",
+        message: "containers with unready status: [container_running_0]",
+        lastProbeTime: 1,
+        lastTransitionTime: "longer ago",
+      });
+      firstStatus.ready = false;
+
+      expect(pod.hasIssues()).toStrictEqual(true);
+    });
+
+    it("should return true if a running pod has a readiness gate that is not ready", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.status.phase = "Running";
+      pod.spec.readinessGates = [{ conditionType: "example.com/ready" }];
+      pod.status.conditions.push({
+        type: "Ready",
+        status: "False",
+        reason: "ReadinessGatesNotReady",
+        message: 'the status of pod readiness gate "example.com/ready" is not "True", but False',
+        lastProbeTime: 1,
+        lastTransitionTime: "longer ago",
+      });
+
+      expect(pod.hasIssues()).toStrictEqual(true);
+    });
+
+    it("should return true if a restartable init container is not ready", () => {
+      const pod = getDummyPod({ running: 1, initRunning: 1 });
+      const firstInitContainer = pod.spec.initContainers[0];
+      const firstInitStatus = pod.status?.initContainerStatuses?.[0];
+
+      assert(firstInitContainer);
+      assert(firstInitStatus);
+
+      firstInitContainer.restartPolicy = "Always";
+      firstInitStatus.ready = false;
+
+      expect(pod.hasIssues()).toStrictEqual(true);
+    });
+
+    it("should return false if a restartable init container completed successfully", () => {
+      const pod = getDummyPod({ running: 1, initRunning: 1 });
+      const firstInitContainer = pod.spec.initContainers[0];
+      const firstInitStatus = pod.status?.initContainerStatuses?.[0];
+
+      assert(firstInitContainer);
+      assert(firstInitStatus);
+
+      firstInitContainer.restartPolicy = "Always";
+      firstInitStatus.ready = false;
+      firstInitStatus.state = {
+        terminated: {
+          exitCode: 0,
+          finishedAt: "later",
+          reason: "Completed",
+          startedAt: "before",
+        },
+      };
+
+      expect(pod.hasIssues()).toStrictEqual(false);
+    });
+
+    it("should return true if a readiness gate fails even when unready containers completed successfully", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.spec.readinessGates = [{ conditionType: "example.com/ready" }];
+      pod.status.conditions.push(
+        {
+          type: "Ready",
+          status: "False",
+          reason: "ContainersNotReady",
+          message: "containers with unready status: [step-git-clone]",
+          lastProbeTime: 1,
+          lastTransitionTime: "longer ago",
+        },
+        {
+          type: "example.com/ready",
+          status: "False",
+          lastProbeTime: 1,
+          lastTransitionTime: "longer ago",
+        },
+      );
+      pod.spec.containers.push({
+        image: "dummy",
+        imagePullPolicy: "Always",
+        name: "step-git-clone",
+      });
+      pod.status.containerStatuses?.push({
+        image: "dummy",
+        imageID: "dummy",
+        name: "step-git-clone",
+        ready: false,
+        restartCount: 0,
+        state: {
+          terminated: {
+            exitCode: 0,
+            finishedAt: "later",
+            reason: "Completed",
+            startedAt: "before",
+          },
+        },
+      });
+
+      expect(pod.hasIssues()).toStrictEqual(true);
+    });
+
+    it("should return true if a regular container status is missing", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      pod.status?.conditions.push({
+        type: "Ready",
+        status: "False",
+        reason: "ContainersNotReady",
+        message: "containers with unknown status: [missing-status]",
+        lastProbeTime: 1,
+        lastTransitionTime: "longer ago",
+      });
+      pod.spec.containers.push({
+        image: "dummy",
+        imagePullPolicy: "Always",
+        name: "missing-status",
       });
 
       expect(pod.hasIssues()).toStrictEqual(true);
@@ -294,6 +498,28 @@ describe("Pods", () => {
       expect(pod.hasIssues()).toStrictEqual(true);
     });
 
+    it("should return true if an ephemeral container is in a crash loop back off", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.status.ephemeralContainerStatuses = [{
+        image: "dummy",
+        imageID: "dummy",
+        name: "debugger",
+        ready: false,
+        restartCount: 0,
+        state: {
+          waiting: {
+            reason: "CrashLoopBackOff",
+            message: "too much foobar",
+          },
+        },
+      }];
+
+      expect(pod.hasIssues()).toStrictEqual(true);
+    });
+
     it("should return true if a current phase isn't running", () => {
       const pod = getDummyPod({ running: 1 });
 
@@ -310,6 +536,16 @@ describe("Pods", () => {
       assert(pod.status);
 
       pod.status.phase = "Running";
+
+      expect(pod.hasIssues()).toStrictEqual(false);
+    });
+
+    it("should return false if a current phase succeeded", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.status.phase = "Succeeded";
 
       expect(pod.hasIssues()).toStrictEqual(false);
     });

--- a/packages/kube-object/src/specifics/pod.test.ts
+++ b/packages/kube-object/src/specifics/pod.test.ts
@@ -503,19 +503,21 @@ describe("Pods", () => {
 
       assert(pod.status);
 
-      pod.status.ephemeralContainerStatuses = [{
-        image: "dummy",
-        imageID: "dummy",
-        name: "debugger",
-        ready: false,
-        restartCount: 0,
-        state: {
-          waiting: {
-            reason: "CrashLoopBackOff",
-            message: "too much foobar",
+      pod.status.ephemeralContainerStatuses = [
+        {
+          image: "dummy",
+          imageID: "dummy",
+          name: "debugger",
+          ready: false,
+          restartCount: 0,
+          state: {
+            waiting: {
+              reason: "CrashLoopBackOff",
+              message: "too much foobar",
+            },
           },
         },
-      }];
+      ];
 
       expect(pod.hasIssues()).toStrictEqual(true);
     });

--- a/packages/kube-object/src/specifics/pod.test.ts
+++ b/packages/kube-object/src/specifics/pod.test.ts
@@ -522,6 +522,60 @@ describe("Pods", () => {
       expect(pod.hasIssues()).toStrictEqual(true);
     });
 
+    it("should return true if an ephemeral container is in a crash loop back off even when containers are ready", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.status.conditions.push({
+        type: "ContainersReady",
+        status: "True",
+        lastProbeTime: 1,
+        lastTransitionTime: "longer ago",
+      });
+      pod.status.ephemeralContainerStatuses = [
+        {
+          image: "dummy",
+          imageID: "dummy",
+          name: "debugger",
+          ready: false,
+          restartCount: 0,
+          state: {
+            waiting: {
+              reason: "CrashLoopBackOff",
+              message: "too much foobar",
+            },
+          },
+        },
+      ];
+
+      expect(pod.hasIssues()).toStrictEqual(true);
+    });
+
+    it("should return false if containers and pod readiness conditions are true", () => {
+      const pod = getDummyPod({ running: 1 });
+
+      assert(pod.status);
+
+      pod.spec.readinessGates = [{ conditionType: "example.com/ready" }];
+      pod.status.conditions.push(
+        {
+          type: "ContainersReady",
+          status: "True",
+          lastProbeTime: 1,
+          lastTransitionTime: "longer ago",
+        },
+        {
+          type: "Ready",
+          status: "True",
+          lastProbeTime: 1,
+          lastTransitionTime: "longer ago",
+        },
+      );
+
+      expect(pod.hasIssues()).toStrictEqual(false);
+    });
+
     it("should return true if a current phase failed", () => {
       const pod = getDummyPod({ running: 1 });
 

--- a/packages/kube-object/src/specifics/pod.test.ts
+++ b/packages/kube-object/src/specifics/pod.test.ts
@@ -522,16 +522,6 @@ describe("Pods", () => {
       expect(pod.hasIssues()).toStrictEqual(true);
     });
 
-    it("should return true if a current phase isn't running", () => {
-      const pod = getDummyPod({ running: 1 });
-
-      assert(pod.status);
-
-      pod.status.phase = "not running";
-
-      expect(pod.hasIssues()).toStrictEqual(true);
-    });
-
     it("should return true if a current phase failed", () => {
       const pod = getDummyPod({ running: 1 });
 

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -836,121 +836,107 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
     return this.spec?.affinity ?? {};
   }
 
-  hasIssues() {
-    const phase = this.getStatusPhase();
+ hasIssues() {
+  const phase = this.getStatusPhase();
 
-    if (!phase) {
+  if (!phase) {
+    return true;
+  }
+
+  if (phase === "Succeeded") {
+    return false;
+  }
+
+  if (phase === "Failed" || phase === "Pending" || phase === "Unknown") {
+    return true;
+  }
+
+  // "Running" pods can still have container or readiness-gate issues.
+  if (this.hasCrashLoopingContainers()) {
+    return true;
+  }
+
+  const podIsReady = this.getConditions().some(
+    ({ type, status }) => type === "Ready" && status === "True",
+  );
+
+  if (!podIsReady) {
+    if (this.hasUnreadyContainers()) {
       return true;
     }
 
-    if (phase === "Succeeded") {
-      return false;
-    } else if (phase === "Failed" || phase === "Pending" || phase === "Unknown") {
+    if (this.hasGateReadinessIssues()) {
       return true;
-    } else {
-      // "Running" pods can still have container or readiness-gate issues.
-      let podIsReady = false;
-
-      for (const { type, status } of this.getConditions()) {
-        if (type === "Ready") {
-          podIsReady = status === "True";
-          break;
-        }
-      }
-
-      if (this.hasContainerIssues(podIsReady)) {
-        return true;
-      }
-
-      if (!podIsReady && this.hasGateReadinessIssues()) {
-        return true;
-      }
-
-      return false;
     }
   }
 
-  private hasContainerIssues(podIsReady: boolean) {
-    const { containerStatuses = [], initContainerStatuses = [], ephemeralContainerStatuses = [] } = this.status ?? {};
+  return false;
+}
+  private hasCrashLoopingContainers() {
+  const {
+    containerStatuses = [],
+    initContainerStatuses = [],
+    ephemeralContainerStatuses = [],
+  } = this.status ?? {};
+
+  for (const status of [
+    ...initContainerStatuses,
+    ...containerStatuses,
+    ...ephemeralContainerStatuses,
+  ]) {
+    if (status.state?.waiting?.reason === "CrashLoopBackOff") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+  private hasUnreadyContainers() {
+    const {
+      containerStatuses = [],
+      initContainerStatuses = [],
+    } = this.status ?? {};
+
     const statusesByName = new Map<string, PodContainerStatus>();
 
-    // CrashLoopBackOff is an issue for any container status, including ephemeral containers.
-    // While checking regular/init statuses, also index them for the readiness checks below.
     for (const status of initContainerStatuses) {
-      if (status.state?.waiting?.reason === "CrashLoopBackOff") {
-        return true;
-      }
-
       statusesByName.set(status.name, status);
     }
 
     for (const status of containerStatuses) {
-      if (status.state?.waiting?.reason === "CrashLoopBackOff") {
-        return true;
-      }
-
       statusesByName.set(status.name, status);
     }
 
-    // Ephemeral containers do not contribute to ContainersReady, but they can still crash-loop.
-    for (const status of ephemeralContainerStatuses) {
-      if (status.state?.waiting?.reason === "CrashLoopBackOff") {
-        return true;
-      }
-    }
-
-    if (podIsReady) {
-      return false;
-    }
-
-    // Kubelet's ContainersReady checks restartable init containers and regular containers.
-    // Freelens differs by accepting unready containers that terminated successfully with exit code 0.
     for (const { name, restartPolicy } of this.getInitContainers()) {
-      // Non-restartable init containers do not contribute to ContainersReady.
       if (restartPolicy !== "Always") {
         continue;
       }
 
-      const status = statusesByName.get(name);
-
-      // Missing status means kubelet cannot report the container ready.
-      if (!status) {
+      if (this.isContainerStatusUnready(statusesByName.get(name))) {
         return true;
       }
-
-      if (status.ready) {
-        continue;
-      }
-
-      // Completed pipeline-style containers should not keep showing pod issues.
-      if (status.state?.terminated?.exitCode === 0) {
-        continue;
-      }
-
-      return true;
     }
 
     for (const { name } of this.getContainers()) {
-      const status = statusesByName.get(name);
-
-      // Missing status means kubelet cannot report the container ready.
-      if (!status) {
+      if (this.isContainerStatusUnready(statusesByName.get(name))) {
         return true;
       }
-
-      if (status.ready) {
-        continue;
-      }
-
-      // Completed pipeline-style containers should not keep showing pod issues.
-      if (status.state?.terminated?.exitCode === 0) {
-        continue;
-      }
-
-      return true;
     }
 
     return false;
+  }
+
+  private isContainerStatusUnready(status?: PodContainerStatus) {
+    if (!status) {
+      return true;
+    }
+
+    if (status.ready) {
+      return false;
+    }
+
+    return status.state?.terminated?.exitCode !== 0;
   }
 
   private hasGateReadinessIssues() {

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -837,20 +837,28 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
   }
 
   hasIssues() {
-    if (this.getStatusPhase() === "Succeeded") {
+    const phase = this.getStatusPhase();
+
+    if (!phase) {
+      return true;
+    }
+
+    if (phase === "Succeeded") {
+      return false;
+    } else if (phase === "Failed" || phase === "Pending" || phase === "Unknown") {
+      return true;
+    } else {
+      // "Running" pods can still have container or readiness-gate issues.
+      if (this.hasContainerIssues()) {
+        return true;
+      }
+
+      if (this.hasGateReadinessIssues()) {
+        return true;
+      }
+
       return false;
     }
-
-    // Active pods can still have container or readiness-gate issues.
-    if (this.hasContainerIssues()) {
-      return true;
-    }
-
-    if (this.hasGateReadinessIssues()) {
-      return true;
-    }
-
-    return this.getStatusPhase() !== "Running";
   }
 
   private hasContainerIssues() {

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -872,14 +872,11 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
   }
 
   private hasCrashLoopingContainers() {
-    const { containerStatuses = [], initContainerStatuses = [], ephemeralContainerStatuses = [] } = this.status ?? {};
-
-    for (const status of [...initContainerStatuses, ...containerStatuses, ...ephemeralContainerStatuses]) {
-      if (status.state?.waiting?.reason === "CrashLoopBackOff") {
+    for (const { state } of this.getContainerStatuses()) {
+      if (state?.waiting?.reason === "CrashLoopBackOff") {
         return true;
       }
     }
-
     return false;
   }
 

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -930,9 +930,15 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
 
   private hasGateReadinessIssues() {
     // Kubelet's Ready condition fails when any configured readiness gate is missing or not True.
+    const readinessGates = this.spec?.readinessGates;
+
+    if (!readinessGates?.length) {
+      return false;
+    }
+
     const conditionStatuses = new Map(this.getConditions().map(({ type, status }) => [type, status]));
 
-    for (const { conditionType } of this.spec?.readinessGates ?? []) {
+    for (const { conditionType } of readinessGates) {
       if (conditionStatuses.get(conditionType) !== "True") {
         return true;
       }

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -836,67 +836,54 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
     return this.spec?.affinity ?? {};
   }
 
- hasIssues() {
-  const phase = this.getStatusPhase();
+  hasIssues() {
+    const phase = this.getStatusPhase();
 
-  if (!phase) {
-    return true;
+    if (!phase) {
+      return true;
+    }
+
+    if (phase === "Succeeded") {
+      return false;
+    }
+
+    if (phase === "Failed" || phase === "Pending" || phase === "Unknown") {
+      return true;
+    }
+
+    // "Running" pods can still have container or readiness-gate issues.
+    if (this.hasCrashLoopingContainers()) {
+      return true;
+    }
+
+    const podIsReady = this.getConditions().some(({ type, status }) => type === "Ready" && status === "True");
+
+    if (!podIsReady) {
+      if (this.hasUnreadyContainers()) {
+        return true;
+      }
+
+      if (this.hasGateReadinessIssues()) {
+        return true;
+      }
+    }
+
+    return false;
   }
+  private hasCrashLoopingContainers() {
+    const { containerStatuses = [], initContainerStatuses = [], ephemeralContainerStatuses = [] } = this.status ?? {};
 
-  if (phase === "Succeeded") {
+    for (const status of [...initContainerStatuses, ...containerStatuses, ...ephemeralContainerStatuses]) {
+      if (status.state?.waiting?.reason === "CrashLoopBackOff") {
+        return true;
+      }
+    }
+
     return false;
   }
 
-  if (phase === "Failed" || phase === "Pending" || phase === "Unknown") {
-    return true;
-  }
-
-  // "Running" pods can still have container or readiness-gate issues.
-  if (this.hasCrashLoopingContainers()) {
-    return true;
-  }
-
-  const podIsReady = this.getConditions().some(
-    ({ type, status }) => type === "Ready" && status === "True",
-  );
-
-  if (!podIsReady) {
-    if (this.hasUnreadyContainers()) {
-      return true;
-    }
-
-    if (this.hasGateReadinessIssues()) {
-      return true;
-    }
-  }
-
-  return false;
-}
-  private hasCrashLoopingContainers() {
-  const {
-    containerStatuses = [],
-    initContainerStatuses = [],
-    ephemeralContainerStatuses = [],
-  } = this.status ?? {};
-
-  for (const status of [
-    ...initContainerStatuses,
-    ...containerStatuses,
-    ...ephemeralContainerStatuses,
-  ]) {
-    if (status.state?.waiting?.reason === "CrashLoopBackOff") {
-      return true;
-    }
-  }
-
-  return false;
-}
-
   private hasUnreadyContainers() {
-    const {
-      containerStatuses = [],
-      initContainerStatuses = [],
-    } = this.status ?? {};
+    const { containerStatuses = [], initContainerStatuses = [] } = this.status ?? {};
 
     const statusesByName = new Map<string, PodContainerStatus>();
 

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -574,7 +574,7 @@ export interface PodSpec {
   preemptionPolicy?: string;
   priority?: number;
   priorityClassName?: string;
-  readinessGates?: unknown[];
+  readinessGates?: PodReadinessGate[];
   restartPolicy?: "Always" | "OnFailure" | "Never";
   runtimeClassName?: string;
   schedulerName?: string;
@@ -600,12 +600,16 @@ export type PodConditionType =
   | "PodResizePending"
   | "PodResizeInProgress";
 
+export interface PodReadinessGate {
+  conditionType: string;
+}
+
 export interface PodCondition {
   lastProbeTime?: number;
   lastTransitionTime?: string;
   message?: string;
   reason?: string;
-  type: PodConditionType;
+  type: PodConditionType | string;
   status: string;
 }
 
@@ -833,19 +837,108 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
   }
 
   hasIssues() {
-    for (const { type, status } of this.getConditions()) {
-      if (type === "Ready" && status !== "True") {
-        return true;
-      }
+    // Mirror the kubelet's Ready inputs, but don't treat successfully completed containers as issues.
+    if (this.hasContainerIssues()) {
+      return true;
     }
 
-    for (const { state } of this.getContainerStatuses()) {
+    if (this.hasGateReadinessIssues()) {
+      return true;
+    }
+
+    return !(this.getStatusPhase() === "Running" || this.getStatusPhase() === "Succeeded");
+  }
+
+  private hasContainerIssues() {
+    const { containerStatuses = [], initContainerStatuses = [], ephemeralContainerStatuses = [] } = this.status ?? {};
+    const statusesByName = new Map<string, PodContainerStatus>();
+
+    // CrashLoopBackOff is an issue for any container status, including ephemeral containers.
+    // While checking regular/init statuses, also index them for the readiness checks below.
+    for (const status of initContainerStatuses) {
+      if (status.state?.waiting?.reason === "CrashLoopBackOff") {
+        return true;
+      }
+
+      statusesByName.set(status.name, status);
+    }
+
+    for (const status of containerStatuses) {
+      if (status.state?.waiting?.reason === "CrashLoopBackOff") {
+        return true;
+      }
+
+      statusesByName.set(status.name, status);
+    }
+
+    // Ephemeral containers do not contribute to ContainersReady, but they can still crash-loop.
+    for (const { state } of ephemeralContainerStatuses) {
       if (state?.waiting?.reason === "CrashLoopBackOff") {
         return true;
       }
     }
 
-    return this.getStatusPhase() !== "Running";
+    // Kubelet's ContainersReady checks restartable init containers and regular containers.
+    // Freelens differs by accepting unready containers that terminated successfully with exit code 0.
+    for (const { name, restartPolicy } of this.getInitContainers()) {
+      // Non-restartable init containers do not contribute to ContainersReady.
+      if (restartPolicy !== "Always") {
+        continue;
+      }
+
+      const status = statusesByName.get(name);
+
+      // Missing status means kubelet cannot report the container ready.
+      if (!status) {
+        return true;
+      }
+
+      if (status.ready) {
+        continue;
+      }
+
+      // Completed pipeline-style containers should not keep showing pod issues.
+      if (status.state?.terminated?.exitCode === 0) {
+        continue;
+      }
+
+      return true;
+    }
+
+    for (const { name } of this.getContainers()) {
+      const status = statusesByName.get(name);
+
+      // Missing status means kubelet cannot report the container ready.
+      if (!status) {
+        return true;
+      }
+
+      if (status.ready) {
+        continue;
+      }
+
+      // Completed pipeline-style containers should not keep showing pod issues.
+      if (status.state?.terminated?.exitCode === 0) {
+        continue;
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
+  private hasGateReadinessIssues() {
+    // Kubelet's Ready condition fails when any configured readiness gate is missing or not True.
+    const conditionStatuses = new Map(this.getConditions().map(({ type, status }) => [type, status]));
+
+    for (const { conditionType } of this.spec?.readinessGates ?? []) {
+      if (conditionStatuses.get(conditionType) !== "True") {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   getLivenessProbe(container: Container) {

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -870,6 +870,7 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
 
     return false;
   }
+
   private hasCrashLoopingContainers() {
     const { containerStatuses = [], initContainerStatuses = [], ephemeralContainerStatuses = [] } = this.status ?? {};
 

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -849,11 +849,20 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
       return true;
     } else {
       // "Running" pods can still have container or readiness-gate issues.
-      if (this.hasContainerIssues()) {
+      let podIsReady = false;
+
+      for (const { type, status } of this.getConditions()) {
+        if (type === "Ready") {
+          podIsReady = status === "True";
+          break;
+        }
+      }
+
+      if (this.hasContainerIssues(podIsReady)) {
         return true;
       }
 
-      if (this.hasGateReadinessIssues()) {
+      if (!podIsReady && this.hasGateReadinessIssues()) {
         return true;
       }
 
@@ -861,7 +870,7 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
     }
   }
 
-  private hasContainerIssues() {
+  private hasContainerIssues(podIsReady: boolean) {
     const { containerStatuses = [], initContainerStatuses = [], ephemeralContainerStatuses = [] } = this.status ?? {};
     const statusesByName = new Map<string, PodContainerStatus>();
 
@@ -884,10 +893,14 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
     }
 
     // Ephemeral containers do not contribute to ContainersReady, but they can still crash-loop.
-    for (const { state } of ephemeralContainerStatuses) {
-      if (state?.waiting?.reason === "CrashLoopBackOff") {
+    for (const status of ephemeralContainerStatuses) {
+      if (status.state?.waiting?.reason === "CrashLoopBackOff") {
         return true;
       }
+    }
+
+    if (podIsReady) {
+      return false;
     }
 
     // Kubelet's ContainersReady checks restartable init containers and regular containers.

--- a/packages/kube-object/src/specifics/pod.ts
+++ b/packages/kube-object/src/specifics/pod.ts
@@ -837,7 +837,11 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
   }
 
   hasIssues() {
-    // Mirror the kubelet's Ready inputs, but don't treat successfully completed containers as issues.
+    if (this.getStatusPhase() === "Succeeded") {
+      return false;
+    }
+
+    // Active pods can still have container or readiness-gate issues.
     if (this.hasContainerIssues()) {
       return true;
     }
@@ -846,7 +850,7 @@ export class Pod extends KubeObject<NamespaceScopedMetadata, PodStatus, PodSpec>
       return true;
     }
 
-    return !(this.getStatusPhase() === "Running" || this.getStatusPhase() === "Succeeded");
+    return this.getStatusPhase() !== "Running";
   }
 
   private hasContainerIssues() {


### PR DESCRIPTION
## Summary

This removes `Ready=False` as a direct proxy for `Pod.hasIssues()`.
The Kubernetes `Ready` condition describes whether a pod is ready to serve traffic. That is not always the same thing as whether the pod has an issue a user should be warned about. `Ready=False` can mean several different things, including unready containers, readiness gates, missing statuses, terminal pod state, or containers that completed successfully.
This distinction matters for pipeline-style pods and Jobs. Pipeline step containers can terminate successfully with `exitCode: 0`, and succeeded Job pods are also reported as `Ready=False` after completion. In both cases, users do not expect Freelens to keep showing a warning for work that finished successfully.

## What Changed

`Pod.hasIssues()` now checks the concrete signals behind readiness instead of treating `Ready=False` itself as an issue.
The checks follow the same inputs kubelet uses to derive pod readiness as closely as possible ([kubelet Pod Ready condition logic](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/status/generate.go#L126)):

- regular container readiness;
- restartable init container readiness;
- readiness gates.

Freelens then applies issue-specific exceptions for cases that are known not to be user-facing problems:
- successfully terminated containers with `exitCode: 0` are not treated as issues;
- `Succeeded` pods are not treated as issues only because they are no longer `Running`.
-
`CrashLoopBackOff` is still treated as an issue, including for ephemeral containers. Pod phase remains a final fallback for other non-running/non-succeeded states.