### PR TITLE
Add custom theme color overrides

### DIFF
--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+.customColors {
+  margin-top: 16px;
+}
+
+.customColors summary {
+  align-items: center;
+  color: var(--textColorAccent);
+  cursor: pointer;
+  display: inline-flex;
+  gap: 8px;
+}
+
+.customColorCount {
+  background: var(--badgeBackgroundColor);
+  border-radius: 999px;
+  color: var(--mainBackground);
+  font-size: 11px;
+  line-height: 1;
+  min-width: 18px;
+  padding: 4px 6px;
+  text-align: center;
+}
+
+.customColorGrid {
+  display: grid;
+  gap: 8px 16px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin: 12px 0;
+}
+
+.customColorRow {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+}
+
+.customColorRow code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.customColorInput {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  height: 32px;
+  padding: 0;
+  width: 32px;
+}

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
@@ -4,24 +4,50 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Button } from "@freelensapp/button";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
 import { defaultColorThemePreference } from "../../../../../../common/vars";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
+import activeThemeInjectable from "../../../../../../renderer/themes/active.injectable";
 import { lensThemeDeclarationInjectionToken } from "../../../../../../renderer/themes/declaration";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";
+import styles from "./theme.module.scss";
+
+import type { IComputedValue } from "mobx";
 
 import type { LensTheme } from "../../../../../../renderer/themes/lens-theme";
 import type { UserPreferencesState } from "../../../../../user-preferences/common/state.injectable";
 
 interface Dependencies {
+  activeTheme: IComputedValue<LensTheme>;
   state: UserPreferencesState;
   themes: LensTheme[];
 }
 
-const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
+const customColorValuePattern = /^#[0-9a-f]{6}$/i;
+
+const updateThemeColorOverride = (state: UserPreferencesState, colorName: string, value: string) => {
+  if (!customColorValuePattern.test(value)) {
+    return;
+  }
+
+  state.themeColorOverrides = {
+    ...(state.themeColorOverrides ?? {}),
+    [colorName]: value.toLowerCase(),
+  };
+};
+
+const resetThemeColorOverride = (state: UserPreferencesState, colorName: string) => {
+  const { [colorName]: _removed, ...themeColorOverrides } = state.themeColorOverrides ?? {};
+
+  state.themeColorOverrides = themeColorOverrides;
+};
+
+const NonInjectedTheme = observer(({ activeTheme, state, themes }: Dependencies) => {
+  const [customColorsOpen, setCustomColorsOpen] = React.useState(false);
   const themeOptions = [
     {
       value: defaultColorThemePreference,
@@ -32,6 +58,18 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
       label: theme.name,
     })),
   ];
+  const activeThemeColors = activeTheme.get().colors;
+  const themeColorOverrides = state.themeColorOverrides ?? {};
+  const customColorNames = (Object.keys(activeThemeColors) as (keyof LensTheme["colors"])[]).filter((colorName) =>
+    customColorValuePattern.test(activeThemeColors[colorName]),
+  );
+  const customColorCount = Object.keys(themeColorOverrides).length;
+
+  React.useEffect(() => {
+    if (customColorCount > 0) {
+      setCustomColorsOpen(true);
+    }
+  }, [customColorCount]);
 
   return (
     <section id="appearance">
@@ -43,12 +81,56 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
         onChange={(value) => (state.colorTheme = value?.value ?? defaultColorThemePreference)}
         themeName="lens"
       />
+      <details className={styles.customColors} open={customColorsOpen}>
+        <summary
+          onClick={(event) => {
+            event.preventDefault();
+            setCustomColorsOpen((isOpen) => !isOpen);
+          }}
+        >
+          <span>Custom colors</span>
+          {customColorCount > 0 && <span className={styles.customColorCount}>{customColorCount}</span>}
+        </summary>
+        <div className={styles.customColorGrid}>
+          {customColorNames.map((colorName) => {
+            const value = themeColorOverrides[colorName] ?? activeThemeColors[colorName];
+
+            return (
+              <div className={styles.customColorRow} key={colorName}>
+                <input
+                  aria-label={colorName}
+                  className={styles.customColorInput}
+                  type="color"
+                  value={value}
+                  onChange={(event) => updateThemeColorOverride(state, colorName, event.currentTarget.value)}
+                />
+                <code>{colorName}</code>
+                <Button
+                  disabled={!themeColorOverrides[colorName]}
+                  label="Reset"
+                  onClick={() => resetThemeColorOverride(state, colorName)}
+                  plain
+                />
+              </div>
+            );
+          })}
+        </div>
+        <Button
+          disabled={customColorCount === 0}
+          label="Reset all"
+          onClick={() => {
+            state.themeColorOverrides = {};
+          }}
+          outlined
+        />
+      </details>
     </section>
   );
 });
 
 export const Theme = withInjectables<Dependencies>(NonInjectedTheme, {
   getProps: (di) => ({
+    activeTheme: di.inject(activeThemeInjectable),
     state: di.inject(userPreferencesStateInjectable),
     themes: di.injectMany(lensThemeDeclarationInjectionToken),
   }),

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -30,9 +30,26 @@ import type {
   KubeconfigSyncValue,
   LogViewerPreferences,
   TerminalConfig,
+  ThemeColorOverrides,
 } from "./preferences-helpers";
 
 export type PreferenceDescriptors = ReturnType<(typeof userPreferenceDescriptorsInjectable)["instantiate"]>;
+
+const themeColorValuePattern = /^#[0-9a-f]{6}$/i;
+
+const normalizeThemeColorOverrides = (overrides?: ThemeColorOverrides): ThemeColorOverrides => {
+  if (!overrides || typeof overrides !== "object" || Array.isArray(overrides)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(overrides)
+      .filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string" && themeColorValuePattern.test(entry[1]),
+      )
+      .map(([key, value]) => [key, value.toLowerCase()]),
+  );
+};
 
 const userPreferenceDescriptorsInjectable = getInjectable({
   id: "user-preference-descriptors",
@@ -52,6 +69,14 @@ const userPreferenceDescriptorsInjectable = getInjectable({
       colorTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || defaultColorThemePreference,
         toStore: (val) => (!val || val === defaultColorThemePreference ? undefined : val),
+      }),
+      themeColorOverrides: getPreferenceDescriptor<ThemeColorOverrides>({
+        fromStore: (val) => normalizeThemeColorOverrides(val),
+        toStore: (val) => {
+          const overrides = normalizeThemeColorOverrides(val);
+
+          return Object.keys(overrides).length > 0 ? overrides : undefined;
+        },
       }),
       terminalTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || "",

--- a/packages/core/src/features/user-preferences/common/preferences-helpers.ts
+++ b/packages/core/src/features/user-preferences/common/preferences-helpers.ts
@@ -26,6 +26,8 @@ export interface LogViewerPreferences {
   showWordWrap: boolean;
 }
 
+export type ThemeColorOverrides = Record<string, string>;
+
 export const defaultLogViewerPreferences: LogViewerPreferences = {
   showTimestamps: false,
   showPrevious: false,

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -39,6 +39,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.allowErrorReporting = descriptors.allowErrorReporting.fromStore(preferences.allowErrorReporting);
         state.allowUntrustedCAs = descriptors.allowUntrustedCAs.fromStore(preferences.allowUntrustedCAs);
         state.colorTheme = descriptors.colorTheme.fromStore(preferences.colorTheme);
+        state.themeColorOverrides = descriptors.themeColorOverrides.fromStore(preferences.themeColorOverrides);
         state.downloadBinariesPath = descriptors.downloadBinariesPath.fromStore(preferences.downloadBinariesPath);
         state.downloadKubectlBinaries = descriptors.downloadKubectlBinaries.fromStore(
           preferences.downloadKubectlBinaries,
@@ -68,6 +69,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             allowErrorReporting: descriptors.allowErrorReporting.toStore(state.allowErrorReporting),
             allowUntrustedCAs: descriptors.allowUntrustedCAs.toStore(state.allowUntrustedCAs),
             colorTheme: descriptors.colorTheme.toStore(state.colorTheme),
+            themeColorOverrides: descriptors.themeColorOverrides.toStore(state.themeColorOverrides),
             downloadBinariesPath: descriptors.downloadBinariesPath.toStore(state.downloadBinariesPath),
             downloadKubectlBinaries: descriptors.downloadKubectlBinaries.toStore(state.downloadKubectlBinaries),
             downloadMirror: descriptors.downloadMirror.toStore(state.downloadMirror),

--- a/packages/core/src/renderer/themes/active.injectable.ts
+++ b/packages/core/src/renderer/themes/active.injectable.ts
@@ -8,10 +8,31 @@ import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { computed } from "mobx";
 import lensColorThemePreferenceInjectable from "../../features/user-preferences/common/lens-color-theme.injectable";
+import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
 import { lensThemeDeclarationInjectionToken } from "./declaration";
 import defaultLensThemeInjectable from "./default-theme.injectable";
 import systemThemeConfigurationInjectable from "./system-theme.injectable";
 import lensThemesInjectable from "./themes.injectable";
+
+import type { LensTheme } from "./lens-theme";
+
+const applyColorOverrides = (theme: LensTheme, overrides: Record<string, string>): LensTheme => {
+  const themeColorOverrides = Object.fromEntries(
+    Object.entries(overrides).filter(([name]) => Object.hasOwn(theme.colors, name)),
+  );
+
+  if (Object.keys(themeColorOverrides).length === 0) {
+    return theme;
+  }
+
+  return {
+    ...theme,
+    colors: {
+      ...theme.colors,
+      ...themeColorOverrides,
+    },
+  };
+};
 
 const activeThemeInjectable = getInjectable({
   id: "active-theme",
@@ -21,9 +42,11 @@ const activeThemeInjectable = getInjectable({
     const lensColorThemePreference = di.inject(lensColorThemePreferenceInjectable);
     const systemThemeConfiguration = di.inject(systemThemeConfigurationInjectable);
     const defaultLensTheme = di.inject(defaultLensThemeInjectable);
+    const userPreferencesState = di.inject(userPreferencesStateInjectable);
 
     return computed(() => {
       const pref = lensColorThemePreference.get();
+      let activeTheme: LensTheme;
 
       if (pref.useSystemTheme) {
         const systemThemeType = systemThemeConfiguration.get();
@@ -31,10 +54,12 @@ const activeThemeInjectable = getInjectable({
 
         assert(matchingTheme, `Missing theme declaration for system theme "${systemThemeType}"`);
 
-        return matchingTheme;
+        activeTheme = matchingTheme;
+      } else {
+        activeTheme = lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
       }
 
-      return lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
+      return applyColorOverrides(activeTheme, userPreferencesState.themeColorOverrides ?? {});
     });
   },
 });


### PR DESCRIPTION
## Summary
- add persistent custom color overrides to user preferences
- merge valid color overrides into the active theme before CSS variables are applied
- expose a Custom colors panel in Application > Theme with color pickers and reset controls

Closes #1280

## Testing
- pnpm biome:check
- pnpm build:core
- pnpm build
- pnpm build:resources