### PR TITLE
Add customizable theme colors

### DIFF
--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
@@ -4,10 +4,12 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Button } from "@freelensapp/button";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
 import { defaultColorThemePreference } from "../../../../../../common/vars";
+import { Input } from "../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
 import { lensThemeDeclarationInjectionToken } from "../../../../../../renderer/themes/declaration";
@@ -21,7 +23,82 @@ interface Dependencies {
   themes: LensTheme[];
 }
 
+const coreCustomThemeColorNames = [
+  "primary",
+  "textColorAccent",
+  "mainBackground",
+  "contentColor",
+  "sidebarBackground",
+  "colorInfo",
+  "colorSuccess",
+  "colorWarning",
+  "colorError",
+] as const;
+
+type CoreCustomThemeColorName = (typeof coreCustomThemeColorNames)[number];
+
+const customThemeColorLabels: Record<CoreCustomThemeColorName, string> = {
+  primary: "Primary",
+  textColorAccent: "Accent text",
+  mainBackground: "Main background",
+  contentColor: "Content background",
+  sidebarBackground: "Sidebar background",
+  colorInfo: "Info",
+  colorSuccess: "Success",
+  colorWarning: "Warning",
+  colorError: "Error",
+};
+
+const getSelectedTheme = (state: UserPreferencesState, themes: LensTheme[]) =>
+  themes.find((theme) => theme.name === state.colorTheme) ?? themes[0];
+
+const getCurrentThemeColor = (colorName: string, state: UserPreferencesState, themes: LensTheme[]) => {
+  const selectedTheme = getSelectedTheme(state, themes);
+
+  return (
+    state.customThemeColors?.[colorName] ?? selectedTheme?.colors[colorName as keyof LensTheme["colors"]] ?? "#000000"
+  );
+};
+
+const getThemeColorNames = (state: UserPreferencesState, themes: LensTheme[]) =>
+  Object.keys(getSelectedTheme(state, themes)?.colors ?? {});
+
+const setCustomThemeColor = (colorName: string, color: string, state: UserPreferencesState) => {
+  state.customThemeColors = {
+    ...(state.customThemeColors ?? {}),
+    [colorName]: color,
+  };
+};
+
+const resetCustomThemeColor = (colorName: string, state: UserPreferencesState) => {
+  const nextColors = { ...(state.customThemeColors ?? {}) };
+
+  delete nextColors[colorName];
+  state.customThemeColors = nextColors;
+};
+
+const renderColorControl = (colorName: string, label: string, state: UserPreferencesState, themes: LensTheme[]) => (
+  <label key={colorName} style={{ alignItems: "center", display: "flex", gap: 8 }}>
+    <span style={{ flex: 1 }}>{label}</span>
+    <Input
+      aria-label={`${label} color`}
+      type="color"
+      value={getCurrentThemeColor(colorName, state, themes)}
+      onChange={(color) => setCustomThemeColor(colorName, color, state)}
+    />
+    <Button
+      plain
+      label="Reset"
+      disabled={!state.customThemeColors?.[colorName]}
+      onClick={() => resetCustomThemeColor(colorName, state)}
+    />
+  </label>
+);
+
 const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
+  const advancedColorNames = getThemeColorNames(state, themes).filter(
+    (colorName) => !coreCustomThemeColorNames.includes(colorName as CoreCustomThemeColorName),
+  );
   const themeOptions = [
     {
       value: defaultColorThemePreference,
@@ -42,6 +119,31 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
         value={state.colorTheme}
         onChange={(value) => (state.colorTheme = value?.value ?? defaultColorThemePreference)}
         themeName="lens"
+      />
+      <SubTitle title="Custom colors" />
+      <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+        {coreCustomThemeColorNames.map((colorName) =>
+          renderColorControl(colorName, customThemeColorLabels[colorName], state, themes),
+        )}
+      </div>
+      <details style={{ marginTop: 12 }}>
+        <summary>Advanced theme colors</summary>
+        <div
+          style={{
+            display: "grid",
+            gap: 12,
+            gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+            marginTop: 12,
+          }}
+        >
+          {advancedColorNames.map((colorName) => renderColorControl(colorName, colorName, state, themes))}
+        </div>
+      </details>
+      <Button
+        plain
+        label="Reset all custom colors"
+        disabled={Object.keys(state.customThemeColors ?? {}).length === 0}
+        onClick={() => (state.customThemeColors = {})}
       />
     </section>
   );

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -12,12 +12,14 @@ import { defaultColorThemePreference } from "../../../common/vars";
 import currentTimezoneInjectable from "../../../common/vars/current-timezone.injectable";
 import {
   ClusterPageMenuOrder,
+  CustomThemeColors,
   defaultEditorConfig,
   defaultExtensionRegistryUrlLocation,
   defaultLogViewerPreferences,
   defaultPackageMirror,
   defaultTerminalConfig,
   getPreferenceDescriptor,
+  normalizeCustomThemeColors,
   packageMirrors,
 } from "./preferences-helpers";
 
@@ -52,6 +54,14 @@ const userPreferenceDescriptorsInjectable = getInjectable({
       colorTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || defaultColorThemePreference,
         toStore: (val) => (!val || val === defaultColorThemePreference ? undefined : val),
+      }),
+      customThemeColors: getPreferenceDescriptor<Partial<CustomThemeColors>, CustomThemeColors>({
+        fromStore: normalizeCustomThemeColors,
+        toStore: (val) => {
+          const normalizedColors = normalizeCustomThemeColors(val);
+
+          return Object.keys(normalizedColors).length > 0 ? normalizedColors : undefined;
+        },
       }),
       terminalTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || "",

--- a/packages/core/src/features/user-preferences/common/preferences-helpers.ts
+++ b/packages/core/src/features/user-preferences/common/preferences-helpers.ts
@@ -26,6 +26,23 @@ export interface LogViewerPreferences {
   showWordWrap: boolean;
 }
 
+export type CustomThemeColors = Record<string, string>;
+
+const customThemeColorNamePattern = /^[a-zA-Z][\w-]*$/;
+const hexColorPattern = /^#[\da-f]{6}$/i;
+
+export const normalizeCustomThemeColors = (colors: Partial<Record<string, string>> = {}): CustomThemeColors => {
+  const normalized: CustomThemeColors = {};
+
+  for (const [colorName, color] of Object.entries(colors)) {
+    if (typeof color === "string" && customThemeColorNamePattern.test(colorName) && hexColorPattern.test(color)) {
+      normalized[colorName] = color;
+    }
+  }
+
+  return normalized;
+};
+
 export const defaultLogViewerPreferences: LogViewerPreferences = {
   showTimestamps: false,
   showPrevious: false,

--- a/packages/core/src/features/user-preferences/common/reset-theme.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/reset-theme.injectable.ts
@@ -19,6 +19,7 @@ const resetThemeInjectable = getInjectable({
 
     return action(() => {
       state.colorTheme = preferenceDescriptors.colorTheme.fromStore(undefined);
+      state.customThemeColors = preferenceDescriptors.customThemeColors.fromStore(undefined);
     });
   },
 });

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -39,6 +39,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.allowErrorReporting = descriptors.allowErrorReporting.fromStore(preferences.allowErrorReporting);
         state.allowUntrustedCAs = descriptors.allowUntrustedCAs.fromStore(preferences.allowUntrustedCAs);
         state.colorTheme = descriptors.colorTheme.fromStore(preferences.colorTheme);
+        state.customThemeColors = descriptors.customThemeColors.fromStore(preferences.customThemeColors);
         state.downloadBinariesPath = descriptors.downloadBinariesPath.fromStore(preferences.downloadBinariesPath);
         state.downloadKubectlBinaries = descriptors.downloadKubectlBinaries.fromStore(
           preferences.downloadKubectlBinaries,
@@ -68,6 +69,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             allowErrorReporting: descriptors.allowErrorReporting.toStore(state.allowErrorReporting),
             allowUntrustedCAs: descriptors.allowUntrustedCAs.toStore(state.allowUntrustedCAs),
             colorTheme: descriptors.colorTheme.toStore(state.colorTheme),
+            customThemeColors: descriptors.customThemeColors.toStore(state.customThemeColors),
             downloadBinariesPath: descriptors.downloadBinariesPath.toStore(state.downloadBinariesPath),
             downloadKubectlBinaries: descriptors.downloadKubectlBinaries.toStore(state.downloadKubectlBinaries),
             downloadMirror: descriptors.downloadMirror.toStore(state.downloadMirror),

--- a/packages/core/src/renderer/themes/apply-lens-theme.injectable.ts
+++ b/packages/core/src/renderer/themes/apply-lens-theme.injectable.ts
@@ -8,6 +8,7 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { object } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import resetThemeInjectable from "../../features/user-preferences/common/reset-theme.injectable";
+import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
 
 import type { LensTheme } from "./lens-theme";
 
@@ -18,10 +19,14 @@ const applyLensThemeInjectable = getInjectable({
   instantiate: (di): ApplyLensTheme => {
     const logger = di.inject(loggerInjectionToken);
     const resetTheme = di.inject(resetThemeInjectable);
+    const userPreferencesState = di.inject(userPreferencesStateInjectable);
 
     return (theme) => {
       try {
-        const colors = object.entries(theme.colors);
+        const colors = object.entries({
+          ...theme.colors,
+          ...(userPreferencesState.customThemeColors ?? {}),
+        });
 
         for (const [name, value] of colors) {
           document.documentElement.style.setProperty(`--${name}`, value);

--- a/packages/core/src/renderer/themes/setup-apply-active-theme.injectable.ts
+++ b/packages/core/src/renderer/themes/setup-apply-active-theme.injectable.ts
@@ -7,6 +7,7 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import { reaction } from "mobx";
 import initializeSystemThemeTypeInjectable from "../../features/theme/system-type/renderer/initialize.injectable";
+import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
 import initUserStoreInjectable from "../../features/user-preferences/renderer/load-storage.injectable";
 import { beforeFrameStartsSecondInjectionToken } from "../before-frame-starts/tokens";
 import activeThemeInjectable from "./active.injectable";
@@ -18,10 +19,18 @@ const setupApplyActiveThemeInjectable = getInjectable({
     run: () => {
       const activeTheme = di.inject(activeThemeInjectable);
       const applyLensTheme = di.inject(applyLensThemeInjectable);
+      const userPreferencesState = di.inject(userPreferencesStateInjectable);
 
-      reaction(() => activeTheme.get(), applyLensTheme, {
-        fireImmediately: true,
-      });
+      reaction(
+        () => ({
+          theme: activeTheme.get(),
+          customThemeColors: { ...(userPreferencesState.customThemeColors ?? {}) },
+        }),
+        ({ theme }) => applyLensTheme(theme),
+        {
+          fireImmediately: true,
+        },
+      );
     },
     runAfter: [initializeSystemThemeTypeInjectable, initUserStoreInjectable],
   }),


### PR DESCRIPTION
## Summary

- Add persisted custom theme color overrides to user preferences.
- Add color controls in Preferences > Appearance for common theme colors.
- Add an Advanced theme colors section that exposes the active theme's remaining color variables.
- Apply custom colors immediately by merging saved overrides into the active theme CSS variables.
- Add reset controls for individual colors and all custom color overrides.

## Verification

- `npx --yes @biomejs/biome@2.4.15 check packages\core\src\features\preferences\renderer\preference-items\application\theme\theme.tsx packages\core\src\features\user-preferences\common\preference-descriptors.injectable.ts packages\core\src\features\user-preferences\common\preferences-helpers.ts packages\core\src\features\user-preferences\common\reset-theme.injectable.ts packages\core\src\features\user-preferences\common\storage.injectable.ts packages\core\src\renderer\themes\apply-lens-theme.injectable.ts packages\core\src\renderer\themes\setup-apply-active-theme.injectable.ts`
- `git diff --check`

## Notes

Full TypeScript verification is currently blocked in this local environment because the repository expects Node >=24 and the local runtime is Node 22.22.0. Running `tsc` directly also reports pre-existing missing workspace build artifacts under `@freelensapp/*/dist`, so a full workspace build should be run in a Node 24 environment before merge.