### PR TITLE
Add custom theme color preferences

### DIFF
--- a/packages/core/src/common/__tests__/user-store.test.ts
+++ b/packages/core/src/common/__tests__/user-store.test.ts
@@ -59,8 +59,50 @@ describe("user store tests", () => {
 
     it("correctly resets theme to default value", async () => {
       state.colorTheme = "some other theme";
+      state.customThemeColors = {
+        primary: "#123456",
+      };
       resetTheme();
       expect(state.colorTheme).toBe(defaultColorThemePreference);
+      expect(state.customThemeColors).toBeUndefined();
+    });
+
+    it("loads and stores custom theme colors as a global preference", async () => {
+      const writeJsonSync = di.inject(writeJsonSyncInjectable);
+      const readJsonSync = di.inject(readJsonSyncInjectable);
+
+      writeJsonSync("/some-directory-for-user-data/lens-user-store.json", {
+        preferences: {
+          customThemeColors: {
+            primary: "#123456",
+            ignored: "not-a-color",
+          },
+        },
+      });
+      writeJsonSync("/some-directory-for-user-data/kube_config", {});
+
+      di.inject(userPreferencesPersistentStorageInjectable).loadAndStartSyncing();
+
+      expect(state.customThemeColors).toEqual({
+        primary: "#123456",
+      });
+
+      state.customThemeColors = {
+        primary: "#abcdef",
+      };
+
+      expect(readJsonSync("/some-directory-for-user-data/lens-user-store.json")).toMatchObject({
+        preferences: {
+          customThemeColors: {
+            primary: "#abcdef",
+          },
+        },
+      });
+
+      state.customThemeColors = undefined;
+      expect(
+        readJsonSync("/some-directory-for-user-data/lens-user-store.json").preferences.customThemeColors,
+      ).toBeUndefined();
     });
 
     it("loads and stores persistentSearch as a global preference", async () => {

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss
@@ -1,0 +1,49 @@
+.themeInput {
+  max-width: 320px;
+}
+
+.customColors {
+  margin-top: 24px;
+}
+
+.customColorsHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.customColorsHeader button {
+  margin-left: auto;
+}
+
+.colorGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 8px 16px;
+}
+
+.colorRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 40px 56px;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+}
+
+.colorName {
+  color: var(--textColorAccent);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.colorPicker {
+  width: 36px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--borderColor);
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
@@ -4,16 +4,19 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Button } from "@freelensapp/button";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
 import { defaultColorThemePreference } from "../../../../../../common/vars";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
+import { lensColorNames } from "../../../../../../renderer/themes/custom-theme-colors";
 import { lensThemeDeclarationInjectionToken } from "../../../../../../renderer/themes/declaration";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";
+import styles from "./theme.module.scss";
 
-import type { LensTheme } from "../../../../../../renderer/themes/lens-theme";
+import type { LensColorName, LensTheme } from "../../../../../../renderer/themes/lens-theme";
 import type { UserPreferencesState } from "../../../../../user-preferences/common/state.injectable";
 
 interface Dependencies {
@@ -22,6 +25,10 @@ interface Dependencies {
 }
 
 const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
+  const selectedTheme =
+    themes.find((theme) => theme.name === state.colorTheme) ?? themes.find((theme) => theme.isDefault) ?? themes[0];
+  const customThemeColors = state.customThemeColors ?? {};
+  const hasCustomThemeColors = Object.keys(customThemeColors).length > 0;
   const themeOptions = [
     {
       value: defaultColorThemePreference,
@@ -37,15 +44,71 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
     <section id="appearance">
       <SubTitle title="Theme" />
       <Select
+        className={styles.themeInput}
         id="theme-input"
         options={themeOptions}
         value={state.colorTheme}
         onChange={(value) => (state.colorTheme = value?.value ?? defaultColorThemePreference)}
         themeName="lens"
       />
+
+      <div className={styles.customColors}>
+        <div className={styles.customColorsHeader}>
+          <SubTitle title="Custom colors" />
+          <Button
+            hidden={!hasCustomThemeColors}
+            label="Reset all"
+            plain
+            onClick={() => (state.customThemeColors = undefined)}
+          />
+        </div>
+
+        <div className={styles.colorGrid}>
+          {lensColorNames.map((colorName) => {
+            const baseColor = selectedTheme?.colors[colorName] ?? "#000000";
+            const value = customThemeColors[colorName] ?? baseColor;
+
+            return (
+              <label className={styles.colorRow} key={colorName}>
+                <span className={styles.colorName} title={colorName}>
+                  {colorName}
+                </span>
+                <input
+                  aria-label={colorName}
+                  className={styles.colorPicker}
+                  type="color"
+                  value={toColorInputValue(value)}
+                  onChange={({ currentTarget }) => {
+                    state.customThemeColors = {
+                      ...customThemeColors,
+                      [colorName]: currentTarget.value,
+                    };
+                  }}
+                />
+                <Button
+                  hidden={!customThemeColors[colorName]}
+                  label="Reset"
+                  plain
+                  onClick={() => resetCustomThemeColor(state, colorName)}
+                />
+              </label>
+            );
+          })}
+        </div>
+      </div>
     </section>
   );
 });
+
+const resetCustomThemeColor = (state: UserPreferencesState, colorName: LensColorName) => {
+  const { [colorName]: _color, ...customThemeColors } = state.customThemeColors ?? {};
+
+  state.customThemeColors = Object.keys(customThemeColors).length > 0 ? customThemeColors : undefined;
+};
+
+const colorInputValuePattern = /^#[0-9a-fA-F]{6}/;
+
+const toColorInputValue = (value: string) => (colorInputValuePattern.test(value) ? value.slice(0, 7) : "#000000");
 
 export const Theme = withInjectables<Dependencies>(NonInjectedTheme, {
   getProps: (di) => ({

--- a/packages/core/src/features/user-preferences/common/custom-theme-colors.ts
+++ b/packages/core/src/features/user-preferences/common/custom-theme-colors.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+export type CustomThemeColors = Record<string, string>;
+
+export const customThemeColorPattern = /^#[0-9a-fA-F]{6}$/;
+
+export const isCustomThemeColor = (value: unknown): value is string =>
+  typeof value === "string" && customThemeColorPattern.test(value);
+
+export const normalizeCustomThemeColors = (value: unknown): CustomThemeColors | undefined => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const normalizedColors: CustomThemeColors = {};
+
+  for (const [name, color] of Object.entries(value)) {
+    if (name && isCustomThemeColor(color)) {
+      normalizedColors[name] = color.toLowerCase();
+    }
+  }
+
+  return Object.keys(normalizedColors).length > 0 ? normalizedColors : undefined;
+};

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -10,6 +10,7 @@ import { observable } from "mobx";
 import kubeDirectoryPathInjectable from "../../../common/os/kube-directory-path.injectable";
 import { defaultColorThemePreference } from "../../../common/vars";
 import currentTimezoneInjectable from "../../../common/vars/current-timezone.injectable";
+import { normalizeCustomThemeColors } from "./custom-theme-colors";
 import {
   ClusterPageMenuOrder,
   defaultEditorConfig,
@@ -52,6 +53,10 @@ const userPreferenceDescriptorsInjectable = getInjectable({
       colorTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || defaultColorThemePreference,
         toStore: (val) => (!val || val === defaultColorThemePreference ? undefined : val),
+      }),
+      customThemeColors: getPreferenceDescriptor<Record<string, string> | undefined>({
+        fromStore: (val) => normalizeCustomThemeColors(val),
+        toStore: (val) => normalizeCustomThemeColors(val),
       }),
       terminalTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || "",

--- a/packages/core/src/features/user-preferences/common/reset-theme.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/reset-theme.injectable.ts
@@ -19,6 +19,7 @@ const resetThemeInjectable = getInjectable({
 
     return action(() => {
       state.colorTheme = preferenceDescriptors.colorTheme.fromStore(undefined);
+      state.customThemeColors = preferenceDescriptors.customThemeColors.fromStore(undefined);
     });
   },
 });

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -39,6 +39,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.allowErrorReporting = descriptors.allowErrorReporting.fromStore(preferences.allowErrorReporting);
         state.allowUntrustedCAs = descriptors.allowUntrustedCAs.fromStore(preferences.allowUntrustedCAs);
         state.colorTheme = descriptors.colorTheme.fromStore(preferences.colorTheme);
+        state.customThemeColors = descriptors.customThemeColors.fromStore(preferences.customThemeColors);
         state.downloadBinariesPath = descriptors.downloadBinariesPath.fromStore(preferences.downloadBinariesPath);
         state.downloadKubectlBinaries = descriptors.downloadKubectlBinaries.fromStore(
           preferences.downloadKubectlBinaries,
@@ -68,6 +69,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             allowErrorReporting: descriptors.allowErrorReporting.toStore(state.allowErrorReporting),
             allowUntrustedCAs: descriptors.allowUntrustedCAs.toStore(state.allowUntrustedCAs),
             colorTheme: descriptors.colorTheme.toStore(state.colorTheme),
+            customThemeColors: descriptors.customThemeColors.toStore(state.customThemeColors),
             downloadBinariesPath: descriptors.downloadBinariesPath.toStore(state.downloadBinariesPath),
             downloadKubectlBinaries: descriptors.downloadKubectlBinaries.toStore(state.downloadKubectlBinaries),
             downloadMirror: descriptors.downloadMirror.toStore(state.downloadMirror),

--- a/packages/core/src/renderer/themes/active.injectable.ts
+++ b/packages/core/src/renderer/themes/active.injectable.ts
@@ -8,10 +8,16 @@ import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { computed } from "mobx";
 import lensColorThemePreferenceInjectable from "../../features/user-preferences/common/lens-color-theme.injectable";
+import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
+import { withCustomThemeColors } from "./custom-theme-colors";
 import { lensThemeDeclarationInjectionToken } from "./declaration";
 import defaultLensThemeInjectable from "./default-theme.injectable";
 import systemThemeConfigurationInjectable from "./system-theme.injectable";
 import lensThemesInjectable from "./themes.injectable";
+
+import type { ReadonlyDeep } from "type-fest";
+
+import type { LensTheme } from "./lens-theme";
 
 const activeThemeInjectable = getInjectable({
   id: "active-theme",
@@ -21,9 +27,11 @@ const activeThemeInjectable = getInjectable({
     const lensColorThemePreference = di.inject(lensColorThemePreferenceInjectable);
     const systemThemeConfiguration = di.inject(systemThemeConfigurationInjectable);
     const defaultLensTheme = di.inject(defaultLensThemeInjectable);
+    const userPreferencesState = di.inject(userPreferencesStateInjectable);
 
     return computed(() => {
       const pref = lensColorThemePreference.get();
+      let activeTheme: ReadonlyDeep<LensTheme>;
 
       if (pref.useSystemTheme) {
         const systemThemeType = systemThemeConfiguration.get();
@@ -31,10 +39,12 @@ const activeThemeInjectable = getInjectable({
 
         assert(matchingTheme, `Missing theme declaration for system theme "${systemThemeType}"`);
 
-        return matchingTheme;
+        activeTheme = matchingTheme;
+      } else {
+        activeTheme = lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
       }
 
-      return lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
+      return withCustomThemeColors(activeTheme, userPreferencesState.customThemeColors);
     });
   },
 });

--- a/packages/core/src/renderer/themes/custom-theme-colors.test.ts
+++ b/packages/core/src/renderer/themes/custom-theme-colors.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getCustomThemeColors, withCustomThemeColors } from "./custom-theme-colors";
+import lensDarkThemeInjectable from "./lens-dark.injectable";
+
+describe("custom theme colors", () => {
+  it("keeps only supported lens theme color names", () => {
+    expect(
+      getCustomThemeColors({
+        primary: "#123456",
+        unknownColor: "#abcdef",
+      }),
+    ).toEqual({
+      primary: "#123456",
+    });
+  });
+
+  it("applies valid overrides to a theme", () => {
+    const theme = lensDarkThemeInjectable.instantiate({} as never);
+
+    expect(withCustomThemeColors(theme, { primary: "#123456" })).toMatchObject({
+      colors: {
+        ...theme.colors,
+        primary: "#123456",
+      },
+    });
+  });
+
+  it("returns the original theme without valid overrides", () => {
+    const theme = lensDarkThemeInjectable.instantiate({} as never);
+
+    expect(withCustomThemeColors(theme, undefined)).toBe(theme);
+  });
+});

--- a/packages/core/src/renderer/themes/custom-theme-colors.ts
+++ b/packages/core/src/renderer/themes/custom-theme-colors.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { normalizeCustomThemeColors } from "../../features/user-preferences/common/custom-theme-colors";
+
+import type { ReadonlyDeep } from "type-fest";
+
+import type { CustomThemeColors } from "../../features/user-preferences/common/custom-theme-colors";
+import type { LensColorName, LensTheme } from "./lens-theme";
+
+export const lensColorNames = [
+  "blue",
+  "magenta",
+  "golden",
+  "halfGray",
+  "primary",
+  "textColorPrimary",
+  "textColorSecondary",
+  "textColorTertiary",
+  "textColorAccent",
+  "textColorDimmed",
+  "borderColor",
+  "borderFaintColor",
+  "mainBackground",
+  "secondaryBackground",
+  "contentColor",
+  "layoutBackground",
+  "layoutTabsBackground",
+  "layoutTabsActiveColor",
+  "layoutTabsLineColor",
+  "sidebarLogoBackground",
+  "sidebarActiveColor",
+  "sidebarSubmenuActiveColor",
+  "sidebarBackground",
+  "sidebarItemHoverBackground",
+  "badgeBackgroundColor",
+  "buttonPrimaryBackground",
+  "buttonDefaultBackground",
+  "buttonLightBackground",
+  "buttonAccentBackground",
+  "buttonDisabledBackground",
+  "tableBgcStripe",
+  "tableBgcSelected",
+  "tableHeaderBackground",
+  "tableHeaderColor",
+  "tableSelectedRowColor",
+  "helmLogoBackground",
+  "helmStableRepo",
+  "helmIncubatorRepo",
+  "helmDescriptionHr",
+  "helmDescriptionBlockquoteColor",
+  "helmDescriptionBlockquoteBorder",
+  "helmDescriptionBlockquoteBackground",
+  "helmDescriptionHeaders",
+  "helmDescriptionH6",
+  "helmDescriptionTdBorder",
+  "helmDescriptionTrBackground",
+  "helmDescriptionCodeBackground",
+  "helmDescriptionPreBackground",
+  "helmDescriptionPreColor",
+  "colorSuccess",
+  "colorOk",
+  "colorInfo",
+  "colorError",
+  "colorSoftError",
+  "colorWarning",
+  "colorVague",
+  "colorTerminated",
+  "dockHeadBackground",
+  "dockInfoBackground",
+  "dockInfoBorderColor",
+  "dockEditorBackground",
+  "dockEditorTag",
+  "dockEditorKeyword",
+  "dockEditorComment",
+  "dockEditorActiveLineBackground",
+  "dockBadgeBackground",
+  "dockTabBorderColor",
+  "dockTabActiveBackground",
+  "logsBackground",
+  "logsForeground",
+  "logRowHoverBackground",
+  "dialogTextColor",
+  "dialogBackground",
+  "dialogHeaderBackground",
+  "dialogFooterBackground",
+  "drawerTogglerBackground",
+  "drawerTitleText",
+  "drawerSubtitleBackground",
+  "drawerItemNameColor",
+  "drawerItemValueColor",
+  "clusterMenuBackground",
+  "clusterMenuBorderColor",
+  "clusterMenuCellBackground",
+  "clusterMenuCellOutline",
+  "clusterSettingsBackground",
+  "addClusterIconColor",
+  "boxShadow",
+  "iconActiveColor",
+  "iconActiveBackground",
+  "filterAreaBackground",
+  "chartLiveBarBackground",
+  "chartStripesColor",
+  "chartCapacityColor",
+  "pieChartDefaultColor",
+  "inputOptionHoverColor",
+  "inputControlBackground",
+  "inputControlBorder",
+  "inputControlHoverBorder",
+  "lineProgressBackground",
+  "radioActiveBackground",
+  "menuActiveBackground",
+  "menuSelectedOptionBgc",
+  "canvasBackground",
+  "scrollBarColor",
+  "settingsBackground",
+  "settingsColor",
+  "navSelectedBackground",
+  "navHoverColor",
+  "hrColor",
+  "tooltipBackground",
+] as const satisfies LensColorName[];
+
+const lensColorNameSet = new Set<string>(lensColorNames);
+
+export const isLensColorName = (value: string): value is LensColorName => lensColorNameSet.has(value);
+
+export const getCustomThemeColors = (
+  customThemeColors: CustomThemeColors | undefined,
+): Partial<Record<LensColorName, string>> => {
+  const normalizedColors = normalizeCustomThemeColors(customThemeColors);
+
+  if (!normalizedColors) {
+    return {};
+  }
+
+  const colors: Partial<Record<LensColorName, string>> = {};
+
+  for (const [name, color] of Object.entries(normalizedColors)) {
+    if (isLensColorName(name)) {
+      colors[name] = color;
+    }
+  }
+
+  return colors;
+};
+
+export const withCustomThemeColors = (
+  theme: ReadonlyDeep<LensTheme>,
+  customThemeColors: CustomThemeColors | undefined,
+): ReadonlyDeep<LensTheme> | LensTheme => {
+  const colors = getCustomThemeColors(customThemeColors);
+
+  if (Object.keys(colors).length === 0) {
+    return theme;
+  }
+
+  return {
+    ...theme,
+    colors: {
+      ...theme.colors,
+      ...colors,
+    },
+  };
+};


### PR DESCRIPTION
Fixes #1280.

## Summary
- Add persisted custom theme color overrides for Lens theme variables.
- Merge valid custom colors into the active theme for system, dark, and light theme modes.
- Add a preferences UI for choosing and resetting custom colors.

## Tests
- `pnpm biome check packages/core/src/common/__tests__/user-store.test.ts packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss packages/core/src/features/user-preferences/common/custom-theme-colors.ts packages/core/src/renderer/themes/custom-theme-colors.ts packages/core/src/renderer/themes/custom-theme-colors.test.ts`
- `pnpm --dir packages/core test:unit src/renderer/themes/custom-theme-colors.test.ts src/common/__tests__/user-store.test.ts --runInBand`
- `pnpm build:core`