### PR TITLE
Display providerID in node details

### DIFF
--- a/packages/core/src/renderer/components/nodes/details.tsx
+++ b/packages/core/src/renderer/components/nodes/details.tsx
@@ -58,6 +58,7 @@ class NonInjectedNodeDetails extends React.Component<NodeDetailsProps & Dependen
     }
 
     const { nodeInfo, addresses } = node.status ?? {};
+    const providerID = node.spec?.providerID;
     const taints = node.getTaints();
     const childPods = podStore.getPodsByNode(node.getName());
 
@@ -70,6 +71,7 @@ class NonInjectedNodeDetails extends React.Component<NodeDetailsProps & Dependen
             ))}
           </DrawerItem>
         )}
+        {providerID && <DrawerItem name="Provider ID">{providerID}</DrawerItem>}
         {nodeInfo && (
           <>
             <DrawerItem name="OS">{`${nodeInfo.operatingSystem} (${nodeInfo.architecture})`}</DrawerItem>


### PR DESCRIPTION
<!-- markdownlint-disable -->

**Description of changes:**

- Display the Kubernetes Node `spec.providerID` field in the node details panel when it is set, rendered as a `Provider ID` row between the **Addresses** and **System Info** sections.
- Uses the existing conditional `DrawerItem` pattern (as with `Addresses` and `Taints`), so nodes without a provider ID (e.g. bare-metal/kubeadm clusters) show no empty row.
- `providerID` identifies the cloud provider/instance backing a node (e.g. `aws:///us-east-1a/i-0abc...`, `gce://project/zone/instance`); it was already typed on `NodeSpec` but never surfaced in the UI.
- No type or model changes were needed — `providerID?: string` already exists on `NodeSpec`.