### PR TITLE
feat(pods): add Running Time column

### DIFF
--- a/freelens/package.json
+++ b/freelens/package.json
@@ -196,7 +196,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "engines": {
-    "node": "^24.0.0"
+    "node": ">=24.0.0"
   },
   "copyright": "© 2024-2026 Freelens Authors",
   "productName": "Freelens"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -254,7 +254,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "engines": {
-    "node": "^24.0.0"
+    "node": ">=24.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/src/renderer/components/workloads-pods/columns/column-priority.ts
+++ b/packages/core/src/renderer/components/workloads-pods/columns/column-priority.ts
@@ -11,6 +11,7 @@ export const COLUMN_PRIORITY = {
   NODE: 30,
   QOS: 20,
   AGE: 10,
+  RUNNING_TIME: 8,
   STATUS: 5,
   LOGS: 0,
 };

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-running-time-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-running-time-column.injectable.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
+import { getInjectable } from "@ogre-tools/injectable";
+import React from "react";
+import moment from "moment-timezone";
+import { ReactiveDuration } from "../../duration/reactive-duration";
+import { WithTooltip } from "../../with-tooltip";
+import { COLUMN_PRIORITY } from "./column-priority";
+
+const columnId = "running-time";
+
+export const podsRunningTimeColumnInjectable = getInjectable({
+  id: "pods-running-time-column",
+  instantiate: () => ({
+    id: columnId,
+    kind: "Pod",
+    apiVersion: "v1",
+    priority: COLUMN_PRIORITY.RUNNING_TIME ?? 8,
+    content: (pod) => {
+      if (pod.status?.phase !== "Running") {
+        return <>-</>;
+      }
+      const containerStatuses = pod.getContainerStatuses();
+      const runningStartedAts = containerStatuses
+        .map((c) => c.state?.running?.startedAt)
+        .filter((t): t is string => !!t);
+
+      if (runningStartedAts.length === 0) {
+        return <>-</>;
+      }
+      const times = runningStartedAts.map((t) => new Date(t).getTime());
+      const minTime = Math.min(...times);
+      const startTime = new Date(minTime).toISOString();
+
+      return (
+        <WithTooltip tooltip={moment(startTime).toDate()}>
+          <ReactiveDuration key="running-time" timestamp={startTime} compact={true} />
+        </WithTooltip>
+      );
+    },
+    header: { title: "Running Time", className: "running-time", sortBy: columnId, id: columnId },
+    sortingCallBack: (pod) => {
+      if (pod.status?.phase !== "Running") {
+        return 0;
+      }
+      const containerStatuses = pod.getContainerStatuses();
+      const runningStartedAts = containerStatuses
+        .map((c) => c.state?.running?.startedAt)
+        .filter((t): t is string => !!t);
+
+      if (runningStartedAts.length === 0) {
+        return 0;
+      }
+      const times = runningStartedAts.map((t) => new Date(t).getTime());
+      return -Math.min(...times);
+    },
+  }),
+  injectionToken: podListLayoutColumnInjectionToken,
+});

--- a/packages/core/src/renderer/components/workloads-pods/columns/register-injectables.ts
+++ b/packages/core/src/renderer/components/workloads-pods/columns/register-injectables.ts
@@ -18,6 +18,7 @@ import { podsNodeColumnInjectable } from "./pods-node-column.injectable";
 import { podsOwnersColumnInjectable } from "./pods-owners-column.injectable";
 import { podsQosColumnInjectable } from "./pods-qos-column.injectable";
 import { podsRestartsColumnInjectable } from "./pods-restarts-column.injectable";
+import { podsRunningTimeColumnInjectable } from "./pods-running-time-column.injectable";
 import { podsStatusColumnInjectable } from "./pods-status-column.injectable";
 import { podsWarningColumnInjectable } from "./pods-warning-column.injectable";
 
@@ -66,6 +67,11 @@ export function registerInjectables(di: DiContainerForInjection): void {
   }
   try {
     di.register(podsRestartsColumnInjectable);
+  } catch (e) {
+    /* Ignore duplicate registration */
+  }
+  try {
+    di.register(podsRunningTimeColumnInjectable);
   } catch (e) {
     /* Ignore duplicate registration */
   }

--- a/packages/core/src/renderer/components/workloads-pods/pods.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pods.tsx
@@ -49,7 +49,7 @@ const NonInjectedPods = observer((props: Dependencies) => {
         dependentStores={[eventStore]} // status icon component uses event store
         tableId="workloads_pods"
         isConfigurable
-        defaultHiddenTableColumns={["ip", "node", "qos"]}
+        defaultHiddenTableColumns={["ip", "node", "qos", "running-time"]}
         searchFilters={[
           (pod) => pod.getSearchFields(),
           (pod) => pod.getStatusMessage(),


### PR DESCRIPTION
This PR adds a Running Time column to the Pods list table which calculates the real-time running duration of a Pod based on its oldest container's startedAt status.