### PR TITLE
Display schedulerName in pod details

### DIFF
--- a/packages/core/src/renderer/components/workloads-pods/pod-details.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details.tsx
@@ -71,11 +71,11 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
         <DrawerItem name="Status">
           <span className={cssNames("status", kebabCase(pod.getStatusMessage()))}>{pod.getStatusMessage()}</span>
         </DrawerItem>
+        <DrawerItem name="Scheduler" hidden={!schedulerName || schedulerName === "default-scheduler"}>
+          {schedulerName}
+        </DrawerItem>
         <DrawerItem name="Node" hidden={!nodeName}>
           <LinkToNode name={nodeName} />
-        </DrawerItem>
-        <DrawerItem name="Scheduler" hidden={!schedulerName}>
-          {schedulerName}
         </DrawerItem>
         <DrawerItem name="Host IPs" hidden={!hostIPs.length && !hostIP} labelsOnly>
           {(hostIPs.length ? hostIPs : hostIP ? [hostIP] : []).map((label) => (

--- a/packages/core/src/renderer/components/workloads-pods/pod-details.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details.tsx
@@ -53,7 +53,7 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
     const { status, spec } = pod;
     const { podIP } = status ?? {};
     const podIPs = pod.getIPs();
-    const { nodeName } = spec ?? {};
+    const { nodeName, schedulerName } = spec ?? {};
     const nodeSelector = pod.getNodeSelectors();
     const { hostIP } = status ?? {};
     const hostIPs = pod.getHostIPs();
@@ -73,6 +73,9 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
         </DrawerItem>
         <DrawerItem name="Node" hidden={!nodeName}>
           <LinkToNode name={nodeName} />
+        </DrawerItem>
+        <DrawerItem name="Scheduler" hidden={!schedulerName}>
+          {schedulerName}
         </DrawerItem>
         <DrawerItem name="Host IPs" hidden={!hostIPs.length && !hostIP} labelsOnly>
           {(hostIPs.length ? hostIPs : hostIP ? [hostIP] : []).map((label) => (


### PR DESCRIPTION
<!-- markdownlint-disable -->

**Description of changes:**

- Display the Kubernetes Pod `spec.schedulerName` field in the pod details panel as a `Scheduler` row, placed directly after the `Node` row (both are scheduling-related).
- Makes the scheduler that placed a pod visible at a glance (e.g. `default-scheduler` vs `kai-scheduler`) without inspecting raw YAML.
- Uses the existing `hidden={!schedulerName}` `DrawerItem` convention, consistent with the adjacent `Node` and `Runtime Class` rows. In practice `schedulerName` is API-defaulted to `default-scheduler`, so the row is shown on essentially every pod.
- No type or model changes were needed — `schedulerName?: string` already exists on `PodSpec`.