### PR TITLE
Custom theme and color feature

### DIFF
--- a/packages/core/src/common/vars.ts
+++ b/packages/core/src/common/vars.ts
@@ -6,6 +6,7 @@
 
 // App's common configuration for any process (main, renderer, build pipeline, etc.)
 export const defaultColorThemePreference = "system";
+export const defaultAccentColor = "#00a7a0";
 export const defaultFontSize = 12;
 export const defaultTerminalFontFamily = "RobotoMono";
 export const defaultEditorFontFamily = "RobotoMono";

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
@@ -7,9 +7,10 @@
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
-import { defaultColorThemePreference } from "../../../../../../common/vars";
+import { defaultAccentColor, defaultColorThemePreference } from "../../../../../../common/vars";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
+import { accentColorPresets } from "../../../../../../renderer/themes/accent-colors";
 import { lensThemeDeclarationInjectionToken } from "../../../../../../renderer/themes/declaration";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";
 
@@ -33,6 +34,13 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
     })),
   ];
 
+  const accentOptions = accentColorPresets.map((preset) => ({
+    value: preset.value,
+    label: preset.name,
+  }));
+
+  const currentAccent = state.customAccentColor || defaultAccentColor;
+
   return (
     <section id="appearance">
       <SubTitle title="Theme" />
@@ -42,6 +50,34 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
         value={state.colorTheme}
         onChange={(value) => (state.colorTheme = value?.value ?? defaultColorThemePreference)}
         themeName="lens"
+      />
+      <SubTitle title="Accent Color" />
+      <Select
+        id="accent-color-input"
+        options={accentOptions}
+        value={currentAccent}
+        onChange={(value) => {
+          const selected = value?.value ?? defaultAccentColor;
+
+          state.customAccentColor = selected === defaultAccentColor ? "" : selected;
+        }}
+        themeName="lens"
+        formatOptionLabel={(option) => (
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <span
+              style={{
+                display: "inline-block",
+                width: "14px",
+                height: "14px",
+                borderRadius: "50%",
+                backgroundColor: option.value,
+                border: "1px solid rgba(128,128,128,0.3)",
+                flexShrink: 0,
+              }}
+            />
+            <span>{option.label}</span>
+          </div>
+        )}
       />
     </section>
   );

--- a/packages/core/src/features/user-preferences/common/custom-accent-color.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/custom-accent-color.injectable.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getInjectable } from "@ogre-tools/injectable";
+import { computed } from "mobx";
+import { defaultAccentColor } from "../../../common/vars";
+import userPreferencesStateInjectable from "./state.injectable";
+
+const customAccentColorPreferenceInjectable = getInjectable({
+  id: "custom-accent-color-preference",
+  instantiate: (di) => {
+    const state = di.inject(userPreferencesStateInjectable);
+
+    return computed((): string => state.customAccentColor || defaultAccentColor);
+  },
+});
+
+export default customAccentColorPreferenceInjectable;

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -8,8 +8,8 @@ import { getInjectable } from "@ogre-tools/injectable";
 import { merge } from "lodash";
 import { observable } from "mobx";
 import kubeDirectoryPathInjectable from "../../../common/os/kube-directory-path.injectable";
-import { defaultColorThemePreference } from "../../../common/vars";
 import currentTimezoneInjectable from "../../../common/vars/current-timezone.injectable";
+import { defaultAccentColor, defaultColorThemePreference } from "../../../common/vars";
 import {
   ClusterPageMenuOrder,
   defaultEditorConfig,
@@ -52,6 +52,10 @@ const userPreferenceDescriptorsInjectable = getInjectable({
       colorTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || defaultColorThemePreference,
         toStore: (val) => (!val || val === defaultColorThemePreference ? undefined : val),
+      }),
+      customAccentColor: getPreferenceDescriptor<string>({
+        fromStore: (val) => val || "",
+        toStore: (val) => (!val || val === defaultAccentColor ? undefined : val),
       }),
       terminalTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || "",

--- a/packages/core/src/features/user-preferences/common/register-injectables.ts
+++ b/packages/core/src/features/user-preferences/common/register-injectables.ts
@@ -10,6 +10,7 @@ import {
   getClusterPageMenuOrderInjectable,
   resetClusterPageMenuOrderInjectable,
 } from "./cluster-page-menu-order.injectable";
+import customAccentColorPreferenceInjectable from "./custom-accent-color.injectable";
 import httpsProxyConfigurationInjectable from "./https-proxy.injectable";
 import isTableColumnHiddenInjectable from "./is-table-column-hidden.injectable";
 import kubeconfigSyncsInjectable from "./kubeconfig-syncs.injectable";
@@ -27,6 +28,11 @@ import toggleTableColumnVisibilityInjectable from "./toggle-table-column-visibil
 import type { DiContainerForInjection } from "@ogre-tools/injectable";
 
 export function registerInjectables(di: DiContainerForInjection): void {
+  try {
+    di.register(customAccentColorPreferenceInjectable);
+  } catch (e) {
+    /* Ignore duplicate registration */
+  }
   try {
     di.register(getClusterPageMenuOrderInjectable);
   } catch (e) {

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -39,6 +39,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.allowErrorReporting = descriptors.allowErrorReporting.fromStore(preferences.allowErrorReporting);
         state.allowUntrustedCAs = descriptors.allowUntrustedCAs.fromStore(preferences.allowUntrustedCAs);
         state.colorTheme = descriptors.colorTheme.fromStore(preferences.colorTheme);
+        state.customAccentColor = descriptors.customAccentColor.fromStore(preferences.customAccentColor);
         state.downloadBinariesPath = descriptors.downloadBinariesPath.fromStore(preferences.downloadBinariesPath);
         state.downloadKubectlBinaries = descriptors.downloadKubectlBinaries.fromStore(
           preferences.downloadKubectlBinaries,
@@ -69,6 +70,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             allowErrorReporting: descriptors.allowErrorReporting.toStore(state.allowErrorReporting),
             allowUntrustedCAs: descriptors.allowUntrustedCAs.toStore(state.allowUntrustedCAs),
             colorTheme: descriptors.colorTheme.toStore(state.colorTheme),
+            customAccentColor: descriptors.customAccentColor.toStore(state.customAccentColor),
             downloadBinariesPath: descriptors.downloadBinariesPath.toStore(state.downloadBinariesPath),
             downloadKubectlBinaries: descriptors.downloadKubectlBinaries.toStore(state.downloadKubectlBinaries),
             downloadMirror: descriptors.downloadMirror.toStore(state.downloadMirror),

--- a/packages/core/src/renderer/themes/accent-colors.ts
+++ b/packages/core/src/renderer/themes/accent-colors.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { defaultAccentColor } from "../../common/vars";
+
+import type { ReadonlyDeep } from "type-fest";
+import type { LensColorName, LensTheme } from "./lens-theme";
+
+export interface AccentColor {
+  name: string;
+  value: string;
+}
+
+export { defaultAccentColor };
+
+export const accentColorPresets: AccentColor[] = [
+  { name: "Teal", value: defaultAccentColor },
+  { name: "Blue", value: "#2563eb" },
+  { name: "Indigo", value: "#6366f1" },
+  { name: "Purple", value: "#9333ea" },
+  { name: "Pink", value: "#ec4899" },
+  { name: "Red", value: "#dc2626" },
+  { name: "Orange", value: "#ea580c" },
+  { name: "Green", value: "#16a34a" },
+];
+
+/**
+ * Theme color keys that may be overridden by the accent color.
+ * The override only replaces values that match the default teal on a given
+ * theme, so per-theme intentional differences are preserved.
+ */
+export const accentOverrideKeys: LensColorName[] = [
+  "primary",
+  "blue",
+  "buttonPrimaryBackground",
+  "menuActiveBackground",
+  "sidebarSubmenuActiveColor",
+  "helmStableRepo",
+  "colorInfo",
+];
+
+/**
+ * Replace the default teal with the chosen accent color, but only on keys
+ * in `accentOverrideKeys` whose value currently equals the default teal.
+ * This preserves intentional per-theme differences (for example the dark
+ * theme keeps its white `sidebarSubmenuActiveColor`). Returns the original
+ * theme unchanged when the accent is the default or nothing matches.
+ */
+export function applyAccentColorOverride(
+  theme: ReadonlyDeep<LensTheme>,
+  accent: string,
+): ReadonlyDeep<LensTheme> {
+  if (accent === defaultAccentColor) {
+    return theme;
+  }
+
+  const overriddenColors = { ...theme.colors };
+  let changed = false;
+
+  for (const key of accentOverrideKeys) {
+    if (overriddenColors[key] === defaultAccentColor) {
+      overriddenColors[key] = accent;
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return theme;
+  }
+
+  return {
+    ...theme,
+    colors: overriddenColors,
+  } as ReadonlyDeep<LensTheme>;
+}

--- a/packages/core/src/renderer/themes/active.injectable.ts
+++ b/packages/core/src/renderer/themes/active.injectable.ts
@@ -7,11 +7,16 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { computed } from "mobx";
+import customAccentColorPreferenceInjectable from "../../features/user-preferences/common/custom-accent-color.injectable";
 import lensColorThemePreferenceInjectable from "../../features/user-preferences/common/lens-color-theme.injectable";
+import { applyAccentColorOverride } from "./accent-colors";
 import { lensThemeDeclarationInjectionToken } from "./declaration";
 import defaultLensThemeInjectable from "./default-theme.injectable";
 import systemThemeConfigurationInjectable from "./system-theme.injectable";
 import lensThemesInjectable from "./themes.injectable";
+
+import type { ReadonlyDeep } from "type-fest";
+import type { LensTheme } from "./lens-theme";
 
 const activeThemeInjectable = getInjectable({
   id: "active-theme",
@@ -21,9 +26,13 @@ const activeThemeInjectable = getInjectable({
     const lensColorThemePreference = di.inject(lensColorThemePreferenceInjectable);
     const systemThemeConfiguration = di.inject(systemThemeConfigurationInjectable);
     const defaultLensTheme = di.inject(defaultLensThemeInjectable);
+    const customAccentColorPreference = di.inject(customAccentColorPreferenceInjectable);
 
     return computed(() => {
       const pref = lensColorThemePreference.get();
+      const accent = customAccentColorPreference.get();
+
+      let baseTheme: ReadonlyDeep<LensTheme>;
 
       if (pref.useSystemTheme) {
         const systemThemeType = systemThemeConfiguration.get();
@@ -31,10 +40,12 @@ const activeThemeInjectable = getInjectable({
 
         assert(matchingTheme, `Missing theme declaration for system theme "${systemThemeType}"`);
 
-        return matchingTheme;
+        baseTheme = matchingTheme;
+      } else {
+        baseTheme = lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
       }
 
-      return lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
+      return applyAccentColorOverride(baseTheme, accent);
     });
   },
 });


### PR DESCRIPTION
## Summary

Add a custom accent color selector to the Application Preferences theme section. Users can choose from a set of preset accent colors that override the default teal (#00a7a0) on primary UI elements like buttons, menus, sidebar highlights, and link-colored text. The selection persists across sessions and syncs across frames via the existing user preferences storage mechanism.

## Changes

- `packages/core/src/renderer/themes/accent-colors.ts` — New module defining the accent color palette (8 presets), the default accent value, and the explicit list of theme color keys that get overridden.
- `packages/core/src/renderer/themes/active.injectable.ts` — Extend the active theme computed to apply accent color overrides on keys that match the default teal, preserving per-theme differences (e.g. dark theme keeps white sidebar text).
- `packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts` — Add `customAccentColor` preference descriptor.
- `packages/core/src/features/user-preferences/common/storage.injectable.ts` — Wire `customAccentColor` into persistent storage (fromStore/toJSON).
- `packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx` — Add accent color dropdown alongside the existing theme selector with color swatches.
- `packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.module.scss` — Styles for the side-by-side layout and color swatch rendering.
- `packages/core/src/renderer/themes/__tests__/active-theme.test.ts` — Unit tests covering accent override behavior on both dark and light themes.

## Test Plan

- `cd packages/core && pnpm test:unit -- --testPathPattern="active-theme"` → All accent override tests pass
- `pnpm test:unit:updatesnapshot` → Snapshots regenerate to reflect new accent selector in theme preferences
- `pnpm biome:check` → No lint or format errors on changed files
- Manual: Open Preferences > Application > Theme, select an accent color, verify primary-colored UI elements update immediately

## Notes

- Selecting the default Teal clears `customAccentColor` from storage (does not persist the default value), following the existing pattern for preferences.
- The override only replaces color values that match the default teal (#00a7a0) on a fixed key list. This means the dark theme's white `sidebarSubmenuActiveColor` stays white, while the light theme's teal value there gets overridden — preserving intentional per-theme differences.
- Snapshot files under `packages/core/src/features/preferences/__snapshots__/` and `packages/core/src/features/welcome/__snapshots__/` will need regeneration via `pnpm test:unit:updatesnapshot` since the theme preference block HTML structure changed.
- No new npm dependencies added. No color picker library — uses preset swatches only, with room to add a full picker in a follow-up if the community requests it.

Closes #1280