### PR TITLE
Claude: Add PR title convention rule for agent-related changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,30 @@ When asked to implement a change on a PR:
 2. Describe what will change and why
 3. After confirmation, apply the changes with commits on the PR branch
 
+### Branch Naming Conventions
+
+When creating a branch from an issue, use a human-readable name that includes
+the issue number and a short slug derived from the issue title:
+
+```text
+claude/issue-<number>-<short-slug>
+```
+
+- `<number>` is the GitHub issue number
+- `<short-slug>` is a kebab-case summary of the issue title, kept short
+  (3–6 words maximum, omit articles and filler words)
+
+Examples:
+
+- Issue #1957 "Add PR title convention rule for agent-related changes"
+  → `claude/issue-1957-add-pr-title-rules`
+- Issue #42 "Fix crash when opening preferences dialog"
+  → `claude/issue-42-fix-preferences-crash`
+
+Do **not** use auto-generated timestamp suffixes (e.g.
+`claude/issue-1957-20260612-2108`) — these are not human-readable and make
+branch lists hard to scan.
+
 ### PR Title Conventions
 
 When creating a PR, use the following title conventions:
@@ -287,7 +311,7 @@ When creating a PR, use the following title conventions:
 - **Agent-related changes** — PRs whose changes are strictly related to coding
   agent configuration (e.g. `AGENTS.md`, `.github/workflows/claude.yaml`, or
   other files that govern how Claude operates in this repository) MUST use
-  the prefix `Claude: ` in the title.
+  the prefix `Claude:` (followed by a space) in the title.
 
   Examples:
   - `Claude: Add rule for PR title conventions in AGENTS.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,22 @@ When asked to implement a change on a PR:
 2. Describe what will change and why
 3. After confirmation, apply the changes with commits on the PR branch
 
+### PR Title Conventions
+
+When creating a PR, use the following title conventions:
+
+- **Agent-related changes** — PRs whose changes are strictly related to coding
+  agent configuration (e.g. `AGENTS.md`, `.github/workflows/claude.yaml`, or
+  other files that govern how Claude operates in this repository) MUST use
+  the prefix `Claude: ` in the title.
+
+  Examples:
+  - `Claude: Add rule for PR title conventions in AGENTS.md`
+  - `Claude: Update claude.yaml workflow permissions`
+
+- **All other PRs** — do **not** use any prefix (no `fix:`, `feat:`, `chore:`,
+  etc.). Use plain, descriptive titles.
+
 ### Pushing Changes from Fork PRs
 
 When you have commits ready to push but the PR originates from a fork


### PR DESCRIPTION
Add a rule that PRs whose changes are strictly related to coding agent configuration (AGENTS.md, claude.yaml workflow, etc.) must use the "Claude: " prefix in the title.

Fixes #1957

Generated with [Claude Code](https://claude.ai/code)