### PR TITLE
Reduce packaged app size by excluding debug artifacts

### DIFF
--- a/freelens/electron-builder.yml
+++ b/freelens/electron-builder.yml
@@ -17,6 +17,11 @@ files:
   - "!node_modules/@freelensapp/core/build"
   - "!node_modules/@freelensapp/core/static/build/library/fonts"
   - "!node_modules/electron"
+  ## Source maps and TS build info are only useful when debugging local builds
+  - "!**/*.map"
+  - "!**/*.tsbuildinfo"
+  ## Monaco is bundled into the renderer by webpack and never required at runtime
+  - "!node_modules/monaco-editor/**"
 
 ## Notarization
 afterPack: build/prune-unused-native-binaries.js


### PR DESCRIPTION
## What

Excludes two categories of files from the packaged `app.asar` that are never needed at runtime:

- **Source maps and `*.tsbuildinfo`** (`!**/*.map`, `!**/*.tsbuildinfo`) — emitted by the production webpack build but only useful when debugging a local build. ~105 MB unpacked.
- **`node_modules/monaco-editor`** (`!node_modules/monaco-editor/**`) — the editor is bundled into the renderer by `monaco-editor-webpack-plugin`, so the package is never `require`d at runtime. ~94 MB unpacked.

## Impact (macOS arm64, measured)

| | Before | After |
|---|---|---|
| `.app` | 734 MB | 522 MB |
| `app.asar` | 319 MB | 154 MB |
| DMG | 225 MB | 175 MB |

## Verification

- Confirmed via `grep` over the renderer/main bundles that `monaco-editor` is never `require`d at runtime (it is inlined by webpack).
- Built the macOS arm64 DMG with these exclusions, launched the app, connected to a cluster, and opened the **Create resource** dock tab — the Monaco editor renders and works, so removing the unbundled package copy is safe.

## Notes

This is complementary to the existing `prune-unused-native-binaries` afterPack hook (which trims unpacked native binaries): this change only touches files that go *into* the asar, so the two do not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)