### PR TITLE
Expose navigateToPreferences on renderer extension API

### DIFF
--- a/packages/core/src/extensions/lens-renderer-extension.ts
+++ b/packages/core/src/extensions/lens-renderer-extension.ts
@@ -9,6 +9,7 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { pipeline } from "@ogre-tools/fp";
 import { fromPairs, map, matches, toPairs } from "lodash/fp";
 import catalogCategoryRegistryInjectable from "../common/catalog/category-registry.injectable";
+import navigateToPreferencesInjectable from "../features/preferences/common/navigate-to-preferences.injectable";
 import catalogEntityRegistryInjectable from "../renderer/api/catalog/entity/registry.injectable";
 import { getExtensionRoutePath } from "../renderer/routes/for-extension";
 import getExtensionPageParametersInjectable from "../renderer/routes/get-extension-page-parameters.injectable";
@@ -51,6 +52,7 @@ interface LensRendererExtensionDependencies extends LensExtensionDependencies {
   navigateToRoute: NavigateToRoute;
   getExtensionPageParameters: GetExtensionPageParameters;
   readonly routes: IComputedValue<Route<unknown>[]>;
+  navigateToPreferences: (tabId?: string) => void;
   readonly entityRegistry: CatalogEntityRegistry;
   readonly categoryRegistry: CatalogCategoryRegistry;
 }
@@ -89,6 +91,7 @@ export class LensRendererExtension extends LensExtension {
       categoryRegistry: di.inject(catalogCategoryRegistryInjectable),
       entityRegistry: di.inject(catalogEntityRegistryInjectable),
       routes: di.inject(routesInjectable),
+      navigateToPreferences: di.inject(navigateToPreferencesInjectable),
       logger: di.inject(loggerInjectionToken),
     };
 
@@ -126,6 +129,18 @@ export class LensRendererExtension extends LensExtension {
     this.dependencies.navigateToRoute(targetRoute, {
       query,
     });
+  }
+
+  /**
+   * Navigate to this extension's own preferences page.
+   *
+   * Opens the application preferences and selects the tab that holds the
+   * preference items registered by this extension through `appPreferences`.
+   * It always navigates to this extension's preferences, never to the
+   * generic preferences or to another extension's preferences.
+   */
+  navigateToPreferences() {
+    this.dependencies.navigateToPreferences(this.sanitizedExtensionId);
   }
 
   /**

--- a/packages/core/src/features/preferences/navigation-to-extension-preferences-using-extension-api.test.tsx
+++ b/packages/core/src/features/preferences/navigation-to-extension-preferences-using-extension-api.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { discoverFor } from "@freelensapp/react-testing-library-discovery";
+import React from "react";
+import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
+import currentPathInjectable from "../../renderer/routes/current-path.injectable";
+
+import type { Discover } from "@freelensapp/react-testing-library-discovery";
+
+import type { RenderResult } from "@testing-library/react";
+import type { IComputedValue } from "mobx";
+
+import type { LensRendererExtension } from "../../extensions/lens-renderer-extension";
+import type { FakeExtensionOptions } from "../../renderer/components/test-utils/get-extension-fake";
+
+describe("preferences - navigation to extension preferences using extension api", () => {
+  let rendered: RenderResult;
+  let discover: Discover;
+  let currentPath: IComputedValue<string>;
+  let testExtension: LensRendererExtension;
+
+  beforeEach(async () => {
+    const builder = getApplicationBuilder();
+
+    builder.extensions.enable(extensionWithPreferences, someOtherExtensionWithPreferences);
+
+    rendered = await builder.render();
+
+    discover = discoverFor(() => rendered);
+
+    const windowDi = builder.applicationWindow.only.di;
+
+    currentPath = windowDi.inject(currentPathInjectable);
+
+    testExtension = builder.extensions.get("some-test-extension-id").applicationWindows.only;
+  });
+
+  describe("when extension navigates to its own preferences", () => {
+    beforeEach(() => {
+      testExtension.navigateToPreferences();
+    });
+
+    it("URL points to the extension's own preferences tab", () => {
+      expect(currentPath.get()).toBe("/preferences/some-test-extension-id");
+    });
+
+    it("shows the page title for this extension", () => {
+      const { discovered } = discover.getSingleElement("preference-page-title");
+
+      expect(discovered).toHaveTextContent("some-test-extension-id preferences");
+    });
+
+    it("shows only this extension's preference items", () => {
+      const { attributeValues } = discover.queryAllElements("preference-item");
+
+      expect(attributeValues).toEqual([
+        "preference-item-for-extension-some-test-extension-id-item-some-preference-item-id",
+      ]);
+    });
+
+    it("does not show another extension's preferences", () => {
+      const { discovered } = discover.querySingleElement(
+        "preference-page",
+        "preference-item-for-extension-some-other-test-extension-id-page",
+      );
+
+      expect(discovered).toBeNull();
+    });
+  });
+});
+
+const extensionWithPreferences: FakeExtensionOptions = {
+  id: "some-test-extension-id",
+  name: "some-test-extension-id",
+
+  rendererOptions: {
+    appPreferences: [
+      {
+        title: "Some preference item",
+        id: "some-preference-item-id",
+
+        components: {
+          Hint: () => <div data-testid="some-preference-item-hint" />,
+          Input: () => <div data-testid="some-preference-item-input" />,
+        },
+      },
+    ],
+  },
+};
+
+const someOtherExtensionWithPreferences: FakeExtensionOptions = {
+  id: "some-other-test-extension-id",
+  name: "some-other-test-extension-id",
+
+  rendererOptions: {
+    appPreferences: [
+      {
+        title: "Some other preference item",
+        id: "some-other-preference-item-id",
+
+        components: {
+          Hint: () => <div data-testid="some-other-preference-item-hint" />,
+          Input: () => <div data-testid="some-other-preference-item-input" />,
+        },
+      },
+    ],
+  },
+};


### PR DESCRIPTION
Adds a `navigateToPreferences()` method to `LensRendererExtension` so an extension can open its own preferences page without extra hacks. It always targets the calling extension's own preferences tab, never the generic preferences or another extension's.

Fixes #1982.

| Model: `claude-opus-4-8`