### PR TITLE
Convert synchronous execFile spawn errors into AsyncResult failures

### DIFF
--- a/packages/core/src/common/fs/exec-file.injectable.ts
+++ b/packages/core/src/common/fs/exec-file.injectable.ts
@@ -38,19 +38,31 @@ const execFileInjectable = getInjectable({
       })();
 
       return new Promise((resolve) => {
-        execFile(filePath, args, options, (error, stdout, stderr) => {
-          if (error) {
-            resolve({
-              callWasSuccessful: false,
-              error: Object.assign(error, { stderr }),
-            });
-          } else {
-            resolve({
-              callWasSuccessful: true,
-              response: stdout.toString(),
-            });
-          }
-        });
+        try {
+          execFile(filePath, args, options, (error, stdout, stderr) => {
+            if (error) {
+              resolve({
+                callWasSuccessful: false,
+                error: Object.assign(error, { stderr }),
+              });
+            } else {
+              resolve({
+                callWasSuccessful: true,
+                response: stdout.toString(),
+              });
+            }
+          });
+        } catch (error) {
+          // On Windows, spawn failures such as `spawn UNKNOWN` (errno -4094)
+          // are thrown synchronously instead of being passed to the callback.
+          // Convert them into the AsyncResult error shape so callers don't hang.
+          resolve({
+            callWasSuccessful: false,
+            error: Object.assign(error as ExecFileError, {
+              stderr: (error as Partial<ExecFileError>).stderr ?? "",
+            }),
+          });
+        }
       });
     };
   },


### PR DESCRIPTION
On Windows, spawn failures such as `spawn UNKNOWN` (errno -4094) are thrown synchronously from `ChildProcess.spawn` instead of being delivered to the `execFile` callback. The Promise executor therefore rejected instead of resolving to an `AsyncResult`, bypassing the `{ callWasSuccessful: false }` contract callers rely on. The rejection left the renderer's `asyncComputed` stuck pending, so Helm Releases/Charts spun forever.

Wrapping the `execFile` call in a try/catch converts synchronous spawn errors into the `AsyncResult` error shape, so every caller (helm, kubectl, k8s-proxy) surfaces a visible error instead of hanging.

Fixes #1993