### PR TITLE
Claude: fix PreToolUse hook so the sensitive-file guard actually runs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,13 @@
   "hooks": {
     "PreToolUse": [
       {
-        "type": "command",
-        "command": "python3 -c \"\nimport json, sys, re\ninput_data = json.load(sys.stdin)\ntool = input_data.get('tool_name', '')\nparams = input_data.get('tool_input', {})\npath = params.get('filePath', params.get('path', ''))\npatterns = [\n    r'(^|/)\\.env$',\n    r'(^|/)\\.env\\.',\n    r'\\.npmrc$',\n    r'\\.pem$',\n    r'\\.key$',\n    r'serviceAccountKey\\.json$',\n    r'credentials\\.json$'\n]\nif any(re.search(p, path) for p in patterns):\n    print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'deny', 'permissionDecisionReason': 'Sensitive file excluded for security: ' + path}}))\n    sys.exit(0)\nprint(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow'}}))\n\""
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"\nimport json, sys, re\ninput_data = json.load(sys.stdin)\ntool = input_data.get('tool_name', '')\nparams = input_data.get('tool_input', {})\npath = params.get('file_path', '')\npatterns = [\n    r'(^|/)\\.env$',\n    r'(^|/)\\.env\\.',\n    r'\\.npmrc$',\n    r'\\.pem$',\n    r'\\.key$',\n    r'serviceAccountKey\\.json$',\n    r'credentials\\.json$'\n]\nif any(re.search(p, path) for p in patterns):\n    print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'deny', 'permissionDecisionReason': 'Sensitive file excluded for security: ' + path}}))\n    sys.exit(0)\nprint(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow'}}))\n\""
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Problem

The `PreToolUse` hook in `.claude/settings.json` is meant to block reads/writes of sensitive files (`.env`, `.pem`, `.key`, `serviceAccountKey.json`, `credentials.json`, etc.), but it is currently inert for two independent reasons:

1. **Wrong config shape.** Each `PreToolUse` array entry must be a matcher group — `{ "matcher": "...", "hooks": [ { "type": "command", "command": "..." } ] }`. The command was placed directly on the entry instead, so schema validation rejects it and the command never runs. `claude doctor` reports:

   ```
   hooks.PreToolUse.0.hooks: Expected array, but received undefined
   ```

2. **Wrong `tool_input` key.** Even when it does run, it reads the file path from `filePath`/`path`, but the Read/Edit/Write tools expose it as `file_path` (snake_case). The path is therefore always empty, the patterns never match, and every file is allowed.

Net effect: the guard never blocks anything, which contradicts the security rule in `AGENTS.md` ("Never read, display, reference, or include the contents of the following files...").

## Fix

- Wrap the command in a match-all matcher group (`"matcher": ""`).
- Read the path from `file_path`.

The pattern list and deny logic are unchanged.

## Verification

Running the configured command against real Read tool input:

| `tool_input.file_path` | Decision |
|---|---|
| `/app/.env` | `deny` |
| `/app/cert.pem` | `deny` |
| `/app/src/x.ts` | `allow` |

`claude doctor` no longer reports the `PreToolUse.0.hooks` error, and the file remains valid JSON.

Refs: [PreToolUse hook configuration and tool_input fields](https://code.claude.com/docs/en/hooks.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)