### PR TITLE
Bootstrap extension pnpm root

### DIFF
--- a/packages/core/src/extensions/install-extension/install-extension.injectable.ts
+++ b/packages/core/src/extensions/install-extension/install-extension.injectable.ts
@@ -7,10 +7,9 @@
 import { prefixedLoggerInjectable } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import AwaitLock from "await-lock";
-import directoryForUserDataInjectable from "../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
-import removePathInjectable from "../../common/fs/remove.injectable";
+import pathExistsInjectable from "../../common/fs/path-exists.injectable";
 import statInjectable from "../../common/fs/stat.injectable";
-import joinPathsInjectable from "../../common/path/join-paths.injectable";
+import writeJsonSyncInjectable from "../../common/fs/write-json-sync.injectable";
 import forkPnpmInjectable from "./fork-pnpm.injectable";
 
 export type InstallExtension = (params: { name: string; packageJsonPath: string }) => Promise<void>;
@@ -18,35 +17,25 @@ export type InstallExtension = (params: { name: string; packageJsonPath: string 
 const installExtensionInjectable = getInjectable({
   id: "install-extension",
   instantiate: (di): InstallExtension => {
-    const directoryForUserData = di.inject(directoryForUserDataInjectable);
     const logger = di.inject(prefixedLoggerInjectable, "EXTENSION-INSTALLER");
-    const joinPaths = di.inject(joinPathsInjectable);
-    const removePath = di.inject(removePathInjectable);
+    const pathExists = di.inject(pathExistsInjectable);
     const stat = di.inject(statInjectable);
+    const writeJsonSync = di.inject(writeJsonSyncInjectable);
 
     const forkPnpm = di.inject(forkPnpmInjectable);
 
     const installLock = new AwaitLock();
-
-    const packageLock = joinPaths(directoryForUserData, "package.json");
 
     return async ({ name, packageJsonPath }) => {
       await installLock.acquireAsync();
 
       try {
         logger.info(`installing package for extension "${name}"`);
-        try {
-          const s = await stat(packageLock);
-          if (s.size == 0) {
-            try {
-              await removePath(packageJsonPath);
-            } catch (error) {
-              logger.error(`package.json has zero size and cannot be removed: ${error}`);
-            }
-          } else if (s.size > 0) {
-            await forkPnpm("install", "--prefer-offline", "--prod", "--force");
-          }
-        } catch (_) {}
+        if (!(await pathExists(packageJsonPath))) {
+          writeJsonSync(packageJsonPath, { private: true });
+        } else if ((await stat(packageJsonPath)).size === 0) {
+          writeJsonSync(packageJsonPath, { private: true });
+        }
         await forkPnpm("install", "--prefer-offline", "--prod", "--force", "--save-optional", name);
         logger.info(`installed package for extension "${name}"`);
       } catch (error) {

--- a/packages/core/src/extensions/install-extension/install-extension.test.ts
+++ b/packages/core/src/extensions/install-extension/install-extension.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import pathExistsInjectable from "../../common/fs/path-exists.injectable";
+import statInjectable from "../../common/fs/stat.injectable";
+import writeJsonSyncInjectable from "../../common/fs/write-json-sync.injectable";
+import { getDiForUnitTesting } from "../../main/getDiForUnitTesting";
+import forkPnpmInjectable from "./fork-pnpm.injectable";
+import installExtensionInjectable from "./install-extension.injectable";
+
+import type { InstallExtension } from "./install-extension.injectable";
+
+describe("install-extension", () => {
+  let installExtension: InstallExtension;
+  let forkPnpmMock: jest.Mock;
+  let pathExistsMock: jest.Mock;
+  let statMock: jest.Mock;
+  let writeJsonSyncMock: jest.Mock;
+
+  beforeEach(() => {
+    const di = getDiForUnitTesting();
+
+    pathExistsMock = jest.fn().mockResolvedValue(false);
+    di.override(pathExistsInjectable, () => pathExistsMock);
+
+    statMock = jest.fn();
+    di.override(statInjectable, () => statMock);
+
+    writeJsonSyncMock = jest.fn();
+    di.override(writeJsonSyncInjectable, () => writeJsonSyncMock);
+
+    forkPnpmMock = jest.fn().mockResolvedValue(undefined);
+    di.override(forkPnpmInjectable, () => forkPnpmMock);
+
+    installExtension = di.inject(installExtensionInjectable);
+  });
+
+  it("bootstraps package.json before installing an extension", async () => {
+    await installExtension({
+      name: "/tmp/my-extension",
+      packageJsonPath: "/some-directory-for-user-data/package.json",
+    });
+
+    expect(pathExistsMock).toHaveBeenCalledWith("/some-directory-for-user-data/package.json");
+    expect(statMock).not.toHaveBeenCalled();
+    expect(writeJsonSyncMock).toHaveBeenCalledWith("/some-directory-for-user-data/package.json", {
+      private: true,
+    });
+    expect(forkPnpmMock).toHaveBeenCalledWith(
+      "install",
+      "--prefer-offline",
+      "--prod",
+      "--force",
+      "--save-optional",
+      "/tmp/my-extension",
+    );
+  });
+});


### PR DESCRIPTION
Fix extension installs when ~/.config/Freelens is missing a package.json by bootstrapping the pnpm root before install. Adds a regression test for the installer.

Closes #2015