### PR TITLE
Use node-pty prebuilt binaries to avoid antivirus false positives

### DIFF
--- a/freelens/electron-builder.yml
+++ b/freelens/electron-builder.yml
@@ -22,6 +22,14 @@ files:
   - "!**/*.tsbuildinfo"
   ## Monaco is bundled into the renderer by webpack and never required at runtime
   - "!node_modules/monaco-editor/**"
+  ## node-pty is a N-API (node-addon-api) module, so its bundled prebuilt
+  ## binaries are ABI-stable and work as-is on every Electron version we ship.
+  ## electron-rebuild still recompiles them into build/Release, producing
+  ## unsigned binaries that some antivirus engines flag as false positives
+  ## (see issue #2021). Excluding build/ from the package makes node-pty fall
+  ## back to the original, vendor-provided prebuilds/ binaries at runtime
+  ## (lib/utils.js checks build/Release first, then prebuilds/<platform>-<arch>).
+  - "!node_modules/node-pty/build"
   ## Native binaries for other platforms/arches are never loaded at runtime, so
   ## exclude them at pack time. Doing this here (instead of deleting them from
   ## app.asar.unpacked afterwards) keeps the app.asar header consistent with the


### PR DESCRIPTION
Fixes #2021, #2018

node-pty is a N-API module, so its vendor-provided prebuilt binaries are ABI-stable and run as-is on every Electron version. electron-rebuild recompiles them into build/Release, producing unsigned binaries that some antivirus engines flag as false positives (e.g. conpty_console_list.node on Windows). This excludes node-pty's build/ directory from the package so node-pty falls back to the original prebuilds/ binaries at runtime.
