### PR TITLE
Persist helm binary path and helm server-side preferences

### DIFF
--- a/packages/core/src/features/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
+++ b/packages/core/src/features/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
@@ -439,6 +439,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -1248,6 +1249,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -2095,6 +2097,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -3053,6 +3056,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -3908,6 +3912,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -4866,6 +4871,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -6006,6 +6012,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -6964,6 +6971,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -8104,6 +8112,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -9063,6 +9072,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -9918,6 +9928,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -10763,6 +10774,7 @@ exports[`add custom helm repository in preferences when navigating to preference
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />

--- a/packages/core/src/features/helm-charts/__snapshots__/add-helm-repository-from-list-in-preferences.test.ts.snap
+++ b/packages/core/src/features/helm-charts/__snapshots__/add-helm-repository-from-list-in-preferences.test.ts.snap
@@ -439,6 +439,7 @@ exports[`add helm repository from list in preferences when navigating to prefere
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -1248,6 +1249,7 @@ exports[`add helm repository from list in preferences when navigating to prefere
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -2095,6 +2097,7 @@ exports[`add helm repository from list in preferences when navigating to prefere
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -3000,6 +3003,7 @@ exports[`add helm repository from list in preferences when navigating to prefere
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -3847,6 +3851,7 @@ exports[`add helm repository from list in preferences when navigating to prefere
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -4694,6 +4699,7 @@ exports[`add helm repository from list in preferences when navigating to prefere
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -5531,6 +5537,7 @@ exports[`add helm repository from list in preferences when navigating to prefere
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -6412,6 +6419,7 @@ exports[`add helm repository from list in preferences when navigating to prefere
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -7361,6 +7369,7 @@ exports[`add helm repository from list in preferences when navigating to prefere
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -8242,6 +8251,7 @@ exports[`add helm repository from list in preferences when navigating to prefere
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />

--- a/packages/core/src/features/helm-charts/__snapshots__/listing-active-helm-repositories-in-preferences.test.ts.snap
+++ b/packages/core/src/features/helm-charts/__snapshots__/listing-active-helm-repositories-in-preferences.test.ts.snap
@@ -439,6 +439,7 @@ exports[`listing active helm repositories in preferences when navigating to pref
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -1248,6 +1249,7 @@ exports[`listing active helm repositories in preferences when navigating to pref
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -2085,6 +2087,7 @@ exports[`listing active helm repositories in preferences when navigating to pref
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -2811,6 +2814,7 @@ exports[`listing active helm repositories in preferences when navigating to pref
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -3623,6 +3627,7 @@ exports[`listing active helm repositories in preferences when navigating to pref
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -4504,6 +4509,7 @@ exports[`listing active helm repositories in preferences when navigating to pref
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -5230,6 +5236,7 @@ exports[`listing active helm repositories in preferences when navigating to pref
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -5956,6 +5963,7 @@ exports[`listing active helm repositories in preferences when navigating to pref
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />

--- a/packages/core/src/features/helm-charts/__snapshots__/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts.snap
+++ b/packages/core/src/features/helm-charts/__snapshots__/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts.snap
@@ -439,6 +439,7 @@ exports[`remove helm repository from list of active repositories in preferences 
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -1248,6 +1249,7 @@ exports[`remove helm repository from list of active repositories in preferences 
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -2067,6 +2069,7 @@ exports[`remove helm repository from list of active repositories in preferences 
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />
@@ -2914,6 +2917,7 @@ exports[`remove helm repository from list of active repositories in preferences 
                         >
                           Use server-side apply for Helm chart operations
                           <input
+                            checked=""
                             role="switch"
                             type="checkbox"
                           />

--- a/packages/core/src/features/preferences/__snapshots__/navigation-to-kubernetes-preferences.test.ts.snap
+++ b/packages/core/src/features/preferences/__snapshots__/navigation-to-kubernetes-preferences.test.ts.snap
@@ -1205,6 +1205,7 @@ exports[`preferences - navigation to kubernetes preferences given in preferences
                       >
                         Use server-side apply for Helm chart operations
                         <input
+                          checked=""
                           role="switch"
                           type="checkbox"
                         />

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -47,6 +47,8 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.downloadCustomMirror = descriptors.downloadCustomMirror.fromStore(preferences.downloadCustomMirror);
         state.editorConfiguration = descriptors.editorConfiguration.fromStore(preferences.editorConfiguration);
         state.extensionRegistryUrl = descriptors.extensionRegistryUrl.fromStore(preferences.extensionRegistryUrl);
+        state.helmBinariesPath = descriptors.helmBinariesPath.fromStore(preferences.helmBinariesPath);
+        state.helmServerSide = descriptors.helmServerSide.fromStore(preferences.helmServerSide);
         state.hiddenTableColumns = descriptors.hiddenTableColumns.fromStore(preferences.hiddenTableColumns);
         state.httpsProxy = descriptors.httpsProxy.fromStore(preferences.httpsProxy);
         state.kubectlBinariesPath = descriptors.kubectlBinariesPath.fromStore(preferences.kubectlBinariesPath);
@@ -75,6 +77,8 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             downloadCustomMirror: descriptors.downloadCustomMirror.toStore(state.downloadCustomMirror),
             editorConfiguration: descriptors.editorConfiguration.toStore(state.editorConfiguration),
             extensionRegistryUrl: descriptors.extensionRegistryUrl.toStore(state.extensionRegistryUrl),
+            helmBinariesPath: descriptors.helmBinariesPath.toStore(state.helmBinariesPath),
+            helmServerSide: descriptors.helmServerSide.toStore(state.helmServerSide),
             hiddenTableColumns: descriptors.hiddenTableColumns.toStore(state.hiddenTableColumns),
             httpsProxy: descriptors.httpsProxy.toStore(state.httpsProxy),
             kubectlBinariesPath: descriptors.kubectlBinariesPath.toStore(state.kubectlBinariesPath),


### PR DESCRIPTION
Fixes #1927

### Problem

The `helmBinariesPath` preference (Preferences › Kubernetes › Path to helm binary) reverted to the bundled default after restarting the app.

### Root cause

In `storage.injectable.ts`, the `fromStore` and `toJSON` handlers enumerate each preference explicitly but omitted `helmBinariesPath` and `helmServerSide`. Although descriptors exist and the renderer updates state, the values were never serialized to disk nor read back at startup.

### Fix

Added both fields to `fromStore` (load) and `toJSON` (save) so they persist across restarts.

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`