### PR TITLE
Close pod context menu when a sub-menu item is clicked

### DIFF
--- a/packages/core/src/renderer/components/menu/menu.tsx
+++ b/packages/core/src/renderer/components/menu/menu.tsx
@@ -453,16 +453,19 @@ export const Menu = withInjectables<Dependencies, MenuProps>(NonInjectedMenu, {
 
 export function SubMenu(props: Partial<MenuProps>) {
   const { className, ...menuProps } = props;
+  // Inherit close behavior from the parent menu so that clicking a MenuItem
+  // inside a sub-menu also closes the top-level menu (e.g. MenuActions).
+  const parentMenu = React.useContext(MenuContext);
 
   return (
     <Menu
       className={cssNames("SubMenu", className)}
       isOpen
       open={noop}
-      close={noop}
+      close={parentMenu ? () => parentMenu.close() : noop}
       position={{}} // reset position, must be handled in css
       closeOnClickOutside={false}
-      closeOnClickItem={false}
+      closeOnClickItem={parentMenu?.props.closeOnClickItem ?? false}
       {...menuProps}
     />
   );

--- a/packages/core/src/renderer/components/node-pod-menu/pod-menu-item.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/pod-menu-item.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Icon } from "@freelensapp/icon";
-import { prevDefault } from "@freelensapp/utilities";
 import React from "react";
 import { MenuItem, SubMenu } from "../menu";
 import { StatusBrick } from "../status-brick";
@@ -36,7 +35,14 @@ const PodMenuItem: React.FC<NodePodMenuItemProps> = (props) => {
 
   return (
     <>
-      <MenuItem onClick={prevDefault(() => onMenuItemClick(containers[0]))}>
+      <MenuItem
+        onClick={(evt) => {
+          // Stop propagation so a click on a sub-menu item does not also
+          // trigger this parent item, but allow the menu to close itself.
+          evt.stopPropagation();
+          onMenuItemClick(containers[0]);
+        }}
+      >
         <Icon material={material} svg={svg} interactive={toolbar} tooltip={toolbar && tooltip} />
         <span className="title">{title}</span>
         <Icon className="arrow" material="keyboard_arrow_right" />
@@ -49,7 +55,10 @@ const PodMenuItem: React.FC<NodePodMenuItemProps> = (props) => {
             return (
               <MenuItem
                 key={name}
-                onClick={prevDefault(() => onMenuItemClick(container))}
+                onClick={(evt) => {
+                  evt.stopPropagation();
+                  onMenuItemClick(container);
+                }}
                 className="flex align-center"
               >
                 {brick}


### PR DESCRIPTION
Fixes #2043.

The pod context menu (Logs/Shell/Attach) stayed open after selecting an option.

- `SubMenu` now inherits `close` and `closeOnClickItem` from the parent menu context, so clicking a sub-menu item closes the top-level `MenuActions`.
- `PodMenuItem` no longer uses `prevDefault` (which set `defaultPrevented` and blocked auto-close); handlers now only `stopPropagation`.
