### PR TITLE
Add bundled binaries directory to PowerShell and fish terminal PATH

### DIFF
--- a/packages/core/src/main/shell-session/local-shell-session/local-shell-session.ts
+++ b/packages/core/src/main/shell-session/local-shell-session/local-shell-session.ts
@@ -15,6 +15,7 @@ import type { ShellSessionArgs, ShellSessionDependencies } from "../shell-sessio
 
 export interface LocalShellSessionDependencies extends ShellSessionDependencies {
   readonly directoryForBinaries: string;
+  readonly baseBundledBinariesDirectory: string;
   readonly state: UserPreferencesState;
   modifyTerminalShellEnv: ModifyTerminalShellEnv;
   joinPaths: JoinPaths;
@@ -65,12 +66,19 @@ export class LocalShellSession extends ShellSession {
       .replace(/\.exe$/i, "")
       .toLowerCase();
 
+    // The bundled binaries directory (e.g. resources/<arch>) holds the
+    // kubectl shipped with the app. The bash/zsh init scripts already append
+    // it as a fallback, so include it here as well for PowerShell and fish.
+    // Otherwise, when the downloaded kubectl directory is empty (e.g. a failed
+    // download), Windows PowerShell has no kubectl on PATH at all.
+    const bundledBinariesDir = this.dependencies.baseBundledBinariesDirectory;
+
     switch (shellName) {
       case "powershell":
         return [
           "-NoExit",
           "-command",
-          `& {$Env:PATH="${kubectlPathDir};${this.dependencies.directoryForBinaries};$Env:PATH"}`,
+          `& {$Env:PATH="${kubectlPathDir};${this.dependencies.directoryForBinaries};${bundledBinariesDir};$Env:PATH"}`,
         ];
       case "bash":
         return [
@@ -81,7 +89,7 @@ export class LocalShellSession extends ShellSession {
         return [
           "--login",
           "--init-command",
-          `export PATH="${kubectlPathDir}:${this.dependencies.directoryForBinaries}:$PATH"; export KUBECONFIG="${await this.dependencies.proxyKubeconfigPath}"`,
+          `export PATH="${kubectlPathDir}:${this.dependencies.directoryForBinaries}:${bundledBinariesDir}:$PATH"; export KUBECONFIG="${await this.dependencies.proxyKubeconfigPath}"`,
         ];
       case "zsh":
         return ["--login"];

--- a/packages/core/src/main/shell-session/local-shell-session/open.injectable.ts
+++ b/packages/core/src/main/shell-session/local-shell-session/open.injectable.ts
@@ -13,6 +13,7 @@ import getBasenameOfPathInjectable from "../../../common/path/get-basename.injec
 import getDirnameOfPathInjectable from "../../../common/path/get-dirname.injectable";
 import joinPathsInjectable from "../../../common/path/join-paths.injectable";
 import appNameInjectable from "../../../common/vars/app-name.injectable";
+import baseBundledBinariesDirectoryInjectable from "../../../common/vars/base-bundled-binaries-dir.injectable";
 import defaultShellInjectable from "../../../common/vars/default-shell.injectable";
 import isMacInjectable from "../../../common/vars/is-mac.injectable";
 import isWindowsInjectable from "../../../common/vars/is-windows.injectable";
@@ -48,6 +49,7 @@ const openLocalShellSessionInjectable = getInjectable({
     const createKubectl = di.inject(createKubectlInjectable);
     const dependencies: Omit<LocalShellSessionDependencies, "proxyKubeconfigPath" | "directoryContainingKubectl"> = {
       directoryForBinaries: di.inject(directoryForBinariesInjectable),
+      baseBundledBinariesDirectory: di.inject(baseBundledBinariesDirectoryInjectable),
       isMac: di.inject(isMacInjectable),
       isWindows: di.inject(isWindowsInjectable),
       defaultShell: di.inject(defaultShellInjectable),


### PR DESCRIPTION
Fixes part of #2061.

The integrated terminal only put the bundled `resources/<arch>` directory (which contains the kubectl shipped with the app) on PATH through the bash and zsh init scripts. PowerShell (the Windows default) and fish were launched with only the downloaded-binaries and user-data directories on PATH, so when the downloaded kubectl directory was empty there was no bundled fallback and `kubectl` was "not recognized".

This appends `baseBundledBinariesDirectory` to the PowerShell and fish PATH so the bundled kubectl resolves the same way it already does for bash/zsh.