### PR TITLE
Fall back to default kubectl download mirror when custom mirror is empty

### DIFF
--- a/packages/core/src/main/kubectl/kubectl.ts
+++ b/packages/core/src/main/kubectl/kubectl.ts
@@ -394,6 +394,11 @@ export class Kubectl {
       if (custom) {
         return custom;
       }
+
+      // The custom mirror is selected but left empty: its entry in
+      // `packageMirrors` has an empty URL, which would otherwise produce a
+      // malformed download URL. Fall back to the default mirror instead.
+      return packageMirrors.get(defaultPackageMirror)!.url;
     }
 
     const { url } =


### PR DESCRIPTION
Fixes part of #2061.

When the Custom download mirror is selected but the custom URL is left blank, `getDownloadMirror()` returned the empty URL from the `custom` `packageMirrors` entry, producing a malformed download URL such as `/v1.35.6/bin/darwin/arm64/kubectl`. It now falls back to the default `dl.k8s.io` mirror in that case.
