### PR TITLE
Restrict build:resources turbo outputs to files it actually produces

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -38,7 +38,7 @@
       "dependsOn": ["^build:resources"],
       "env": ["CC", "CXX", "DOWNLOAD_ALL_ARCHITECTURES", "NODE_ENV"],
       "inputs": ["package.json", "**/logo-lens.svg"],
-      "outputs": ["binaries/**", "static/build/**"]
+      "outputs": ["binaries/**", "static/build/license.txt", "static/build/tray/**"]
     },
     "dev": {
       "dependsOn": ["^build:dev"],


### PR DESCRIPTION
## Problem

The `build:resources` turbo task declares its outputs as `static/build/**`, but its scripts only write `static/build/license.txt` and `static/build/tray/**`:

```jsonc
"build:resources": {
  "inputs": ["package.json", "**/logo-lens.svg"],
  "outputs": ["binaries/**", "static/build/**"],   // too broad
}
```

Because its inputs are only `package.json` and the logo SVG, the task is almost always a cache hit. On a cache hit turbo restores the **entire** `static/build/` directory from the cached snapshot — which silently overwrites the webpack bundles (`freelens.js`, etc.) that the `build` task had just produced into the same directory.

The result, reproducible locally: every `pnpm build` (whose `postbuild` runs `build:resources`) reverts `static/build/freelens.js` to whatever bundle happened to exist when the `build:resources` artifact was last cached. Packaged apps then ship **stale renderer code regardless of the current sources**, with no error — the build reports success.

## Fix

Narrow the declared outputs to exactly what the task writes:

```diff
-      "outputs": ["binaries/**", "static/build/**"]
+      "outputs": ["binaries/**", "static/build/license.txt", "static/build/tray/**"]
```

Now a `build:resources` cache hit only restores its own `license.txt` and tray icons, leaving the webpack bundles untouched.

## Verification

- Confirmed the two `build:resources` scripts (`generate-license` → `static/build/license.txt`, `generate-tray-icons` → `static/build/tray`) write nothing else under `static/build`.
- After the change, repeated `pnpm build` runs keep the freshly built `freelens.js`; before it, the bundle reverted on every cached `build:resources` replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)