### PR TITLE
Show event source and count for events.k8s.io/v1 events

### DIFF
--- a/packages/core/src/renderer/components/events/events.tsx
+++ b/packages/core/src/renderer/components/events/events.tsx
@@ -79,7 +79,7 @@ class NonInjectedEvents extends React.Component<Dependencies & EventsProps> {
     [columnId.namespace]: (event) => event.getNs(),
     [columnId.type]: (event) => event.type,
     [columnId.object]: (event) => event.involvedObject.name,
-    [columnId.count]: (event) => event.count,
+    [columnId.count]: (event) => event.getCount(),
     [columnId.age]: (event) => -event.getCreationTimestamp(),
     [columnId.lastSeen]: (event) => (event.lastTimestamp ? -new Date(event.lastTimestamp).getTime() : 0),
   };
@@ -201,7 +201,7 @@ class NonInjectedEvents extends React.Component<Dependencies & EventsProps> {
               <WithTooltip>{`${involvedObject.kind}: ${involvedObject.name}`}</WithTooltip>
             </Link>,
             <WithTooltip>{event.getSource()}</WithTooltip>,
-            event.count,
+            event.getCount(),
             <KubeObjectAge key="age" object={event} />,
             <WithTooltip tooltip={event.lastTimestamp ? moment(event.lastTimestamp).toDate() : undefined}>
               <ReactiveDuration key="last-seen" timestamp={event.lastTimestamp} />

--- a/packages/core/src/renderer/components/events/kube-event-details.tsx
+++ b/packages/core/src/renderer/components/events/kube-event-details.tsx
@@ -78,7 +78,7 @@ class NonInjectedKubeEventDetails extends React.Component<KubeEventDetailsProps 
               <div className={styles.event} key={event.getId()}>
                 <div className={cssNames(styles.title, { [styles.warning]: event.isWarning() })}>{event.message}</div>
                 <DrawerItem name="Source">{event.getSource()}</DrawerItem>
-                <DrawerItem name="Count">{event.count}</DrawerItem>
+                <DrawerItem name="Count">{event.getCount()}</DrawerItem>
                 <DrawerItem name="Sub-object">{event.involvedObject.fieldPath}</DrawerItem>
                 {event.lastTimestamp && (
                   <DrawerItem name="Last seen">

--- a/packages/kube-object/src/specifics/events.test.ts
+++ b/packages/kube-object/src/specifics/events.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { KubeEvent } from "./events";
+
+import type { KubeEventData } from "./events";
+
+function createEvent(overrides: Partial<KubeEventData> = {}): KubeEvent {
+  return new KubeEvent({
+    apiVersion: "v1",
+    kind: "Event",
+    metadata: {
+      name: "some-event",
+      namespace: "default",
+      resourceVersion: "1",
+      uid: "some-uid",
+      selfLink: "/api/v1/namespaces/default/events/some-event",
+    },
+    involvedObject: {
+      apiVersion: "v1",
+      kind: "Pod",
+      name: "some-pod",
+      namespace: "default",
+      resourceVersion: "1",
+      uid: "some-pod-uid",
+      fieldPath: "",
+    },
+    ...overrides,
+  });
+}
+
+describe("KubeEvent tests", () => {
+  describe("getSource()", () => {
+    it("uses the legacy source.component and source.host when present", () => {
+      const event = createEvent({ source: { component: "kubelet", host: "node-1" } });
+
+      expect(event.getSource()).toBe("kubelet node-1");
+    });
+
+    it("falls back to reportingComponent / reportingInstance for events.k8s.io/v1 events", () => {
+      const event = createEvent({
+        reportingComponent: "my-operator",
+        reportingInstance: "my-operator-abc123",
+      });
+
+      expect(event.getSource()).toBe("my-operator my-operator-abc123");
+    });
+
+    it("falls back to reportingComponent alone when reportingInstance is missing", () => {
+      const event = createEvent({ reportingComponent: "my-operator" });
+
+      expect(event.getSource()).toBe("my-operator");
+    });
+
+    it("prefers the legacy source over reportingComponent when both are present", () => {
+      const event = createEvent({
+        source: { component: "kubelet", host: "node-1" },
+        reportingComponent: "my-operator",
+      });
+
+      expect(event.getSource()).toBe("kubelet node-1");
+    });
+
+    it("returns <unknown> when no source information is available", () => {
+      const event = createEvent();
+
+      expect(event.getSource()).toBe("<unknown>");
+    });
+  });
+
+  describe("getCount()", () => {
+    it("uses the legacy count when present", () => {
+      const event = createEvent({ count: 3 });
+
+      expect(event.getCount()).toBe(3);
+    });
+
+    it("falls back to series.count for events.k8s.io/v1 events", () => {
+      const event = createEvent({ series: { count: 7 } });
+
+      expect(event.getCount()).toBe(7);
+    });
+
+    it("prefers the legacy count over series.count when both are present", () => {
+      const event = createEvent({ count: 3, series: { count: 7 } });
+
+      expect(event.getCount()).toBe(3);
+    });
+
+    it("returns 0 when no count information is available", () => {
+      const event = createEvent();
+
+      expect(event.getCount()).toBe(0);
+    });
+  });
+});

--- a/packages/kube-object/src/specifics/events.ts
+++ b/packages/kube-object/src/specifics/events.ts
@@ -116,13 +116,27 @@ export class KubeEvent extends KubeObject<KubeObjectMetadata<KubeObjectScope.Nam
   }
 
   getSource() {
-    if (!this.source?.component) {
-      return "<unknown>";
+    if (this.source?.component) {
+      const { component, host = "" } = this.source;
+
+      return `${component} ${host}`;
     }
 
-    const { component, host = "" } = this.source;
+    // The events.k8s.io/v1 API leaves the legacy `source` empty and reports the
+    // emitter through `reportingComponent` / `reportingInstance` instead.
+    if (this.reportingComponent) {
+      return `${this.reportingComponent} ${this.reportingInstance ?? ""}`.trimEnd();
+    }
 
-    return `${component} ${host}`;
+    return "<unknown>";
+  }
+
+  /**
+   * The repeat count of the event. The events.k8s.io/v1 API leaves the legacy
+   * `count` empty and reports repeats through `series.count` instead.
+   */
+  getCount() {
+    return this.count ?? this.series?.count ?? 0;
   }
 
   /**


### PR DESCRIPTION
## Problem

Kubernetes has two Event APIs. The newer `events.k8s.io/v1` recorder
(`k8s.io/client-go/tools/events`, e.g. `mgr.GetEventRecorder(...)`) writes the
emitter into `reportingController` / `reportingInstance` and repeat counts into
`series.count`, and deliberately leaves the legacy `deprecatedSource`
(`source.component` / `source.host`) and `deprecatedCount` fields empty. The
core/v1 <-> events.k8s.io conversion only copies the `Deprecated*` fields, so
when these events are read through the core/v1 API those legacy fields stay
empty.

Freelens displays events using the legacy `source` and `count` fields, so any
controller emitting via the modern API shows **Source: `<unknown>`** and a
**blank Count** in the UI. This affects every operator/controller on the
modern events API.

## Fix

In `packages/kube-object/src/specifics/events.ts`:

- `getSource()` now falls back to `reportingComponent` (with
  `reportingInstance` as the host part) when the legacy `source.component` is
  empty, before returning `<unknown>`.
- A new `getCount()` returns `count ?? series?.count ?? 0`, so the repeat count
  is shown for modern-API events.

The events table (`events.tsx`) and details views (`kube-event-details.tsx`)
now use `getCount()` instead of reading `count` directly. Behavior is unchanged
for legacy core/v1 events (whose `source` / `count` are populated by the
API server).

## Tests

Added `packages/kube-object/src/specifics/events.test.ts` covering both getters:
legacy path, modern-API fallback, precedence when both are present, and the
empty/unknown cases.

## How to validate

Run any controller using `k8s.io/client-go/tools/events`; its events
previously showed `Source <unknown>` and a blank Count, and now show the
reporting controller (and instance) plus the series count. Legacy events
(kubelet, scheduler) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)