### PR TITLE
Format node CPU usage in cores instead of bytes in nodes list view

### DIFF
--- a/packages/core/src/renderer/components/nodes/route.tsx
+++ b/packages/core/src/renderer/components/nodes/route.tsx
@@ -120,7 +120,7 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
   getNodeCpuUsage(node: Node) {
     const metrics = this.props.nodeStore.getNodeKubeMetrics(node);
 
-    return bytesToUnitsAligned(metrics.cpu);
+    return Number.isNaN(metrics.cpu) ? "N/A" : metrics.cpu.toFixed(3);
   }
 
   getNodeMemoryUsage(node: Node) {

--- a/packages/core/src/renderer/components/nodes/route.tsx
+++ b/packages/core/src/renderer/components/nodes/route.tsx
@@ -126,7 +126,7 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
   getNodeMemoryUsage(node: Node) {
     const metrics = this.props.nodeStore.getNodeKubeMetrics(node);
 
-    return bytesToUnitsAligned(metrics.memory);
+    return Number.isNaN(metrics.memory) ? "N/A" : bytesToUnitsAligned(metrics.memory);
   }
 
   private renderUsage({ node, title, metricNames, formatters, usageText }: UsageArgs) {


### PR DESCRIPTION
The Nodes list view CPU column rendered the metrics-server CPU value (cores) through a bytes formatter, so any realistic core count displayed as `0.0Ki`. CPU is now formatted in cores with three decimals, matching the pods list CPU column. A second commit shows `N/A` for node memory usage when metrics-server data is missing instead of rendering `NaN`.
