### PR TITLE
Derive command palette navigation entries from the sidebar

### DIFF
--- a/packages/core/src/renderer/components/command-palette/registered-commands/internal-commands.injectable.tsx
+++ b/packages/core/src/renderer/components/command-palette/registered-commands/internal-commands.injectable.tsx
@@ -7,29 +7,6 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import React from "react";
 import navigateToCatalogInjectable from "../../../../common/front-end-routing/routes/catalog/navigate-to-catalog.injectable";
-import navigateToConfigMapsInjectable from "../../../../common/front-end-routing/routes/cluster/config/config-maps/navigate-to-config-maps.injectable";
-import navigateToHorizontalPodAutoscalersInjectable from "../../../../common/front-end-routing/routes/cluster/config/horizontal-pod-autoscalers/navigate-to-horizontal-pod-autoscalers.injectable";
-import navigateToLimitRangesInjectable from "../../../../common/front-end-routing/routes/cluster/config/limit-ranges/navigate-to-limit-ranges.injectable";
-import navigateToPodDisruptionBudgetsInjectable from "../../../../common/front-end-routing/routes/cluster/config/pod-disruption-budgets/navigate-to-pod-disruption-budgets.injectable";
-import navigateToPriorityClassesInjectable from "../../../../common/front-end-routing/routes/cluster/config/priority-classes/navigate-to-priority-classes.injectable";
-import navigateToResourceQuotasInjectable from "../../../../common/front-end-routing/routes/cluster/config/resource-quotas/navigate-to-resource-quotas.injectable";
-import navigateToSecretsInjectable from "../../../../common/front-end-routing/routes/cluster/config/secrets/navigate-to-secrets.injectable";
-import navigateToCustomResourceDefinitionsInjectable from "../../../../common/front-end-routing/routes/cluster/custom-resources/navigate-to-custom-resource-definitions.injectable";
-import navigateToHelmChartsInjectable from "../../../../common/front-end-routing/routes/cluster/helm/charts/navigate-to-helm-charts.injectable";
-import navigateToHelmReleasesInjectable from "../../../../common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable";
-import navigateToEndpointSlicesInjectable from "../../../../common/front-end-routing/routes/cluster/network/endpoint-slices/navigate-to-endpoint-slices.injectable";
-import navigateToEndpointsInjectable from "../../../../common/front-end-routing/routes/cluster/network/endpoints/navigate-to-endpoints.injectable";
-import navigateToIngressesInjectable from "../../../../common/front-end-routing/routes/cluster/network/ingresses/navigate-to-ingresses.injectable";
-import navigateToNetworkPoliciesInjectable from "../../../../common/front-end-routing/routes/cluster/network/network-policies/navigate-to-network-policies.injectable";
-import navigateToPortForwardsInjectable from "../../../../common/front-end-routing/routes/cluster/network/port-forwards/navigate-to-port-forwards.injectable";
-import navigateToServicesInjectable from "../../../../common/front-end-routing/routes/cluster/network/services/navigate-to-services.injectable";
-import navigateToNodesInjectable from "../../../../common/front-end-routing/routes/cluster/nodes/navigate-to-nodes.injectable";
-import navigateToCronJobsInjectable from "../../../../common/front-end-routing/routes/cluster/workloads/cron-jobs/navigate-to-cron-jobs.injectable";
-import navigateToDaemonsetsInjectable from "../../../../common/front-end-routing/routes/cluster/workloads/daemonsets/navigate-to-daemonsets.injectable";
-import navigateToDeploymentsInjectable from "../../../../common/front-end-routing/routes/cluster/workloads/deployments/navigate-to-deployments.injectable";
-import navigateToJobsInjectable from "../../../../common/front-end-routing/routes/cluster/workloads/jobs/navigate-to-jobs.injectable";
-import navigateToPodsInjectable from "../../../../common/front-end-routing/routes/cluster/workloads/pods/navigate-to-pods.injectable";
-import navigateToStatefulsetsInjectable from "../../../../common/front-end-routing/routes/cluster/workloads/statefulsets/navigate-to-statefulsets.injectable";
 import navigateToEntitySettingsInjectable from "../../../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
 // TODO: Importing from features is not OK. Make commands to comply with Open Closed Principle to allow moving implementation under a feature
 import navigateToPreferencesInjectable from "../../../../features/preferences/common/navigate-to-preferences.injectable";
@@ -56,29 +33,6 @@ interface Dependencies {
   createTerminalTab: () => DockTabCreate;
   navigateToPreferences: () => void;
   navigateToCatalog: () => void;
-  navigateToHelmCharts: () => void;
-  navigateToHelmReleases: () => void;
-  navigateToConfigMaps: () => void;
-  navigateToSecrets: () => void;
-  navigateToResourceQuotas: () => void;
-  navigateToLimitRanges: () => void;
-  navigateToHorizontalPodAutoscalers: () => void;
-  navigateToPodDisruptionBudgets: () => void;
-  navigateToPriorityClasses: () => void;
-  navigateToServices: () => void;
-  navigateToEndpoints: () => void;
-  navigateToEndpointSlices: () => void;
-  navigateToIngresses: () => void;
-  navigateToNetworkPolicies: () => void;
-  navigateToPortForwards: () => void;
-  navigateToNodes: () => void;
-  navigateToPods: () => void;
-  navigateToDeployments: () => void;
-  navigateToDaemonsets: () => void;
-  navigateToStatefulsets: () => void;
-  navigateToJobs: () => void;
-  navigateToCronJobs: () => void;
-  navigateToCustomResourceDefinitions: () => void;
   navigateToEntitySettings: (entityId: string) => void;
 }
 
@@ -98,144 +52,6 @@ function getInternalCommands(dependencies: Dependencies): CommandRegistration[] 
       id: "clusters.search",
       title: "Clusters: Search ...",
       action: () => dependencies.openCommandDialog(<ClustersSearchCommand />),
-    },
-    {
-      id: "cluster.viewHelmCharts",
-      title: "Cluster: View Helm Charts",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToHelmCharts(),
-    },
-    {
-      id: "cluster.viewHelmReleases",
-      title: "Cluster: View Helm Releases",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToHelmReleases(),
-    },
-    {
-      id: "cluster.viewConfigMaps",
-      title: "Cluster: View ConfigMaps",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToConfigMaps(),
-    },
-    {
-      id: "cluster.viewSecrets",
-      title: "Cluster: View Secrets",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToSecrets(),
-    },
-    {
-      id: "cluster.viewResourceQuotas",
-      title: "Cluster: View ResourceQuotas",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToResourceQuotas(),
-    },
-    {
-      id: "cluster.viewLimitRanges",
-      title: "Cluster: View LimitRanges",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToLimitRanges(),
-    },
-    {
-      id: "cluster.viewHorizontalPodAutoscalers",
-      title: "Cluster: View HorizontalPodAutoscalers (HPA)",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToHorizontalPodAutoscalers(),
-    },
-    {
-      id: "cluster.viewPodDisruptionBudget",
-      title: "Cluster: View PodDisruptionBudgets",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToPodDisruptionBudgets(),
-    },
-    {
-      id: "cluster.viewPriorityClasses",
-      title: "Cluster: View PriorityClasses",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToPriorityClasses(),
-    },
-    {
-      id: "cluster.viewServices",
-      title: "Cluster: View Services",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToServices(),
-    },
-    {
-      id: "cluster.viewEndpoints",
-      title: "Cluster: View Endpoints",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToEndpoints(),
-    },
-    {
-      id: "cluster.viewEndpointSlices",
-      title: "Cluster: View Endpoint Slices",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToEndpointSlices(),
-    },
-    {
-      id: "cluster.viewIngresses",
-      title: "Cluster: View Ingresses",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToIngresses(),
-    },
-    {
-      id: "cluster.viewNetworkPolicies",
-      title: "Cluster: View NetworkPolicies",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToNetworkPolicies,
-    },
-    {
-      id: "cluster.viewPortForwarding",
-      title: "Cluster: View Port Forwarding",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToPortForwards,
-    },
-    {
-      id: "cluster.viewNodes",
-      title: "Cluster: View Nodes",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToNodes(),
-    },
-    {
-      id: "cluster.viewPods",
-      title: "Cluster: View Pods",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToPods(),
-    },
-    {
-      id: "cluster.viewDeployments",
-      title: "Cluster: View Deployments",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToDeployments(),
-    },
-    {
-      id: "cluster.viewDaemonSets",
-      title: "Cluster: View DaemonSets",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToDaemonsets(),
-    },
-    {
-      id: "cluster.viewStatefulSets",
-      title: "Cluster: View StatefulSets",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToStatefulsets(),
-    },
-    {
-      id: "cluster.viewJobs",
-      title: "Cluster: View Jobs",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToJobs(),
-    },
-    {
-      id: "cluster.viewCronJobs",
-      title: "Cluster: View CronJobs",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToCronJobs(),
-    },
-    {
-      id: "cluster.viewCustomResourceDefinitions",
-      title: "Cluster: View Custom Resource Definitions",
-      isActive: isKubernetesClusterActive,
-      action: () => dependencies.navigateToCustomResourceDefinitions(),
     },
     {
       id: "entity.viewSettings",
@@ -282,29 +98,6 @@ const internalCommandsInjectable = getInjectable({
       createTerminalTab: di.inject(createTerminalTabInjectable),
       navigateToPreferences: di.inject(navigateToPreferencesInjectable),
       navigateToCatalog: di.inject(navigateToCatalogInjectable),
-      navigateToHelmCharts: di.inject(navigateToHelmChartsInjectable),
-      navigateToHelmReleases: di.inject(navigateToHelmReleasesInjectable),
-      navigateToConfigMaps: di.inject(navigateToConfigMapsInjectable),
-      navigateToSecrets: di.inject(navigateToSecretsInjectable),
-      navigateToResourceQuotas: di.inject(navigateToResourceQuotasInjectable),
-      navigateToLimitRanges: di.inject(navigateToLimitRangesInjectable),
-      navigateToHorizontalPodAutoscalers: di.inject(navigateToHorizontalPodAutoscalersInjectable),
-      navigateToPodDisruptionBudgets: di.inject(navigateToPodDisruptionBudgetsInjectable),
-      navigateToPriorityClasses: di.inject(navigateToPriorityClassesInjectable),
-      navigateToServices: di.inject(navigateToServicesInjectable),
-      navigateToEndpoints: di.inject(navigateToEndpointsInjectable),
-      navigateToEndpointSlices: di.inject(navigateToEndpointSlicesInjectable),
-      navigateToIngresses: di.inject(navigateToIngressesInjectable),
-      navigateToNetworkPolicies: di.inject(navigateToNetworkPoliciesInjectable),
-      navigateToPortForwards: di.inject(navigateToPortForwardsInjectable),
-      navigateToNodes: di.inject(navigateToNodesInjectable),
-      navigateToPods: di.inject(navigateToPodsInjectable),
-      navigateToDeployments: di.inject(navigateToDeploymentsInjectable),
-      navigateToDaemonsets: di.inject(navigateToDaemonsetsInjectable),
-      navigateToStatefulsets: di.inject(navigateToStatefulsetsInjectable),
-      navigateToJobs: di.inject(navigateToJobsInjectable),
-      navigateToCronJobs: di.inject(navigateToCronJobsInjectable),
-      navigateToCustomResourceDefinitions: di.inject(navigateToCustomResourceDefinitionsInjectable),
       navigateToEntitySettings: di.inject(navigateToEntitySettingsInjectable),
     }),
 });

--- a/packages/core/src/renderer/components/command-palette/registered-commands/register-injectables.ts
+++ b/packages/core/src/renderer/components/command-palette/registered-commands/register-injectables.ts
@@ -8,6 +8,7 @@
 
 import internalCommandsInjectable from "./internal-commands.injectable";
 import registeredCommandsInjectable from "./registered-commands.injectable";
+import sidebarNavigationCommandsInjectable from "./sidebar-navigation-commands.injectable";
 
 import type { DiContainerForInjection } from "@ogre-tools/injectable";
 
@@ -19,6 +20,11 @@ export function registerInjectables(di: DiContainerForInjection): void {
   }
   try {
     di.register(registeredCommandsInjectable);
+  } catch (e) {
+    /* Ignore duplicate registration */
+  }
+  try {
+    di.register(sidebarNavigationCommandsInjectable);
   } catch (e) {
     /* Ignore duplicate registration */
   }

--- a/packages/core/src/renderer/components/command-palette/registered-commands/registered-commands.injectable.ts
+++ b/packages/core/src/renderer/components/command-palette/registered-commands/registered-commands.injectable.ts
@@ -7,10 +7,8 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
 import rendererExtensionsInjectable from "../../../../extensions/renderer-extensions.injectable";
-import customResourceDefinitionsInjectable from "../../custom-resource-definitions/definitions.injectable";
-import internalCommandsInjectable, { isKubernetesClusterActive } from "./internal-commands.injectable";
-
-import type { CustomResourceDefinition } from "@freelensapp/kube-object";
+import internalCommandsInjectable from "./internal-commands.injectable";
+import sidebarNavigationCommandsInjectable from "./sidebar-navigation-commands.injectable";
 
 import type { IComputedValue } from "mobx";
 
@@ -19,24 +17,17 @@ import type { CommandRegistration, RegisteredCommand } from "./commands";
 
 interface Dependencies {
   extensions: IComputedValue<LensRendererExtension[]>;
-  customResourceDefinitions: IComputedValue<CustomResourceDefinition[]>;
+  sidebarNavigationCommands: IComputedValue<CommandRegistration[]>;
   internalCommands: CommandRegistration[];
 }
 
-const instantiateRegisteredCommands = ({ extensions, customResourceDefinitions, internalCommands }: Dependencies) =>
+const instantiateRegisteredCommands = ({ extensions, sidebarNavigationCommands, internalCommands }: Dependencies) =>
   computed(() => {
     const result = new Map<string, RegisteredCommand>();
     const commands = [
       ...internalCommands,
       ...extensions.get().flatMap((e) => e.commands),
-      ...customResourceDefinitions.get().map(
-        (command): CommandRegistration => ({
-          id: `cluster.view.${command.getResourceKind()}`,
-          title: `Cluster: View ${command.getResourceKind()}`,
-          isActive: isKubernetesClusterActive,
-          action: ({ navigate }) => navigate(command.getResourceUrl()),
-        }),
-      ),
+      ...sidebarNavigationCommands.get(),
     ];
 
     for (const { scope, isActive = () => true, ...command } of commands) {
@@ -56,7 +47,7 @@ const registeredCommandsInjectable = getInjectable({
   instantiate: (di) =>
     instantiateRegisteredCommands({
       extensions: di.inject(rendererExtensionsInjectable),
-      customResourceDefinitions: di.inject(customResourceDefinitionsInjectable),
+      sidebarNavigationCommands: di.inject(sidebarNavigationCommandsInjectable),
       internalCommands: di.inject(internalCommandsInjectable),
     }),
 });

--- a/packages/core/src/renderer/components/command-palette/registered-commands/sidebar-navigation-commands.injectable.ts
+++ b/packages/core/src/renderer/components/command-palette/registered-commands/sidebar-navigation-commands.injectable.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { sidebarItemsInjectable } from "@freelensapp/cluster-sidebar";
+import { getInjectable } from "@ogre-tools/injectable";
+import { computed } from "mobx";
+import { isKubernetesClusterActive } from "./internal-commands.injectable";
+
+import type { SidebarItemDeclaration } from "@freelensapp/cluster-sidebar";
+
+import type { IComputedValue } from "mobx";
+
+import type { CommandRegistration } from "./commands";
+
+// CRD group titles embed zero-width spaces to allow line breaks in the sidebar.
+const stripZeroWidthSpaces = (value: string): string => value.replaceAll("\u200b", "");
+
+/**
+ * Derives one command-palette entry per navigable sidebar leaf item.
+ *
+ * Grouping nodes (items with children, such as "Workloads" or CRD group
+ * headers) are not emitted themselves; their titles form the breadcrumb prefix
+ * for the leaves below them. Items whose title is not a plain string (possible
+ * for extension-provided items) are skipped - those extensions can keep
+ * registering explicit commands instead.
+ */
+const deriveNavigationCommands = (items: SidebarItemDeclaration[], ancestorTitles: string[]): CommandRegistration[] =>
+  items.flatMap((item) => {
+    if (typeof item.title !== "string") {
+      return [];
+    }
+
+    const titles = [...ancestorTitles, stripZeroWidthSpaces(item.title)];
+
+    if (item.children.length > 0) {
+      return deriveNavigationCommands(item.children, titles);
+    }
+
+    return [
+      {
+        id: `navigation.${item.id}`,
+        title: titles.join(": "),
+        isActive: (context) => isKubernetesClusterActive(context) && item.isVisible.get(),
+        action: () => item.onClick(),
+      } satisfies CommandRegistration,
+    ];
+  });
+
+const sidebarNavigationCommandsInjectable = getInjectable({
+  id: "sidebar-navigation-commands",
+
+  instantiate: (di): IComputedValue<CommandRegistration[]> => {
+    const sidebarItems = di.inject(sidebarItemsInjectable);
+
+    return computed(() => deriveNavigationCommands(sidebarItems.get(), []));
+  },
+});
+
+export default sidebarNavigationCommandsInjectable;

--- a/packages/core/src/renderer/components/command-palette/registered-commands/sidebar-navigation-commands.test.tsx
+++ b/packages/core/src/renderer/components/command-palette/registered-commands/sidebar-navigation-commands.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
+import { noop } from "@freelensapp/utilities";
+import { getInjectable } from "@ogre-tools/injectable";
+import { computed, runInAction } from "mobx";
+import React from "react";
+import { getApplicationBuilder } from "../../test-utils/get-application-builder";
+import sidebarNavigationCommandsInjectable from "./sidebar-navigation-commands.injectable";
+
+import type { DiContainer } from "@ogre-tools/injectable";
+
+import type { CommandContext } from "./commands";
+
+const clusterContext = { entity: { kind: "KubernetesCluster" } } as CommandContext;
+const nonClusterContext = { entity: { kind: "SomethingElse" } } as CommandContext;
+
+const testGroupSidebarItemInjectable = getInjectable({
+  id: "sidebar-item-test-group",
+  instantiate: () => ({
+    parentId: null,
+    title: "Test Group",
+    onClick: noop,
+    orderNumber: 1000,
+  }),
+  injectionToken: sidebarItemInjectionToken,
+});
+
+const visibleLeafSidebarItemInjectable = getInjectable({
+  id: "sidebar-item-test-visible-leaf",
+  instantiate: () => ({
+    parentId: testGroupSidebarItemInjectable.id,
+    title: "Visible Leaf",
+    onClick: noop,
+    isVisible: computed(() => true),
+    orderNumber: 1,
+  }),
+  injectionToken: sidebarItemInjectionToken,
+});
+
+const hiddenLeafSidebarItemInjectable = getInjectable({
+  id: "sidebar-item-test-hidden-leaf",
+  instantiate: () => ({
+    parentId: testGroupSidebarItemInjectable.id,
+    title: "Hidden Leaf",
+    onClick: noop,
+    isVisible: computed(() => false),
+    orderNumber: 2,
+  }),
+  injectionToken: sidebarItemInjectionToken,
+});
+
+const nonStringTitleSidebarItemInjectable = getInjectable({
+  id: "sidebar-item-test-non-string-title",
+  instantiate: () => ({
+    parentId: null,
+    title: React.createElement("span", null, "Not a string"),
+    onClick: noop,
+    orderNumber: 1001,
+  }),
+  injectionToken: sidebarItemInjectionToken,
+});
+
+const zeroWidthTitleSidebarItemInjectable = getInjectable({
+  id: "sidebar-item-test-zero-width",
+  instantiate: () => ({
+    parentId: null,
+    title: "source\u200b.toolkit\u200b.fluxcd\u200b.io",
+    onClick: noop,
+    orderNumber: 1002,
+  }),
+  injectionToken: sidebarItemInjectionToken,
+});
+
+describe("command-palette - navigation commands derived from the sidebar", () => {
+  let windowDi: DiContainer;
+
+  beforeEach(async () => {
+    const builder = getApplicationBuilder();
+
+    builder.setEnvironmentToClusterFrame();
+
+    builder.beforeWindowStart(({ windowDi: di }) => {
+      runInAction(() => {
+        di.register(testGroupSidebarItemInjectable);
+        di.register(visibleLeafSidebarItemInjectable);
+        di.register(hiddenLeafSidebarItemInjectable);
+        di.register(nonStringTitleSidebarItemInjectable);
+        di.register(zeroWidthTitleSidebarItemInjectable);
+      });
+    });
+
+    await builder.render();
+
+    windowDi = builder.applicationWindow.only.di;
+  });
+
+  const getCommands = () => windowDi.inject(sidebarNavigationCommandsInjectable).get();
+
+  it("emits a command for a navigable leaf item with a breadcrumb title", () => {
+    const command = getCommands().find((c) => c.id === "navigation.sidebar-item-test-visible-leaf");
+
+    expect(command?.title).toBe("Test Group: Visible Leaf");
+  });
+
+  it("does not emit a command for a grouping node with children", () => {
+    const command = getCommands().find((c) => c.id === "navigation.sidebar-item-test-group");
+
+    expect(command).toBeUndefined();
+  });
+
+  it("skips items whose title is not a plain string", () => {
+    const command = getCommands().find((c) => c.id === "navigation.sidebar-item-test-non-string-title");
+
+    expect(command).toBeUndefined();
+  });
+
+  it("strips zero-width spaces from titles", () => {
+    const command = getCommands().find((c) => c.id === "navigation.sidebar-item-test-zero-width");
+
+    expect(command?.title).toBe("source.toolkit.fluxcd.io");
+  });
+
+  it("is active only within an active cluster when the sidebar item is visible", () => {
+    const command = getCommands().find((c) => c.id === "navigation.sidebar-item-test-visible-leaf");
+
+    expect(command?.isActive?.(clusterContext)).toBe(true);
+    expect(command?.isActive?.(nonClusterContext)).toBe(false);
+  });
+
+  it("is not active when the sidebar item is not visible", () => {
+    const command = getCommands().find((c) => c.id === "navigation.sidebar-item-test-hidden-leaf");
+
+    expect(command?.isActive?.(clusterContext)).toBe(false);
+  });
+});


### PR DESCRIPTION
Derives command palette navigation entries from the cluster sidebar registry instead of a hand-maintained list, covering all missing sidebar pages and fixing the broken Port Forwarding / Network Policies entries.

Fixes #1782. Relates to #1402.

| Model: `claude-opus-4-8`