### PR TITLE
Do not persist show-previous-container log setting as a global default

### DIFF
--- a/packages/core/src/common/__tests__/user-store.test.ts
+++ b/packages/core/src/common/__tests__/user-store.test.ts
@@ -112,20 +112,18 @@ describe("user store tests", () => {
 
       expect(state.logViewerPreferences).toEqual({
         showTimestamps: true,
-        showPrevious: false,
         showWordWrap: false,
       });
 
       state.logViewerPreferences = {
-        showTimestamps: false,
-        showPrevious: true,
+        showTimestamps: true,
         showWordWrap: false,
       };
 
       expect(readJsonSync("/some-directory-for-user-data/lens-user-store.json")).toMatchObject({
         preferences: {
           logViewerPreferences: {
-            showPrevious: true,
+            showTimestamps: true,
             showWordWrap: false,
           },
         },
@@ -133,7 +131,6 @@ describe("user store tests", () => {
 
       state.logViewerPreferences = {
         showTimestamps: false,
-        showPrevious: false,
         showWordWrap: true,
       };
 

--- a/packages/core/src/features/user-preferences/common/preferences-helpers.ts
+++ b/packages/core/src/features/user-preferences/common/preferences-helpers.ts
@@ -22,13 +22,11 @@ export interface TerminalConfig {
 
 export interface LogViewerPreferences {
   showTimestamps: boolean;
-  showPrevious: boolean;
   showWordWrap: boolean;
 }
 
 export const defaultLogViewerPreferences: LogViewerPreferences = {
   showTimestamps: false,
-  showPrevious: false,
   showWordWrap: true,
 };
 

--- a/packages/core/src/renderer/components/dock/logs/__test__/controls.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/controls.test.tsx
@@ -21,22 +21,22 @@ import {
 
 import type { UserEvent } from "@testing-library/user-event";
 
-import type { LogViewerPreferences } from "../../../../../features/user-preferences/common/preferences-helpers";
 import type { UserPreferencesState } from "../../../../../features/user-preferences/common/state.injectable";
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { TabId } from "../../dock/store";
 import type { LogTabViewModelDependencies } from "../logs-view-model";
+import type { LogTabData } from "../tab-store";
 
 function getOnePodViewModel(
   tabId: TabId,
   userPreferencesState: UserPreferencesState,
-  logViewerPreferences: LogViewerPreferences,
+  logTabData: Partial<LogTabData>,
   deps: Partial<LogTabViewModelDependencies> = {},
 ): LogTabViewModel {
   const selectedPod = dockerPod;
 
   return createMockLogTabViewModel(tabId, userPreferencesState, {
-    getLogTabData: () => getDefaultOnePodLogTabData(logViewerPreferences),
+    getLogTabData: () => getDefaultOnePodLogTabData(logTabData),
     getPodById: (id) => {
       if (id === selectedPod.getId()) {
         return selectedPod;
@@ -75,7 +75,6 @@ describe("LogControls", () => {
 
     expect(userPreferencesState.logViewerPreferences).toEqual({
       showTimestamps: true,
-      showPrevious: false,
       showWordWrap: true,
     });
   });
@@ -87,21 +86,31 @@ describe("LogControls", () => {
 
     expect(userPreferencesState.logViewerPreferences).toEqual({
       showTimestamps: false,
-      showPrevious: false,
       showWordWrap: false,
     });
   });
 
-  it("updates the saved previous-container preference before reloading logs", async () => {
+  it("updates only the tab data (not the saved preference) before reloading logs", async () => {
+    const setLogTabData = jest.fn();
+
+    model = getOnePodViewModel(
+      "foobar",
+      userPreferencesState,
+      { showTimestamps: false, showPrevious: false, showWordWrap: true },
+      { setLogTabData },
+    );
+
     const reloadLogsSpy = jest.spyOn(model, "reloadLogs");
 
     render(<LogControls model={model} />);
 
     await user.click(await screen.findByText("Show previous terminated container"));
 
+    expect(setLogTabData).toHaveBeenCalledWith("foobar", expect.objectContaining({ showPrevious: true }));
+
+    // The previous-container choice must not be persisted as a global default.
     expect(userPreferencesState.logViewerPreferences).toEqual({
       showTimestamps: false,
-      showPrevious: true,
       showWordWrap: true,
     });
     expect(reloadLogsSpy).toHaveBeenCalledTimes(1);

--- a/packages/core/src/renderer/components/dock/logs/__test__/create-logs-tab.injectable.test.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/create-logs-tab.injectable.test.ts
@@ -28,7 +28,6 @@ describe("create logs tab", () => {
   it("uses global log viewer preferences as the default tab state", () => {
     userPreferencesState.logViewerPreferences = {
       showTimestamps: true,
-      showPrevious: true,
       showWordWrap: false,
     };
 
@@ -45,8 +44,26 @@ describe("create logs tab", () => {
       selectedPodId: "pod-1",
       selectedContainer: "container-1",
       showTimestamps: true,
-      showPrevious: true,
       showWordWrap: false,
+    });
+  });
+
+  it("defaults showPrevious to false for a new tab regardless of the previously viewed pod", () => {
+    userPreferencesState.logViewerPreferences = {
+      showTimestamps: true,
+      showWordWrap: false,
+    };
+
+    const createLogsTab = di.inject(createLogsTabInjectable);
+    const getLogTabData = di.inject(getLogTabDataInjectable);
+    const tabId = createLogsTab("Pod some-pod", {
+      namespace: "default",
+      selectedPodId: "pod-1",
+      selectedContainer: "container-1",
+    });
+
+    expect(getLogTabData(tabId)).toMatchObject({
+      showPrevious: false,
     });
   });
 });

--- a/packages/core/src/renderer/components/dock/logs/__test__/logs-view-model.test.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/logs-view-model.test.ts
@@ -30,7 +30,6 @@ describe("LogTabViewModel", () => {
 
     expect(userPreferencesState.logViewerPreferences).toEqual({
       showTimestamps: true,
-      showPrevious: false,
       showWordWrap: true,
     });
     expect(setLogTabData).toHaveBeenCalledWith("tab-id", {

--- a/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
@@ -23,6 +23,7 @@ export function getDefaultOnePodLogTabData(overrides: Partial<LogTabData> = {}):
     selectedPodId: dockerPod.getId(),
     selectedContainer: dockerPod.getContainers()[0].name,
     namespace: dockerPod.getNs(),
+    showPrevious: false,
     ...defaultLogViewerPreferences,
     ...overrides,
   };

--- a/packages/core/src/renderer/components/dock/logs/controls.tsx
+++ b/packages/core/src/renderer/components/dock/logs/controls.tsx
@@ -33,7 +33,8 @@ export const LogControls = observer(({ model }: LogControlsProps) => {
   };
 
   const togglePrevious = () => {
-    model.updateLogPreferences({ showPrevious: !previous });
+    // Keep this choice per-tab; it should not become a persisted global default.
+    model.updateLogTabData({ showPrevious: !previous });
     model.reloadLogs();
   };
 

--- a/packages/core/src/renderer/components/dock/logs/create-logs-tab.injectable.ts
+++ b/packages/core/src/renderer/components/dock/logs/create-logs-tab.injectable.ts
@@ -42,8 +42,14 @@ const createLogsTab =
         false,
       );
       // Apply saved log preferences first so explicit tab data can override them.
+      // `showPrevious` is intentionally not persisted: it is specific to a single
+      // pod (whether a container has restarted) and must default to false for every
+      // new tab rather than leaking from a previously viewed pod. It is forced to
+      // false after the preferences spread so a stale persisted value (from an
+      // upgraded store) cannot leak back in, while explicit tab data can still set it.
       setLogTabData(id, {
         ...(userPreferencesState.logViewerPreferences ?? defaultLogViewerPreferences),
+        showPrevious: false,
         ...data,
       });
     });


### PR DESCRIPTION
Fixes #2095

The "Show previous terminated container" checkbox wrote its state into the persisted global `logViewerPreferences`, so once toggled for one pod every new pod log tab inherited `showPrevious: true`. This setting is specific to a single pod and now defaults to false for every new tab.

- Removed `showPrevious` from the persisted `LogViewerPreferences`
- New tabs force `showPrevious: false` (guarding against stale persisted values)
- The checkbox updates per-tab data only, not the global preference

Generated with [Claude Code](https://claude.ai/code)
