### PR TITLE
Reduce turbo concurrency on Windows to avoid STATUS_DLL_INIT_FAILED

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -222,7 +222,20 @@ jobs:
         run: pnpx playwright install-deps
 
       - name: Build packages
+        if: runner.os != 'Windows'
         run: pnpm --color=always --stream build
+
+      # STATUS_DLL_INIT_FAILED (0xC0000142) intermittently crashes turbo's
+      # child build processes on the GitHub-hosted Windows runners when the
+      # build fans out across all packages at once (see issue #105). Cap
+      # turbo's concurrency on Windows to lower the parallelism and memory
+      # pressure that trigger the crash; other platforms keep turbo's default.
+      - name: Build packages (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: pnpm --color=always --stream build
+        env:
+          TURBO_CONCURRENCY: "2"
 
       - name: Build extra resources
         id: build-resources

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -204,7 +204,20 @@ jobs:
           curl -sSfL https://www.electronjs.org/headers/v$electron_version/node-v$electron_version-headers.tar.gz -o $ELECTRON_HEADERS_CACHE/node-v$electron_version-headers.tar.gz
 
       - name: Build packages
+        if: runner.os != 'Windows'
         run: pnpm --color=always --stream build
+
+      # STATUS_DLL_INIT_FAILED (0xC0000142) intermittently crashes turbo's
+      # child build processes on the GitHub-hosted Windows runners when the
+      # build fans out across all packages at once (see issue #105). Cap
+      # turbo's concurrency on Windows to lower the parallelism and memory
+      # pressure that trigger the crash; other platforms keep turbo's default.
+      - name: Build packages (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: pnpm --color=always --stream build
+        env:
+          TURBO_CONCURRENCY: "2"
 
       - name: Rebuild native packages for Electron
         run: pnpm --color=always electron-rebuild -a ${{ matrix.arch }}


### PR DESCRIPTION
Backports https://github.com/freelensapp/freelens-nightly-builds/pull/106

Splits the Build packages step so the Windows legs run turbo with TURBO_CONCURRENCY=2, reducing the fan-out that intermittently triggers the transient 0xC0000142 (STATUS_DLL_INIT_FAILED) crash on the GitHub-hosted Windows runners.
 