### PR TITLE
Phase 3: ESM flip (WIP)

### DIFF
--- a/freelens/electron.vite.config.ts
+++ b/freelens/electron.vite.config.ts
@@ -9,6 +9,12 @@
 // electron-vite. It is intentionally incomplete: TODOs below mark the gaps that
 // still need local iteration against a real Electron run (the "packaged app that
 // boots" bar from Phase 1 cannot be verified on a headless CI runner).
+//
+// Phase 3 (WIP) — ESM flip (D2/D3): the main process output is switched from CJS
+// to ESM here. The matching `"type": "module"` flip across freelens and the
+// workspace packages is codemodded by scripts/v2-phase-3-esm-flip.mjs; the
+// extension loader's require()->import() move and Monaco module workers are
+// tracked as TODOs below (behaviour-bearing, not headless-verifiable).
 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -28,7 +34,11 @@ export default defineConfig({
       outDir: buildDir,
       minify: false, // matches optimization.minimize: false
       sourcemap: true,
-      lib: { entry: resolve(root, "src/main/index.ts"), formats: ["cjs"] }, // ESM flip is Phase 3 (D2)
+      // D2/D3 (Phase 3): ESM main output. Requires `"type": "module"` in
+      // freelens/package.json (see scripts/v2-phase-3-esm-flip.mjs) so the
+      // emitted `main.js` is loaded as ESM; otherwise electron-vite writes an
+      // `.mjs` and the package `main` field must point at it. Verify locally.
+      lib: { entry: resolve(root, "src/main/index.ts"), formats: ["es"] },
     },
   },
   renderer: {

--- a/freelens/package.json
+++ b/freelens/package.json
@@ -13,6 +13,7 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"

--- a/packages/business-features/keyboard-shortcuts/package.json
+++ b/packages/business-features/keyboard-shortcuts/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/cluster-settings/package.json
+++ b/packages/cluster-settings/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/cluster-sidebar/package.json
+++ b/packages/cluster-sidebar/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"

--- a/packages/ensure-binaries/package.json
+++ b/packages/ensure-binaries/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -11,6 +11,7 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"

--- a/packages/infrastructure/jest/package.json
+++ b/packages/infrastructure/jest/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "index.js",
   "scripts": {
     "clean:node_modules": "pnpm dlx rimraf@6.1.3 node_modules"

--- a/packages/infrastructure/typescript/package.json
+++ b/packages/infrastructure/typescript/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "scripts": {
     "clean:node_modules": "pnpm dlx rimraf@6.1.3 node_modules"
   },

--- a/packages/infrastructure/webpack/package.json
+++ b/packages/infrastructure/webpack/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "dist/index.js",
   "bin": {
     "lens-webpack-build": "bin/webpack-build"

--- a/packages/kube-object/package.json
+++ b/packages/kube-object/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/kubectl-versions/package.json
+++ b/packages/kubectl-versions/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"

--- a/packages/legacy-global-di/package.json
+++ b/packages/legacy-global-di/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/list-layout/package.json
+++ b/packages/list-layout/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/packages/resource-templates/package.json
+++ b/packages/resource-templates/package.json
@@ -11,6 +11,7 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/application/application-for-electron-main/package.json
+++ b/packages/technical-features/application/application-for-electron-main/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/application/application/package.json
+++ b/packages/technical-features/application/application/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/application/legacy-extensions/package.json
+++ b/packages/technical-features/application/legacy-extensions/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/feature-core/package.json
+++ b/packages/technical-features/feature-core/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/messaging/computed-channel/package.json
+++ b/packages/technical-features/messaging/computed-channel/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/messaging/messaging-fake-bridge/package.json
+++ b/packages/technical-features/messaging/messaging-fake-bridge/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/messaging/messaging-for-main/package.json
+++ b/packages/technical-features/messaging/messaging-for-main/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/messaging/messaging-for-renderer/package.json
+++ b/packages/technical-features/messaging/messaging-for-renderer/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/messaging/messaging/package.json
+++ b/packages/technical-features/messaging/messaging/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/prometheus/package.json
+++ b/packages/technical-features/prometheus/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/technical-features/react-application/package.json
+++ b/packages/technical-features/react-application/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/transpilation/openid-client/package.json
+++ b/packages/transpilation/openid-client/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"

--- a/packages/ui-components/animate/package.json
+++ b/packages/ui-components/animate/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "exports": {
     ".": "./src/index.ts",
     "./styles": "./src/animate.scss"

--- a/packages/ui-components/button/package.json
+++ b/packages/ui-components/button/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "exports": {
     ".": "./src/index.ts",
     "./styles": "./src/button.scss"

--- a/packages/ui-components/error-boundary/package.json
+++ b/packages/ui-components/error-boundary/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "exports": {
     ".": "./src/index.ts",
     "./styles": "./src/error-boundary.scss"

--- a/packages/ui-components/icon/package.json
+++ b/packages/ui-components/icon/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "exports": {
     ".": "./src/index.ts",
     "./styles": "./src/icon.scss",

--- a/packages/ui-components/notifications/package.json
+++ b/packages/ui-components/notifications/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "exports": {
     ".": "./src/index.ts",
     "./styles": "./src/notifications.scss"

--- a/packages/ui-components/resizing-anchor/package.json
+++ b/packages/ui-components/resizing-anchor/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "exports": {
     ".": "./src/index.ts",
     "./styles": "./src/resizing-anchor.scss"

--- a/packages/ui-components/spinner/package.json
+++ b/packages/ui-components/spinner/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "exports": {
     ".": "./src/index.ts",
     "./styles": "./src/spinner.scss"

--- a/packages/ui-components/tooltip/package.json
+++ b/packages/ui-components/tooltip/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "exports": {
     ".": "./src/index.ts",
     "./styles": "./src/tooltip.scss"

--- a/packages/utility-features/event-emitter/package.json
+++ b/packages/utility-features/event-emitter/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/utility-features/json-api/package.json
+++ b/packages/utility-features/json-api/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/utility-features/kube-api-specifics/package.json
+++ b/packages/utility-features/kube-api-specifics/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/utility-features/kube-api/package.json
+++ b/packages/utility-features/kube-api/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/utility-features/react-testing-library-discovery/package.json
+++ b/packages/utility-features/react-testing-library-discovery/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/utility-features/run-many/package.json
+++ b/packages/utility-features/run-many/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/utility-features/startable-stoppable/package.json
+++ b/packages/utility-features/startable-stoppable/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/utility-features/test-utils/package.json
+++ b/packages/utility-features/test-utils/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/utility-features/utilities/package.json
+++ b/packages/utility-features/utilities/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/freelensapp/freelens.git"
   },
   "license": "MIT",
+  "type": "module",
   "author": {
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "type": "commonjs",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/scripts/v2-phase-3-esm-flip.mjs
+++ b/scripts/v2-phase-3-esm-flip.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Freelens v2 — Phase 3 codemod: ESM flip (plan D2/D3).
+//
+// Sets `"type": "module"` on the application manifest (freelens/package.json)
+// and on every `@freelensapp/*` workspace package under packages/, so the whole
+// workspace ships as ES modules. Any explicit `"type": "commonjs"` is replaced.
+//
+// The `"type"` key is inserted right after `"license"` when present (matching
+// the field order the repo already uses), otherwise appended.
+//
+// The script is idempotent and prints a dry-run report by default. Pass
+// `--write` to apply the changes.
+//
+// NOT done here (behaviour-bearing, needs a real Electron run — Phase 3's bar is
+// still "an app that boots", which a headless CI runner cannot verify):
+//
+//   - freelens/electron.vite.config.ts main output is flipped to ESM separately
+//     (formats: ["es"]).
+//   - extension-loader.ts must move from `require(path)` to
+//     `await import(pathToFileURL(path))` (D2) — a sync->async change that
+//     ripples through loadUserExtensions(); left for local iteration.
+//   - Monaco json+yaml module workers via MonacoEnvironment.getWorker (D11).
+//   - The coexisting webpack build and its CommonJS `.js`/ts-node configs break
+//     under `"type": "module"`; they are deleted in Phase 5. This is why the
+//     flip lands on `v2` where CI red is allowed (D9), not on `main`.
+//
+// Usage:
+//   node scripts/v2-phase-3-esm-flip.mjs            # dry run
+//   node scripts/v2-phase-3-esm-flip.mjs --write     # apply
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const write = process.argv.includes("--write");
+
+/** Recursively collect package.json paths under a dir, skipping node_modules and dist. */
+function findPackageJsons(dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      findPackageJsons(full, acc);
+    } else if (entry.name === "package.json") {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/** Set pkg.type to "module", inserting after "license" to keep the repo's field order. */
+function setTypeModule(pkg) {
+  if (pkg.type === "module") return pkg;
+
+  const rebuilt = {};
+  let inserted = false;
+  for (const [key, value] of Object.entries(pkg)) {
+    if (key === "type") continue; // drop an existing "commonjs"; re-added below
+    rebuilt[key] = value;
+    if (key === "license") {
+      rebuilt.type = "module";
+      inserted = true;
+    }
+  }
+  if (!inserted) rebuilt.type = "module";
+  return rebuilt;
+}
+
+const targets = [join(repoRoot, "freelens", "package.json"), ...findPackageJsons(join(repoRoot, "packages"))];
+
+const changed = [];
+
+for (const pkgPath of targets) {
+  const raw = readFileSync(pkgPath, "utf8");
+  const pkg = JSON.parse(raw);
+
+  if (pkg.type === "module") continue;
+
+  const rebuilt = setTypeModule(pkg);
+  changed.push(relative(repoRoot, pkgPath));
+  if (write) writeFileSync(pkgPath, `${JSON.stringify(rebuilt, null, 2)}\n`);
+}
+
+const mode = write ? "applied" : "dry run (pass --write to apply)";
+console.log(`Phase 3 ESM-flip codemod — ${mode}`);
+console.log(`${changed.length} package(s) ${write ? "updated" : "would change"}:`);
+for (const p of changed) console.log(`  ${p}`);


### PR DESCRIPTION
Phase 3 of the v2 plan (D2/D3): flip the workspace to ES modules.

Adds a scripted, idempotent codemod (`scripts/v2-phase-3-esm-flip.mjs`) that sets `"type": "module"` on `freelens/package.json` and every workspace package (applied to 48 manifests), and switches the electron-vite main output to ESM (`formats: ["es"]`).

WIP (CI red allowed on v2 per D9). Left for local iteration: extension-loader require()->import(), Monaco module workers, and deleting the coexisting webpack build (Phase 5).

Builds on #2103, #2104, #2105.

Generated with [Claude Code](https://claude.ai/code)