### PR TITLE
Phase 4: extension API runtime global (WIP)

### DIFF
--- a/freelens/src/freelens-extension-api.ts
+++ b/freelens/src/freelens-extension-api.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+// Phase 4 (D5): ambient type for the extension API runtime global assigned by
+// the main and renderer entrypoints (`globalThis.FreelensExtensionApi`).
+// `Main` is present only in the main process, `Renderer` only in the renderer;
+// `Common` is present in both. This module is picked up by the freelens
+// tsconfig `include` so the declaration applies across both entrypoints without
+// a `.d.ts` (which the repo `.gitignore` treats as a build artifact).
+
+import type { commonExtensionApi, mainExtensionApi } from "@freelensapp/core/main";
+import type { rendererExtensionApi } from "@freelensapp/core/renderer";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var FreelensExtensionApi: {
+    Common: typeof commonExtensionApi;
+    Main?: typeof mainExtensionApi;
+    Renderer?: typeof rendererExtensionApi;
+  };
+}
+
+export {};

--- a/freelens/src/main/index.ts
+++ b/freelens/src/main/index.ts
@@ -51,6 +51,12 @@ export {
   Pty,
 } from "@freelensapp/core/main";
 
+// Phase 4 (D5): expose the extension API through a runtime global so the
+// published `@freelensapp/extensions` shim can re-export it in each process.
+// Main gets `{ Common, Main }`; the renderer gets `{ Common, Renderer }`.
+// The global's ambient type lives in `../freelens-extension-api.ts`.
+globalThis.FreelensExtensionApi = { Common, Main };
+
 export const LensExtensions = {
   Main,
   Common,

--- a/freelens/src/renderer/index.ts
+++ b/freelens/src/renderer/index.ts
@@ -79,6 +79,12 @@ export {
   ReactRouterDom,
 } from "@freelensapp/core/renderer";
 
+// Phase 4 (D5): expose the extension API through a runtime global so the
+// published `@freelensapp/extensions` shim can re-export it in each process.
+// The renderer gets `{ Common, Renderer }`; main gets `{ Common, Main }`.
+// The global's ambient type lives in `../freelens-extension-api.ts`.
+globalThis.FreelensExtensionApi = { Common, Renderer };
+
 export const LensExtensions = {
   Renderer,
   Common,

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -16,16 +16,13 @@
     "name": "Freelens Authors",
     "email": "freelens@freelens.app"
   },
-  "main": "dist/extension-api.js",
-  "types": "dist/extension-api.d.ts",
+  "main": "./src/extension-api.ts",
+  "types": "./src/extension-api.ts",
   "files": [
-    "dist/**/*.ts",
-    "__mocks__/*.ts",
-    "dist/**/*.js"
+    "src/**/*.ts",
+    "__mocks__/*.ts"
   ],
   "scripts": {
-    "build": "webpack --config webpack/extensions.ts",
-    "build:dev": "webpack --config webpack/extensions.ts",
     "clean": "pnpm dlx rimraf@6.1.3 dist",
     "clean:node_modules": "pnpm dlx rimraf@6.1.3 node_modules"
   },

--- a/packages/extensions/src/extension-api.ts
+++ b/packages/extensions/src/extension-api.ts
@@ -4,5 +4,37 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-export { commonExtensionApi as Common, mainExtensionApi as Main } from "@freelensapp/core/main";
-export { rendererExtensionApi as Renderer } from "@freelensapp/core/renderer";
+// Phase 4 (D5): `@freelensapp/extensions` is a thin runtime shim over the
+// extension API. The app assigns the API object to a global at startup
+// (`globalThis.FreelensExtensionApi`, see `freelens/src/{main,renderer}/index.ts`).
+// Extensions depend on this package for types; at runtime the members resolve
+// to the global regardless of whether an extension bundles this shim or marks
+// it external.
+//
+// The type-only imports below give extension authors the full API surface for
+// every process. At runtime `Main` is undefined in the renderer and `Renderer`
+// is undefined in the main process; extensions only touch the namespace for the
+// process they run in.
+//
+// TODO(D5): the published package ships a rolled-up, self-contained `.d.ts`
+// (e.g. `rollup-plugin-dts`) with no `@freelensapp/*` imports, since internal
+// packages become `private` in Phase 5. That declaration emit is the fiddliest
+// deliverable of this phase (see plan §6) and needs local iteration.
+
+import type { commonExtensionApi, mainExtensionApi } from "@freelensapp/core/main";
+import type { rendererExtensionApi } from "@freelensapp/core/renderer";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var FreelensExtensionApi: {
+    Common: typeof commonExtensionApi;
+    Main?: typeof mainExtensionApi;
+    Renderer?: typeof rendererExtensionApi;
+  };
+}
+
+const api = globalThis.FreelensExtensionApi;
+
+export const Common = api.Common;
+export const Main = api.Main as typeof mainExtensionApi;
+export const Renderer = api.Renderer as typeof rendererExtensionApi;


### PR DESCRIPTION
Phase 4 of the v2 plan (D5): expose the extension API through a runtime global and turn `@freelensapp/extensions` into a thin shim over it.

- `freelens/src/{main,renderer}/index.ts` assign `globalThis.FreelensExtensionApi` (`{ Common, Main }` in main, `{ Common, Renderer }` in the renderer).
- `freelens/src/freelens-extension-api.ts` declares the ambient global type.
- `packages/extensions/src/extension-api.ts` re-exports the global; type-only imports keep the full API surface for extension authors.
- `packages/extensions/package.json` points main/types at the source shim and drops the webpack build (D3).

WIP (CI red allowed on v2 per D9). Left for local iteration: the rolled-up self-contained .d.ts for the published package, porting freelens-example-extension, the migration guide, and the Phase 5 private-flip/webpack deletion.

Builds on #2103, #2104, #2105, #2106.

Generated with [Claude Code](https://claude.ai/code)