### PR TITLE
Phase 5: flip internal packages to private (WIP)

### DIFF
--- a/packages/business-features/keyboard-shortcuts/package.json
+++ b/packages/business-features/keyboard-shortcuts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/keyboard-shortcuts",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Keyboard shortcuts for Freelens",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/cluster-settings/package.json
+++ b/packages/cluster-settings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/cluster-settings",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Injection token exporter for cluster settings configuration",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/cluster-sidebar/package.json
+++ b/packages/cluster-sidebar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/cluster-sidebar",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Injection tokens for adding new sidebar items within the Cluster View",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@freelensapp/core",
   "version": "1.10.4-0",
+  "private": true,
   "description": "Freelens Core",
   "keywords": [],
   "homepage": "https://freelens.app",

--- a/packages/ensure-binaries/package.json
+++ b/packages/ensure-binaries/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/ensure-binaries",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "CLI for downloading configured versions of the bundled versions of CLIs",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/generate-license/package.json
+++ b/packages/generate-license/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/generate-license",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "CLI for generating license files",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/generate-tray-icons/package.json
+++ b/packages/generate-tray-icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/generate-tray-icons",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "CLI generating tray icons for building a lens-like application",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/infrastructure/jest/package.json
+++ b/packages/infrastructure/jest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/jest",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Jest configuration and scripts for Freelens packages.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/infrastructure/typescript/package.json
+++ b/packages/infrastructure/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/typescript",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Typescript configuration for Freelens packages.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/infrastructure/webpack/package.json
+++ b/packages/infrastructure/webpack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/webpack",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Webpack configurations and scripts for Lens packages.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/kube-object/package.json
+++ b/packages/kube-object/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/kube-object",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Injection tokens for list layout",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/kubectl-versions/package.json
+++ b/packages/kubectl-versions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/kubectl-versions",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Package of kubectl versions at build time",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/legacy-global-di/package.json
+++ b/packages/legacy-global-di/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/legacy-global-di",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Injection tokens for implementing metrics for Freelens",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/list-layout/package.json
+++ b/packages/list-layout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/list-layout",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Injection tokens for list layout",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/logger",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable logger in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/metrics",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Injection tokens for implementing metrics for Freelens",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/random",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable random in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/resource-templates/package.json
+++ b/packages/resource-templates/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/resource-templates",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "homepage": "https://freelens.app",
   "bugs": {
     "url": "https://github.com/freelensapp/freelens/issues"

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/routing",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable routing in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/application/application-for-electron-main/package.json
+++ b/packages/technical-features/application/application-for-electron-main/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/application-for-electron-main",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Electron's main specifics for creating Freelens applications",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/application/application/package.json
+++ b/packages/technical-features/application/application/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/application",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Package for creating Freelens applications",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/application/legacy-extensions/package.json
+++ b/packages/technical-features/application/legacy-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/legacy-extensions",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Package for Lens extensions using the v1 API",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/feature-core/package.json
+++ b/packages/technical-features/feature-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/feature-core",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Code that is common to all Features and those registering them.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/messaging/computed-channel/package.json
+++ b/packages/technical-features/messaging/computed-channel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/computed-channel",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "MobX-like computed between channels",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/messaging/messaging-fake-bridge/package.json
+++ b/packages/technical-features/messaging/messaging-fake-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/messaging-fake-bridge",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Fake implementation to bridge multiple dependency injection containers.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/messaging/messaging-for-main/package.json
+++ b/packages/technical-features/messaging/messaging-for-main/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/messaging-for-main",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Implementations for 'messaging' in Electron main",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/messaging/messaging-for-renderer/package.json
+++ b/packages/technical-features/messaging/messaging-for-renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/messaging-for-renderer",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Implementations for 'messaging' in Electron renderer",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/messaging/messaging/package.json
+++ b/packages/technical-features/messaging/messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/messaging",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "An abstraction for messaging between Lens environments",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/prometheus/package.json
+++ b/packages/technical-features/prometheus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/prometheus",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Prometheus support for Freelens",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/technical-features/react-application/package.json
+++ b/packages/technical-features/react-application/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/react-application",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Package for React Application",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/transpilation/kubernetes-client-node/package.json
+++ b/packages/transpilation/kubernetes-client-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/kubernetes-client-node",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Kubernetes client for Freelens",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/transpilation/node-fetch/package.json
+++ b/packages/transpilation/node-fetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/node-fetch",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Node fetch for Freelens",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/transpilation/openid-client/package.json
+++ b/packages/transpilation/openid-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/openid-client",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Open ID for Freelens",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/ui-components/animate/package.json
+++ b/packages/ui-components/animate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/animate",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable animate in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/ui-components/button/package.json
+++ b/packages/ui-components/button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/button",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable button in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/ui-components/error-boundary/package.json
+++ b/packages/ui-components/error-boundary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/error-boundary",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable error-boundary in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/ui-components/icon/package.json
+++ b/packages/ui-components/icon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/icon",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable icon in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/ui-components/notifications/package.json
+++ b/packages/ui-components/notifications/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/notifications",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable notifications in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/ui-components/resizing-anchor/package.json
+++ b/packages/ui-components/resizing-anchor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/resizing-anchor",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable resizing-anchor in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/ui-components/spinner/package.json
+++ b/packages/ui-components/spinner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/spinner",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable spinner in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/ui-components/tooltip/package.json
+++ b/packages/ui-components/tooltip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/tooltip",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Highly extendable tooltip in the Freelens.",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/utility-features/event-emitter/package.json
+++ b/packages/utility-features/event-emitter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/event-emitter",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Event emitter",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/utility-features/json-api/package.json
+++ b/packages/utility-features/json-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/json-api",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "JSON api client",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/utility-features/kube-api-specifics/package.json
+++ b/packages/utility-features/kube-api-specifics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/kube-api-specifics",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Kube api",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/utility-features/kube-api/package.json
+++ b/packages/utility-features/kube-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/kube-api",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "Kube api",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/utility-features/react-testing-library-discovery/package.json
+++ b/packages/utility-features/react-testing-library-discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/react-testing-library-discovery",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "A way to discover HTML-elements using react-testing-library",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/utility-features/run-many/package.json
+++ b/packages/utility-features/run-many/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/run-many",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "A package containing runMany and runManySync",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/utility-features/startable-stoppable/package.json
+++ b/packages/utility-features/startable-stoppable/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/startable-stoppable",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "TBD",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/utility-features/test-utils/package.json
+++ b/packages/utility-features/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/test-utils",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "A collection of utilities for testing",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/utility-features/utilities/package.json
+++ b/packages/utility-features/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freelensapp/utilities",
   "version": "1.10.4-0",
-  "private": false,
+  "private": true,
   "description": "A collection of useful types",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/scripts/v2-phase-5-private-flip.mjs
+++ b/scripts/v2-phase-5-private-flip.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Freelens v2 — Phase 5 codemod: flip internal packages to private (plan D4).
+//
+// Since v2 consumes every workspace package as TypeScript source and publishes
+// exactly one package (@freelensapp/extensions), all other @freelensapp/*
+// packages become `"private": true` so they are never published to npm.
+//
+// For each @freelensapp/* workspace package under packages/ (except
+// @freelensapp/extensions) the script sets `"private": true`, replacing any
+// existing `"private": false`. When the key is absent it is inserted right
+// after `"version"` to match the repo's field order. The freelens application
+// manifest is already private and is left untouched.
+//
+// The script is idempotent and prints a dry-run report by default. Pass
+// `--write` to apply the changes.
+//
+// NOT done here (the rest of Phase 5 cleanup is behaviour-bearing and coupled
+// to the electron-vite build reaching the "app that boots" bar, which a
+// headless CI runner cannot verify — see docs/v2-plan.md §4 Phase 5):
+//
+//   - Delete freelens/webpack/, packages/core/webpack/,
+//     packages/extensions/webpack/, packages/infrastructure/webpack and
+//     repoint freelens/package.json scripts (build/dev/start) from webpack to
+//     electron-vite.
+//   - Prune @freelensapp/* from the electron-builder file lists.
+//   - Drop the circular-dependency-plugin pnpm patch (patches/ +
+//     pnpm-workspace.yaml) once webpack no longer consumes it.
+//   - Decide Turbo's fate (removed or kept only as a script runner, D3).
+//
+// Usage:
+//   node scripts/v2-phase-5-private-flip.mjs            # dry run
+//   node scripts/v2-phase-5-private-flip.mjs --write     # apply
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const write = process.argv.includes("--write");
+
+// The only package that stays publishable (plan D4/D5).
+const PUBLISHED = "@freelensapp/extensions";
+
+/** Recursively collect package.json paths under a dir, skipping node_modules and dist. */
+function findPackageJsons(dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      findPackageJsons(full, acc);
+    } else if (entry.name === "package.json") {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/** Set pkg.private to true, inserting after "version" to keep the repo's field order. */
+function setPrivate(pkg) {
+  if (pkg.private === true) return pkg;
+
+  const rebuilt = {};
+  let inserted = false;
+  for (const [key, value] of Object.entries(pkg)) {
+    if (key === "private") continue; // drop an existing "false"; re-added below
+    rebuilt[key] = value;
+    if (key === "version") {
+      rebuilt.private = true;
+      inserted = true;
+    }
+  }
+  if (!inserted) rebuilt.private = true;
+  return rebuilt;
+}
+
+const changed = [];
+
+for (const pkgPath of findPackageJsons(join(repoRoot, "packages"))) {
+  const raw = readFileSync(pkgPath, "utf8");
+  const pkg = JSON.parse(raw);
+
+  // Only touch @freelensapp/* workspace packages, and never the published one.
+  if (!pkg.name?.startsWith("@freelensapp/")) continue;
+  if (pkg.name === PUBLISHED) continue;
+  if (pkg.private === true) continue;
+
+  const rebuilt = setPrivate(pkg);
+  changed.push(relative(repoRoot, pkgPath));
+  if (write) writeFileSync(pkgPath, `${JSON.stringify(rebuilt, null, 2)}\n`);
+}
+
+const mode = write ? "applied" : "dry run (pass --write to apply)";
+console.log(`Phase 5 private-flip codemod — ${mode}`);
+console.log(`${changed.length} package(s) ${write ? "updated" : "would change"}:`);
+for (const p of changed) console.log(`  ${p}`);


### PR DESCRIPTION
Phase 5 cleanup of the v2 plan (D4): v2 consumes every workspace package as TypeScript source and publishes exactly one package, so all other @freelensapp/* packages become private.

Adds a scripted, idempotent codemod (`scripts/v2-phase-5-private-flip.mjs`) and applies it to 50 packages: sets `"private": true` on every @freelensapp/* workspace package except @freelensapp/extensions, replacing any existing `"private": false`.

WIP (CI red allowed on v2 per D9). Left for local iteration: deleting the webpack directories and repointing scripts to electron-vite, pruning @freelensapp/* from the electron-builder file lists, dropping the circular-dependency-plugin patch, and deciding Turbo's fate.

Builds on #2103, #2104, #2105, #2106, #2107.

Generated with [Claude Code](https://claude.ai/code)