### PR TITLE
Phase 6: Vitest scaffold and Jest codemod (WIP)

### DIFF
--- a/scripts/v2-phase-6-vitest.mjs
+++ b/scripts/v2-phase-6-vitest.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Phase 6 of the v2 plan (docs/v2-plan.md, D8): mechanical Jest -> Vitest
+// codemod over test sources. Rewrites the D8 dependency mapping import
+// specifiers and the jest.* runtime API to vi.* (globals are enabled in the
+// root vitest.config.ts, so no `import { vi }` is added).
+//
+// Idempotent and dry-run by default; pass --write to apply. Re-running after a
+// successful --write reports "0 file(s) would change".
+//
+// Deliberately NOT handled here (behaviour-bearing, left for local iteration,
+// CI red allowed on v2 per D9):
+//   - deleting the 33 jest.config.js files and the shared @freelensapp/jest
+//     package, and swapping devDependencies + the pnpm lockfile;
+//   - repointing per-package `test:unit` scripts from `jest` to `vitest run`;
+//   - wiring setupFiles and regenerating snapshots per package (§6 risk);
+//   - confirming @async-fn/vitest needs no equivalent of the Jest pnpm patch;
+//   - re-enabling unit tests in CI.
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const write = process.argv.includes("--write");
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+const SKIP_DIRS = new Set(["node_modules", "dist", "build", "coverage", ".git", ".turbo", "static"]);
+
+// Only touch test sources and the setup/mock files they rely on. jest.config.js
+// files are intentionally excluded — they are deleted during local iteration,
+// not rewritten.
+const isTargetFile = (rel) =>
+  /\.(test)\.(ts|tsx|js)$/.test(rel) ||
+  /(^|\/)(jest\.setup|jest-after-env\.setup|jest\.timezone|setup-react-tests)\.(ts|tsx)$/.test(rel) ||
+  /(^|\/)__mocks__\//.test(rel);
+
+// D8 dependency mapping — import/require specifier rewrites.
+const SPECIFIER_RULES = [
+  { from: /@async-fn\/jest/g, to: "@async-fn/vitest" },
+  { from: /jest-mock-extended/g, to: "vitest-mock-extended" },
+  { from: /jest-canvas-mock/g, to: "vitest-canvas-mock" },
+  // Only the bare specifier; leave an already-migrated `/vitest` entry alone.
+  { from: /@testing-library\/jest-dom(?!\/vitest)/g, to: "@testing-library/jest-dom/vitest" },
+];
+
+// Scoped jest.* runtime API -> vi.* (whitelist, so strings like
+// "@testing-library/jest-dom", `jest-canvas-mock`, comments, and jest.config
+// references are left untouched).
+const JEST_API =
+  "fn|mock|unmock|doMock|dontMock|setMock|spyOn|mocked|clearAllMocks|resetAllMocks|restoreAllMocks|" +
+  "resetModules|requireActual|requireMock|createMockFromModule|useFakeTimers|useRealTimers|" +
+  "advanceTimersByTime|advanceTimersByTimeAsync|runAllTimers|runAllTimersAsync|runOnlyPendingTimers|" +
+  "setSystemTime|getRealSystemTime|isMockFunction|retryTimes|" +
+  "Mock|Mocked|MockedFunction|MockedClass|MockedObject|MockInstance";
+const JEST_API_RE = new RegExp(`\\bjest\\.(${JEST_API})\\b`, "g");
+
+const rewrite = (source) => {
+  let out = source;
+  let changed = 0;
+  for (const { from, to } of SPECIFIER_RULES) {
+    out = out.replace(from, () => {
+      changed++;
+      return to;
+    });
+  }
+  out = out.replace(JEST_API_RE, (_m, api) => {
+    changed++;
+    return `vi.${api}`;
+  });
+  return { out, changed };
+};
+
+const walk = function* (dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) yield* walk(join(dir, entry.name));
+    } else if (entry.isFile()) {
+      yield join(dir, entry.name);
+    }
+  }
+};
+
+let filesChanged = 0;
+let totalEdits = 0;
+
+for (const abs of walk(root)) {
+  const rel = relative(root, abs);
+  if (!isTargetFile(rel)) continue;
+  const source = readFileSync(abs, "utf8");
+  const { out, changed } = rewrite(source);
+  if (changed === 0) continue;
+  filesChanged++;
+  totalEdits += changed;
+  if (write) {
+    writeFileSync(abs, out);
+    console.log(`edited ${rel} (${changed} change${changed === 1 ? "" : "s"})`);
+  } else {
+    console.log(`would edit ${rel} (${changed} change${changed === 1 ? "" : "s"})`);
+  }
+}
+
+const verb = write ? "edited" : "would change";
+console.log(`\n${filesChanged} file(s) ${verb}, ${totalEdits} edit(s) total.`);
+if (!write && filesChanged > 0) {
+  console.log("Dry run — re-run with --write to apply.");
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,75 @@
+import { existsSync, globSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+// Phase 6 of the v2 plan (docs/v2-plan.md, D8): replace the 33 jest.config.js
+// files and the shared @freelensapp/jest package with a single root Vitest
+// config that uses `projects`. Per-package projects preserve the ability to run
+// and isolate each package's tests separately (relevant to D4's optional future
+// package collapse).
+//
+// WIP scaffold: this config only defines the project topology. Driving the
+// suites green package by package, regenerating snapshots per package (not in
+// one commit — see the Snapshot-churn risk in §6), and re-enabling unit tests
+// in CI are the behaviour-bearing steps left for local iteration. CI red is
+// allowed on `v2` (D9), and unit tests are disabled there until Phase 6
+// completes.
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+// Discover every package that currently defines a Jest project. Phase 6 keeps
+// the same project boundaries; each package's jest.config.js is deleted during
+// local iteration once its Vitest project runs green.
+const projectDirs = globSync("packages/**/jest.config.js", { cwd: root })
+  .map((p) => join(root, dirname(p)))
+  .filter((dir) => !dir.includes("node_modules"))
+  .concat([join(root, "freelens")])
+  .filter((dir) => existsSync(join(dir, "package.json")));
+
+// The current @freelensapp/jest split maps configForReact -> jsdom and
+// configForNode -> node. Vitest resolves CSS/asset imports natively, so the
+// moduleNameMapper entries (identity-obj-proxy, assetMock) are dropped rather
+// than migrated.
+//
+// TODO(D8): classify each project as jsdom vs node faithfully. Today the
+// classification is inferred from whether the package's jest.config.js selected
+// `configForReact`; verify per package during local iteration and pin the few
+// node-only projects (e.g. Playwright-driven integration in `freelens`) to the
+// node environment.
+const nodeEnvironmentDirs = new Set([join(root, "freelens")]);
+
+// TODO(D8): wire the shared React setup (packages/infrastructure/jest/
+// setup-react-tests.ts) and per-package setups (jest.setup.tsx,
+// jest-after-env.setup.ts, jest.timezone.ts) as Vitest setupFiles once their
+// jest.* globals are codemodded to vi.* (scripts/v2-phase-6-vitest.mjs).
+const setupCandidates = ["src/jest.setup.tsx", "src/jest-after-env.setup.ts"];
+
+export default defineConfig({
+  test: {
+    // D8: globals enabled for the transition so the jest.* -> vi.* codemod does
+    // not have to add per-file `import { vi } from "vitest"`.
+    globals: true,
+    projects: projectDirs.map((dir) => {
+      const name = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")).name;
+      return {
+        test: {
+          name,
+          root: dir,
+          environment: nodeEnvironmentDirs.has(dir) ? "node" : "jsdom",
+          include: ["**/?(*.)test.{js,ts,tsx}"],
+          exclude: ["**/node_modules/**", "**/dist/**", "**/build/**", "**/coverage/**"],
+          setupFiles: setupCandidates
+            .map((rel) => join(dir, rel))
+            .filter((abs) => existsSync(abs))
+            .map((abs) => `./${relative(dir, abs)}`),
+        },
+      };
+    }),
+    // Coverage stays provider v8, reporter lcov (D8).
+    coverage: {
+      provider: "v8",
+      reporter: ["lcov"],
+    },
+  },
+});


### PR DESCRIPTION
Phase 6 of the v2 plan (D8): begin the Jest -> Vitest swap.

- `vitest.config.ts`: single root config using `projects`, discovered from the existing jest.config.js locations so per-package boundaries are preserved. Globals enabled, coverage v8/lcov.
- `scripts/v2-phase-6-vitest.mjs`: idempotent, dry-run-by-default codemod rewriting the D8 dependency-mapping import specifiers and the whitelisted jest.* runtime API to vi.* (dry run: 167 files / 759 edits).

WIP (CI red allowed on v2 per D9). Left for local iteration: applying the codemod, deleting the 33 jest.config.js files and @freelensapp/jest, dependency + lockfile swaps, per-package snapshot regeneration, and re-enabling unit tests in CI.

Builds on #2103, #2104, #2105, #2106, #2107, #2108.

Generated with [Claude Code](https://claude.ai/code)