### PR TITLE
Fix RoleBinding and ClusterRoleBinding create dialogs

### DIFF
--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/__tests__/dialog.test.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/__tests__/dialog.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ClusterRole } from "@freelensapp/kube-object";
+import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import directoryForKubeConfigsInjectable from "../../../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
@@ -13,23 +14,28 @@ import { Cluster } from "../../../../../common/cluster/cluster";
 import hostedClusterInjectable from "../../../../cluster-frame-context/hosted-cluster.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import storesAndApisCanBeCreatedInjectable from "../../../../stores-apis-can-be-created.injectable";
+import showDetailsInjectable from "../../../kube-detail-params/show-details.injectable";
 import { renderFor } from "../../../test-utils/renderFor";
 import clusterRoleStoreInjectable from "../../cluster-roles/store.injectable";
 import closeClusterRoleBindingDialogInjectable from "../dialog/close.injectable";
 import openClusterRoleBindingDialogInjectable from "../dialog/open.injectable";
 import { ClusterRoleBindingDialog } from "../dialog/view";
+import clusterRoleBindingStoreInjectable from "../store.injectable";
 
 import type { UserEvent } from "@testing-library/user-event";
 
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { CloseClusterRoleBindingDialog } from "../dialog/close.injectable";
 import type { OpenClusterRoleBindingDialog } from "../dialog/open.injectable";
+import type { ClusterRoleBindingStore } from "../store";
 
 describe("ClusterRoleBindingDialog tests", () => {
   let render: DiRender;
   let closeClusterRoleBindingDialog: CloseClusterRoleBindingDialog;
   let openClusterRoleBindingDialog: OpenClusterRoleBindingDialog;
   let user: UserEvent;
+  let createMock: jest.Mock;
+  let updateSubjectsMock: jest.Mock;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -37,6 +43,19 @@ describe("ClusterRoleBindingDialog tests", () => {
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");
     di.override(storesAndApisCanBeCreatedInjectable, () => true);
+
+    createMock = jest.fn(async () => ({ selfLink: "/created-cluster-role-binding" }));
+    updateSubjectsMock = jest.fn(async () => ({ selfLink: "/updated-cluster-role-binding" }));
+
+    di.override(
+      clusterRoleBindingStoreInjectable,
+      () =>
+        ({
+          create: createMock,
+          updateSubjects: updateSubjectsMock,
+        }) as unknown as ClusterRoleBindingStore,
+    );
+    di.override(showDetailsInjectable, () => jest.fn());
 
     closeClusterRoleBindingDialog = di.inject(closeClusterRoleBindingDialogInjectable);
     openClusterRoleBindingDialog = di.inject(openClusterRoleBindingDialogInjectable);
@@ -88,5 +107,33 @@ describe("ClusterRoleBindingDialog tests", () => {
 
     await user.keyboard("a");
     await res.findAllByText("foobar");
+  });
+
+  it("creates a new ClusterRoleBinding when opened without an existing binding", async () => {
+    openClusterRoleBindingDialog();
+    const res = render(<ClusterRoleBindingDialog />);
+
+    // pick the cluster role (the select is autofocused in create mode)
+    await user.click(res.getByText("Select cluster role", { exact: false }));
+    await user.click(await res.findByRole("option", { name: /foobar/ }));
+
+    // enter a binding name (selecting a role does not auto-fill an empty name)
+    await user.type(res.getByPlaceholderText("Name of ClusterRoleBinding ..."), "test-binding");
+
+    // add a user subject so there is at least one binding target
+    await user.type(res.getByPlaceholderText("Bind to User Accounts (comma-separated) ..."), "test-user{Enter}");
+
+    const createButton = res.getByText("Create").closest("button") as HTMLButtonElement;
+    await user.click(createButton);
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+    expect(updateSubjectsMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledWith(
+      { name: "test-binding" },
+      expect.objectContaining({
+        subjects: [{ name: "test-user", kind: "User" }],
+        roleRef: { name: "foobar", kind: "ClusterRole" },
+      }),
+    );
   });
 });

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/__tests__/dialog.test.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/__tests__/dialog.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ClusterRole } from "@freelensapp/kube-object";
+import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import directoryForKubeConfigsInjectable from "../../../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import directoryForUserDataInjectable from "../../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
@@ -12,23 +13,29 @@ import { Cluster } from "../../../../../common/cluster/cluster";
 import hostedClusterInjectable from "../../../../cluster-frame-context/hosted-cluster.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import storesAndApisCanBeCreatedInjectable from "../../../../stores-apis-can-be-created.injectable";
+import showDetailsInjectable from "../../../kube-detail-params/show-details.injectable";
 import { renderFor } from "../../../test-utils/renderFor";
 import clusterRoleStoreInjectable from "../../cluster-roles/store.injectable";
 import closeClusterRoleBindingDialogInjectable from "../dialog/close.injectable";
 import openClusterRoleBindingDialogInjectable from "../dialog/open.injectable";
 import { ClusterRoleBindingDialog } from "../dialog/view";
+import clusterRoleBindingStoreInjectable from "../store.injectable";
 
 import type { UserEvent } from "@testing-library/user-event";
+import type { Mock } from "vitest";
 
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { CloseClusterRoleBindingDialog } from "../dialog/close.injectable";
 import type { OpenClusterRoleBindingDialog } from "../dialog/open.injectable";
+import type { ClusterRoleBindingStore } from "../store";
 
 describe("ClusterRoleBindingDialog tests", () => {
   let render: DiRender;
   let closeClusterRoleBindingDialog: CloseClusterRoleBindingDialog;
   let openClusterRoleBindingDialog: OpenClusterRoleBindingDialog;
   let user: UserEvent;
+  let createMock: Mock;
+  let updateSubjectsMock: Mock;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -36,6 +43,19 @@ describe("ClusterRoleBindingDialog tests", () => {
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");
     di.override(storesAndApisCanBeCreatedInjectable, () => true);
+
+    createMock = vi.fn(async () => ({ selfLink: "/created-cluster-role-binding" }));
+    updateSubjectsMock = vi.fn(async () => ({ selfLink: "/updated-cluster-role-binding" }));
+
+    di.override(
+      clusterRoleBindingStoreInjectable,
+      () =>
+        ({
+          create: createMock,
+          updateSubjects: updateSubjectsMock,
+        }) as unknown as ClusterRoleBindingStore,
+    );
+    di.override(showDetailsInjectable, () => vi.fn());
 
     closeClusterRoleBindingDialog = di.inject(closeClusterRoleBindingDialogInjectable);
     openClusterRoleBindingDialog = di.inject(openClusterRoleBindingDialogInjectable);
@@ -87,5 +107,33 @@ describe("ClusterRoleBindingDialog tests", () => {
 
     await user.keyboard("a");
     await res.findAllByText("foobar");
+  });
+
+  it("creates a new ClusterRoleBinding when opened without an existing binding", async () => {
+    openClusterRoleBindingDialog();
+    const res = render(<ClusterRoleBindingDialog />);
+
+    // pick the cluster role (the select is autofocused in create mode)
+    await user.click(res.getByText("Select cluster role", { exact: false }));
+    await user.click(await res.findByRole("option", { name: /foobar/ }));
+
+    // enter a binding name (selecting a role does not auto-fill an empty name)
+    await user.type(res.getByPlaceholderText("Name of ClusterRoleBinding ..."), "test-binding");
+
+    // add a user subject so there is at least one binding target
+    await user.type(res.getByPlaceholderText("Bind to User Accounts (comma-separated) ..."), "test-user{Enter}");
+
+    const createButton = res.getByText("Create").closest("button") as HTMLButtonElement;
+    await user.click(createButton);
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+    expect(updateSubjectsMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledWith(
+      { name: "test-binding" },
+      expect.objectContaining({
+        subjects: [{ name: "test-user", kind: "User" }],
+        roleRef: { name: "foobar", kind: "ClusterRole" },
+      }),
+    );
   });
 });

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
@@ -75,7 +75,6 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
     return this.props.serviceAccountStore.items.map((serviceAccount) => ({
       value: serviceAccount,
       label: `${serviceAccount.getName()} (${serviceAccount.getNs()})`,
-      isSelected: this.selectedAccounts.has(serviceAccount),
     }));
   }
 
@@ -240,6 +239,7 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
           themeName="light"
           placeholder="Select service accounts ..."
           options={this.serviceAccountOptions}
+          value={Array.from(this.selectedAccounts)}
           formatOptionLabel={(option) => (
             <>
               <Icon small material="account_box" /> {option.label}

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
@@ -142,12 +142,12 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
     const { closeClusterRoleBindingDialog, clusterRoleBindingStore, editBindingNameState, showDetails } = this.props;
     const { selectedRoleRef, selectedBindings, clusterRoleBinding } = this;
 
-    if (!clusterRoleBinding || !selectedRoleRef) {
+    if (!selectedRoleRef) {
       return;
     }
 
     try {
-      const { selfLink } = this.isEditing
+      const { selfLink } = clusterRoleBinding
         ? await clusterRoleBindingStore.updateSubjects(clusterRoleBinding, selectedBindings)
         : await clusterRoleBindingStore.create(
             { name: editBindingNameState.get() },

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
@@ -145,12 +145,12 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
     const { closeClusterRoleBindingDialog, clusterRoleBindingStore, editBindingNameState, showDetails } = this.props;
     const { selectedRoleRef, selectedBindings, clusterRoleBinding } = this;
 
-    if (!clusterRoleBinding || !selectedRoleRef) {
+    if (!selectedRoleRef) {
       return;
     }
 
     try {
-      const { selfLink } = this.isEditing
+      const { selfLink } = clusterRoleBinding
         ? await clusterRoleBindingStore.updateSubjects(clusterRoleBinding, selectedBindings)
         : await clusterRoleBindingStore.create(
             { name: editBindingNameState.get() },

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
@@ -78,7 +78,6 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
     return this.props.serviceAccountStore.items.map((serviceAccount) => ({
       value: serviceAccount,
       label: `${serviceAccount.getName()} (${serviceAccount.getNs()})`,
-      isSelected: this.selectedAccounts.has(serviceAccount),
     }));
   }
 
@@ -243,6 +242,7 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
           themeName="lens"
           placeholder="Select service accounts ..."
           options={this.serviceAccountOptions}
+          value={Array.from(this.selectedAccounts)}
           formatOptionLabel={(option) => (
             <>
               <Icon small material="account_box" /> {option.label}

--- a/packages/core/src/renderer/components/user-management/role-bindings/__tests__/dialog.test.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/__tests__/dialog.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ClusterRole } from "@freelensapp/kube-object";
+import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import directoryForKubeConfigsInjectable from "../../../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
@@ -13,20 +14,25 @@ import { Cluster } from "../../../../../common/cluster/cluster";
 import hostedClusterInjectable from "../../../../cluster-frame-context/hosted-cluster.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import storesAndApisCanBeCreatedInjectable from "../../../../stores-apis-can-be-created.injectable";
+import showDetailsInjectable from "../../../kube-detail-params/show-details.injectable";
 import { renderFor } from "../../../test-utils/renderFor";
 import clusterRoleStoreInjectable from "../../cluster-roles/store.injectable";
 import openRoleBindingDialogInjectable from "../dialog/open.injectable";
 import { RoleBindingDialog } from "../dialog/view";
+import roleBindingStoreInjectable from "../store.injectable";
 
 import type { UserEvent } from "@testing-library/user-event";
 
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { OpenRoleBindingDialog } from "../dialog/open.injectable";
+import type { RoleBindingStore } from "../store";
 
 describe("RoleBindingDialog tests", () => {
   let render: DiRender;
   let openRoleBindingDialog: OpenRoleBindingDialog;
   let user: UserEvent;
+  let createMock: jest.Mock;
+  let updateSubjectsMock: jest.Mock;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -34,6 +40,19 @@ describe("RoleBindingDialog tests", () => {
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");
     di.override(storesAndApisCanBeCreatedInjectable, () => true);
+
+    createMock = jest.fn(async () => ({ selfLink: "/created-role-binding" }));
+    updateSubjectsMock = jest.fn(async () => ({ selfLink: "/updated-role-binding" }));
+
+    di.override(
+      roleBindingStoreInjectable,
+      () =>
+        ({
+          create: createMock,
+          updateSubjects: updateSubjectsMock,
+        }) as unknown as RoleBindingStore,
+    );
+    di.override(showDetailsInjectable, () => jest.fn());
 
     openRoleBindingDialog = di.inject(openRoleBindingDialogInjectable);
 
@@ -44,6 +63,7 @@ describe("RoleBindingDialog tests", () => {
           contextName: "some-context-name",
           id: "some-cluster-id",
           kubeConfigPath: "/some-path-to-a-kubeconfig",
+          accessibleNamespaces: ["default"],
         }),
     );
 
@@ -82,5 +102,44 @@ describe("RoleBindingDialog tests", () => {
     await res.findAllByText("foobar", {
       exact: false,
     });
+  });
+
+  it("creates a new RoleBinding when opened without an existing binding", async () => {
+    openRoleBindingDialog();
+    const res = render(<RoleBindingDialog />);
+
+    // the dialog renders into a portal, so open each Select by clicking its control
+    const openSelect = (inputId: string) =>
+      user.click(res.baseElement.querySelector(`#${inputId}`)?.closest(".Select__control") as HTMLElement);
+
+    // pick the namespace
+    await openSelect("dialog-namespace-input");
+    await user.click(await res.findByRole("option", { name: /default/ }));
+
+    // pick the role reference (a ClusterRole is always listed regardless of namespace)
+    await openSelect("role-reference-input");
+    await user.click(await res.findByRole("option", { name: /foobar/ }));
+
+    // enter a binding name (the only plain input with neither an id nor a placeholder)
+    const nameInput = Array.from(res.baseElement.querySelectorAll("input")).find(
+      (el) => !el.id && !(el as HTMLInputElement).placeholder,
+    ) as HTMLInputElement;
+    await user.type(nameInput, "test-binding");
+
+    // add a user subject so there is at least one binding target
+    await user.type(res.getByPlaceholderText("Bind to User Accounts (comma-separated) ..."), "test-user{Enter}");
+
+    const createButton = res.getByText("Create").closest("button") as HTMLButtonElement;
+    await user.click(createButton);
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+    expect(updateSubjectsMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledWith(
+      { name: "test-binding", namespace: "default" },
+      expect.objectContaining({
+        subjects: [{ name: "test-user", kind: "User" }],
+        roleRef: { name: "foobar", kind: "ClusterRole" },
+      }),
+    );
   });
 });

--- a/packages/core/src/renderer/components/user-management/role-bindings/__tests__/dialog.test.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/__tests__/dialog.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ClusterRole } from "@freelensapp/kube-object";
+import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import directoryForKubeConfigsInjectable from "../../../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import directoryForUserDataInjectable from "../../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
@@ -12,20 +13,26 @@ import { Cluster } from "../../../../../common/cluster/cluster";
 import hostedClusterInjectable from "../../../../cluster-frame-context/hosted-cluster.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import storesAndApisCanBeCreatedInjectable from "../../../../stores-apis-can-be-created.injectable";
+import showDetailsInjectable from "../../../kube-detail-params/show-details.injectable";
 import { renderFor } from "../../../test-utils/renderFor";
 import clusterRoleStoreInjectable from "../../cluster-roles/store.injectable";
 import openRoleBindingDialogInjectable from "../dialog/open.injectable";
 import { RoleBindingDialog } from "../dialog/view";
+import roleBindingStoreInjectable from "../store.injectable";
 
 import type { UserEvent } from "@testing-library/user-event";
+import type { Mock } from "vitest";
 
 import type { DiRender } from "../../../test-utils/renderFor";
 import type { OpenRoleBindingDialog } from "../dialog/open.injectable";
+import type { RoleBindingStore } from "../store";
 
 describe("RoleBindingDialog tests", () => {
   let render: DiRender;
   let openRoleBindingDialog: OpenRoleBindingDialog;
   let user: UserEvent;
+  let createMock: Mock;
+  let updateSubjectsMock: Mock;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -33,6 +40,19 @@ describe("RoleBindingDialog tests", () => {
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");
     di.override(storesAndApisCanBeCreatedInjectable, () => true);
+
+    createMock = vi.fn(async () => ({ selfLink: "/created-role-binding" }));
+    updateSubjectsMock = vi.fn(async () => ({ selfLink: "/updated-role-binding" }));
+
+    di.override(
+      roleBindingStoreInjectable,
+      () =>
+        ({
+          create: createMock,
+          updateSubjects: updateSubjectsMock,
+        }) as unknown as RoleBindingStore,
+    );
+    di.override(showDetailsInjectable, () => vi.fn());
 
     openRoleBindingDialog = di.inject(openRoleBindingDialogInjectable);
 
@@ -43,6 +63,7 @@ describe("RoleBindingDialog tests", () => {
           contextName: "some-context-name",
           id: "some-cluster-id",
           kubeConfigPath: "/some-path-to-a-kubeconfig",
+          accessibleNamespaces: ["default"],
         }),
     );
 
@@ -81,5 +102,44 @@ describe("RoleBindingDialog tests", () => {
     await res.findAllByText("foobar", {
       exact: false,
     });
+  });
+
+  it("creates a new RoleBinding when opened without an existing binding", async () => {
+    openRoleBindingDialog();
+    const res = render(<RoleBindingDialog />);
+
+    // the dialog renders into a portal, so open each Select by clicking its control
+    const openSelect = (inputId: string) =>
+      user.click(res.baseElement.querySelector(`#${inputId}`)?.closest(".Select__control") as HTMLElement);
+
+    // pick the namespace
+    await openSelect("dialog-namespace-input");
+    await user.click(await res.findByRole("option", { name: /default/ }));
+
+    // pick the role reference (a ClusterRole is always listed regardless of namespace)
+    await openSelect("role-reference-input");
+    await user.click(await res.findByRole("option", { name: /foobar/ }));
+
+    // enter a binding name (the only plain input with neither an id nor a placeholder)
+    const nameInput = Array.from(res.baseElement.querySelectorAll("input")).find(
+      (el) => !el.id && !(el as HTMLInputElement).placeholder,
+    ) as HTMLInputElement;
+    await user.type(nameInput, "test-binding");
+
+    // add a user subject so there is at least one binding target
+    await user.type(res.getByPlaceholderText("Bind to User Accounts (comma-separated) ..."), "test-user{Enter}");
+
+    const createButton = res.getByText("Create").closest("button") as HTMLButtonElement;
+    await user.click(createButton);
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+    expect(updateSubjectsMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledWith(
+      { name: "test-binding", namespace: "default" },
+      expect.objectContaining({
+        subjects: [{ name: "test-user", kind: "User" }],
+        roleRef: { name: "foobar", kind: "ClusterRole" },
+      }),
+    );
   });
 });

--- a/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
@@ -113,7 +113,6 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
     return this.props.serviceAccountStore.items.map((serviceAccount) => ({
       value: serviceAccount,
       label: `${serviceAccount.getName()} (${serviceAccount.getNs()})`,
-      isSelected: this.selectedAccounts.has(serviceAccount),
     }));
   }
 
@@ -249,6 +248,7 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
           themeName="light"
           placeholder="Select service accounts ..."
           options={this.serviceAccountOptions}
+          value={Array.from(this.selectedAccounts)}
           formatOptionLabel={(option) => (
             <>
               <Icon small material="account_box" /> {option.label}

--- a/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
@@ -158,12 +158,12 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
     const { roleBindingStore, showDetails, showCheckedErrorNotification } = this.props;
     const { selectedRoleRef, bindingNamespace, selectedBindings, roleBinding, bindingName } = this;
 
-    if (!selectedRoleRef || !roleBinding || !bindingNamespace || !bindingName) {
+    if (!selectedRoleRef || !bindingNamespace || !bindingName) {
       return;
     }
 
     try {
-      const newRoleBinding = this.isEditing
+      const newRoleBinding = roleBinding
         ? await roleBindingStore.updateSubjects(roleBinding, selectedBindings)
         : await roleBindingStore.create(
             {

--- a/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
@@ -116,7 +116,6 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
     return this.props.serviceAccountStore.items.map((serviceAccount) => ({
       value: serviceAccount,
       label: `${serviceAccount.getName()} (${serviceAccount.getNs()})`,
-      isSelected: this.selectedAccounts.has(serviceAccount),
     }));
   }
 
@@ -252,6 +251,7 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
           themeName="lens"
           placeholder="Select service accounts ..."
           options={this.serviceAccountOptions}
+          value={Array.from(this.selectedAccounts)}
           formatOptionLabel={(option) => (
             <>
               <Icon small material="account_box" /> {option.label}

--- a/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
@@ -161,12 +161,12 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
     const { roleBindingStore, showDetails, showCheckedErrorNotification } = this.props;
     const { selectedRoleRef, bindingNamespace, selectedBindings, roleBinding, bindingName } = this;
 
-    if (!selectedRoleRef || !roleBinding || !bindingNamespace || !bindingName) {
+    if (!selectedRoleRef || !bindingNamespace || !bindingName) {
       return;
     }
 
     try {
-      const newRoleBinding = this.isEditing
+      const newRoleBinding = roleBinding
         ? await roleBindingStore.updateSubjects(roleBinding, selectedBindings)
         : await roleBindingStore.create(
             {


### PR DESCRIPTION
## Summary

Fixes two bugs, each present in both the **RoleBinding** and **ClusterRoleBinding** add/edit dialogs (`user-management/*/dialog/view.tsx`).

### 1. "Create" does nothing when creating a new binding

`createBindings` guarded on the dialog state's existing binding object (`roleBinding` / `clusterRoleBinding`), which is only set when **editing**. When creating a brand-new binding that value is `undefined`, so the guard returned early and `store.create` — and the dialog close — never ran. The Create button silently did nothing and the dialog stayed open.

Fix: only require the existing binding for the update path, and branch on it directly (instead of `isEditing`) so the create path runs when there is no existing binding. The `.create()` branch was effectively dead code before.

### 2. Selected service accounts are not shown

The Service Accounts multi-`<Select>` passed no `value` prop. `Select` is controlled and renders its selection solely from `value`, so chosen accounts were stored in the backing observable set but never displayed as chips — the selection looked lost.

Fix: pass `value={Array.from(this.selectedAccounts)}`, and drop the dead `isSelected` option flag the `Select` wrapper ignores.

## Changes

- `packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx`
- `packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx`
- Regression tests for the create flow in both dialogs' `__tests__/dialog.test.tsx` (assert `store.create` is called and `updateSubjects` is not).

Four commits, one per fix, for a bisectable history.

## Testing

- `pnpm test:unit` passes for both dialog suites. The new create-flow tests **fail against the pre-fix source** (`store.create` called 0 times) and pass with the fix.
- Verified end-to-end against a real cluster: creating a RoleBinding with User and ServiceAccount subjects now succeeds and closes the dialog; selected service accounts persist as chips in both dialogs.
- `pnpm biome check` clean on the changed files.

Generated with [Claude Code](https://claude.com/claude-code).
