### PR TITLE
Harden the published extension API types and clean up Vitest type artifacts

### DIFF
--- a/docs/v2-extension-migration.md
+++ b/docs/v2-extension-migration.md
@@ -10,9 +10,12 @@ is ported (the validation vehicle named in the plan).
 ## What changed, and why
 
 - **ESM-first.** The application main process, renderer, and the extension API
-  are all ES modules. Extensions load through `await import(pathToFileURL(...))`
-  instead of `require()`, so an extension may be authored as **ESM or
-  CommonJS** — both are accepted, including graphs with top-level `await`.
+  are all ES modules. Extensions load through Node's `require(esm)` (verified
+  in [#1718](https://github.com/freelensapp/freelens/issues/1718) to work in
+  all processes), so an extension may be authored as **ESM or CommonJS** —
+  both are accepted. The one restriction: the extension entrypoint graph must
+  not use top-level `await`, which synchronous loading cannot express. An
+  `import()`-based main-process loader may lift this later.
 - **One published package.** `@freelensapp/extensions` is the only published
   package. Every other `@freelensapp/*` package is `private` and is consumed by
   the app as TypeScript source. Extensions must not depend on internal
@@ -59,9 +62,39 @@ runtime.
 - Depend on `@freelensapp/extensions` for **types**. You do not need to bundle
   it; the API is provided by the host through the runtime global.
 - Author your entrypoints as ESM or CommonJS. If you ship ESM, set
-  `"type": "module"` (or use `.mjs`); the `import()`-based loader handles both.
+  `"type": "module"` (or use `.mjs`); the loader handles both. Avoid top-level
+  `await` in the entrypoint graph (see above).
 - Do not add any other `@freelensapp/*` package as a dependency — they are
   private in v2 and are not published.
+- The package declares its ~30 type-level dependencies (react, mobx,
+  monaco-editor, type-fest, ...) itself, so its bundled `.d.ts` type-checks in
+  your project with no extra installs — with one exception: **`electron`** is
+  an optional peer dependency (a hard dependency would download the Electron
+  binary into every extension install). Add it as a `devDependency` for its
+  types.
+
+## `tsconfig.json` for an extension
+
+The bundled `extension-api.d.ts` sets two floors for consumer compilers:
+
+- `"skipLibCheck": true` — the type dependency graph (for example
+  `@ogre-tools/injectable`, which references jest types) is not clean under
+  `skipLibCheck: false`, and checking it is not your job.
+- `"lib": ["ES2024", "DOM", "DOM.Iterable"]` (or newer) — mobx 6.15 types
+  reference `ReadonlySetLike`, which first appears in the ES2024 lib.
+
+`"moduleResolution": "bundler"` (or `node16`/`nodenext`) both resolve the
+package's `exports`.
+
+The API namespaces work in type positions exactly as in v1:
+
+```ts
+import { Common, Renderer } from "@freelensapp/extensions";
+
+const manifest: Common.PackageJson = { name: "my-extension", version: "1.0.0" };
+
+function renderIcon(props: Renderer.Component.IconProps) { /* ... */ }
+```
 
 ## API namespace reorganization
 
@@ -89,8 +122,10 @@ in from the freelens-example-extension port and will be appended here.
 These items are finalized as the migration is validated end-to-end and are
 noted here so the guide is honest about what is not yet locked:
 
-- The **rolled-up, self-contained `.d.ts`** for the published
-  `@freelensapp/extensions` (no `@freelensapp/*` imports) — the fiddliest
-  Phase 4 deliverable (plan §6).
 - The **example-extension port**, from which the namespace rename table above
   is derived.
+
+The rolled-up, self-contained `.d.ts` for the published
+`@freelensapp/extensions` (no `@freelensapp/*` imports, declared type
+dependencies, namespaces usable in type positions) is done and verified
+against a strict-mode scratch consumer.

--- a/packages/business-features/keyboard-shortcuts/src/keyboard-shortcuts.test.tsx
+++ b/packages/business-features/keyboard-shortcuts/src/keyboard-shortcuts.test.tsx
@@ -15,10 +15,11 @@ import { KeyboardShortcutScope } from "./keyboard-shortcut-scope";
 import platformInjectable from "./platform.injectable";
 
 import type { RenderResult } from "@testing-library/react";
+import type { Mock } from "vitest";
 
 describe("keyboard-shortcuts", () => {
   let di: DiContainer;
-  let invokeMock: vi.Mock;
+  let invokeMock: Mock;
   let rendered: RenderResult;
   let user: UserEvent;
 

--- a/packages/core/src/common/get-configuration-file-model/get-configuration-file-model.injectable.ts
+++ b/packages/core/src/common/get-configuration-file-model/get-configuration-file-model.injectable.ts
@@ -7,7 +7,7 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import Config from "conf";
 
-import type { Options as ConfOptions } from "conf/dist/source/types";
+import type { Options as ConfOptions } from "conf";
 
 export type GetConfigurationFileModel = <T extends object>(content: ConfOptions<T>) => Config<T>;
 

--- a/packages/core/src/common/k8s-api/endpoints/metrics.api/request-metrics.injectable.test.ts
+++ b/packages/core/src/common/k8s-api/endpoints/metrics.api/request-metrics.injectable.test.ts
@@ -7,6 +7,8 @@
 import apiBaseInjectable from "../../api-base.injectable";
 import requestMetricsInjectable from "./request-metrics.injectable";
 
+import type { Mock } from "vitest";
+
 import type { RequestMetrics } from "./request-metrics.injectable";
 
 describe("requestMetricsInjectable", () => {
@@ -113,7 +115,7 @@ describe("requestMetricsInjectable", () => {
   });
 });
 
-function instantiateRequestMetrics(post: vi.Mock = vi.fn().mockResolvedValue({})) {
+function instantiateRequestMetrics(post: Mock = vi.fn().mockResolvedValue({})) {
   const requestMetrics = requestMetricsInjectable.instantiate({
     inject: (injectable: unknown) => {
       if (injectable === apiBaseInjectable) {

--- a/packages/core/src/common/utils/composite/get-composite/get-composite.test.ts
+++ b/packages/core/src/common/utils/composite/get-composite/get-composite.test.ts
@@ -8,6 +8,8 @@ import { sortBy } from "lodash/fp";
 import { getCompositePaths } from "../get-composite-paths/get-composite-paths";
 import { getCompositeFor } from "./get-composite";
 
+import type { Mock } from "vitest";
+
 import type { Composite } from "./get-composite";
 
 interface SomeItem {
@@ -206,7 +208,7 @@ Available parent ids are:
 
   describe("given items with missing parents, when creating composite with handling for missing parents", () => {
     let composite: Composite<any>;
-    let handleMissingParentIdMock: vi.Mock;
+    let handleMissingParentIdMock: Mock;
 
     beforeEach(() => {
       const someItem = {

--- a/packages/core/src/common/utils/with-error-logging/with-error-logging.test.ts
+++ b/packages/core/src/common/utils/with-error-logging/with-error-logging.test.ts
@@ -12,12 +12,13 @@ import logErrorInjectable from "../../log-error.injectable";
 import withErrorLoggingInjectable from "./with-error-logging.injectable";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
+import type { Mock } from "vitest";
 
 describe("with-error-logging", () => {
   describe("given decorated sync function", () => {
-    let toBeDecorated: vi.Mock<number | undefined, [string, string]>;
+    let toBeDecorated: Mock<number | undefined, [string, string]>;
     let decorated: (a: string, b: string) => number | undefined;
-    let logErrorMock: vi.Mock;
+    let logErrorMock: Mock;
 
     beforeEach(() => {
       const di = getDiForUnitTesting();
@@ -112,7 +113,7 @@ describe("with-error-logging", () => {
   describe("given decorated async function", () => {
     let decorated: (a: string, b: string) => Promise<number | undefined>;
     let toBeDecorated: AsyncFnMock<typeof decorated>;
-    let logErrorMock: vi.Mock;
+    let logErrorMock: Mock;
 
     beforeEach(() => {
       const di = getDiForUnitTesting();

--- a/packages/core/src/common/utils/with-error-suppression/with-error-suppression.test.ts
+++ b/packages/core/src/common/utils/with-error-suppression/with-error-suppression.test.ts
@@ -9,10 +9,11 @@ import { getPromiseStatus } from "@freelensapp/test-utils";
 import { withErrorSuppression } from "./with-error-suppression";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
+import type { Mock } from "vitest";
 
 describe("with-error-suppression", () => {
   describe("given decorated sync function", () => {
-    let toBeDecorated: vi.Mock<void, [string, string]>;
+    let toBeDecorated: Mock<void, [string, string]>;
     let decorated: (a: string, b: string) => void;
 
     beforeEach(() => {

--- a/packages/core/src/common/utils/with-orphan-promise/with-orphan-promise.test.ts
+++ b/packages/core/src/common/utils/with-orphan-promise/with-orphan-promise.test.ts
@@ -10,11 +10,12 @@ import logErrorInjectable from "../../log-error.injectable";
 import withOrphanPromiseInjectable from "./with-orphan-promise.injectable";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
+import type { Mock } from "vitest";
 
 describe("with orphan promise, when called", () => {
   let toBeDecorated: AsyncFnMock<(arg1: string, arg2: string) => Promise<string>>;
   let actual: void;
-  let logErrorMock: vi.Mock;
+  let logErrorMock: Mock;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();

--- a/packages/core/src/extensions/common-api/index.ts
+++ b/packages/core/src/extensions/common-api/index.ts
@@ -20,7 +20,11 @@ export { Util } from "./utils";
 export type { InstalledExtension, LensExtensionManifest } from "@freelensapp/legacy-extensions";
 export type { Logger } from "@freelensapp/logger";
 
-export type { PackageJson } from "type-fest";
+// A plain alias instead of a re-export: type-fest declares PackageJson as a
+// type plus a same-named namespace, and rollup-plugin-dts turns a namespace
+// re-export into `declare const ...: typeof PackageJson`, which is invalid
+// for a type-only namespace (TS2708 for consumers of the bundled d.ts).
+export type PackageJson = import("type-fest").PackageJson;
 
 export type { LensExtension } from "../lens-extension";
 

--- a/packages/core/src/extensions/extension-discovery/extension-discovery.test.ts
+++ b/packages/core/src/extensions/extension-discovery/extension-discovery.test.ts
@@ -22,15 +22,16 @@ import extensionDiscoveryInjectable from "../extension-discovery/extension-disco
 import installExtensionInjectable from "../install-extension/install-extension.injectable";
 
 import type { FSWatcher } from "chokidar";
+import type { Mock } from "vitest";
 
 import type { JoinPaths } from "../../common/path/join-paths.injectable";
 import type { ExtensionDiscovery } from "../extension-discovery/extension-discovery";
 
 describe("ExtensionDiscovery", () => {
   let extensionDiscovery: ExtensionDiscovery;
-  let readJsonFileMock: vi.Mock;
-  let pathExistsMock: vi.Mock;
-  let watchMock: vi.Mock;
+  let readJsonFileMock: Mock;
+  let pathExistsMock: Mock;
+  let watchMock: Mock;
   let joinPaths: JoinPaths;
   let homeDirectoryPath: string;
 

--- a/packages/core/src/extensions/extension-loader/file-system-provisioner-store/ensure-hashed-directory-for-extension.test.ts
+++ b/packages/core/src/extensions/extension-loader/file-system-provisioner-store/ensure-hashed-directory-for-extension.test.ts
@@ -13,12 +13,13 @@ import ensureHashedDirectoryForExtensionInjectable from "./ensure-hashed-directo
 import { registeredExtensionsInjectable } from "./registered-extensions.injectable";
 
 import type { ObservableMap } from "mobx";
+import type { Mock } from "vitest";
 
 import type { EnsureHashedDirectoryForExtension } from "./ensure-hashed-directory-for-extension.injectable";
 
 describe("ensure-hashed-directory-for-extension", () => {
   let ensureHashedDirectoryForExtension: EnsureHashedDirectoryForExtension;
-  let ensureDirMock: vi.Mock;
+  let ensureDirMock: Mock;
   let registeredExtensions: ObservableMap<string, string>;
 
   beforeEach(() => {

--- a/packages/core/src/extensions/install-extension/install-extension.test.ts
+++ b/packages/core/src/extensions/install-extension/install-extension.test.ts
@@ -11,14 +11,16 @@ import { getDiForUnitTesting } from "../../main/getDiForUnitTesting";
 import forkPnpmInjectable from "./fork-pnpm.injectable";
 import installExtensionInjectable from "./install-extension.injectable";
 
+import type { Mock } from "vitest";
+
 import type { InstallExtension } from "./install-extension.injectable";
 
 describe("install-extension", () => {
   let installExtension: InstallExtension;
-  let forkPnpmMock: vi.Mock;
-  let pathExistsMock: vi.Mock;
-  let statMock: vi.Mock;
-  let writeJsonSyncMock: vi.Mock;
+  let forkPnpmMock: Mock;
+  let pathExistsMock: Mock;
+  let statMock: Mock;
+  let writeJsonSyncMock: Mock;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();

--- a/packages/core/src/features/application-menu/application-menu-in-legacy-extension-api.test.ts
+++ b/packages/core/src/features/application-menu/application-menu-in-legacy-extension-api.test.ts
@@ -11,12 +11,14 @@ import logErrorInjectable from "../../common/log-error.injectable";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import applicationMenuItemInjectionToken from "./main/menu-items/application-menu-item-injection-token";
 
+import type { Mock } from "vitest";
+
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import type { FakeExtensionOptions } from "../../renderer/components/test-utils/get-extension-fake";
 
 describe("application-menu-in-legacy-extension-api", () => {
   let builder: ApplicationBuilder;
-  let logErrorMock: vi.Mock;
+  let logErrorMock: Mock;
 
   beforeEach(async () => {
     builder = getApplicationBuilder();
@@ -35,7 +37,7 @@ describe("application-menu-in-legacy-extension-api", () => {
   });
 
   describe("when extension with application menu items is enabled", () => {
-    let onClickMock: vi.Mock;
+    let onClickMock: Mock;
     let testExtensionOptions: FakeExtensionOptions;
 
     beforeEach(() => {

--- a/packages/core/src/features/application-menu/application-menu.test.ts
+++ b/packages/core/src/features/application-menu/application-menu.test.ts
@@ -11,11 +11,13 @@ import { getApplicationBuilder } from "../../renderer/components/test-utils/get-
 import { advanceFakeTime, testUsingFakeTime } from "../../test-utils/use-fake-time";
 import populateApplicationMenuInjectable from "./main/populate-application-menu.injectable";
 
+import type { Mock } from "vitest";
+
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
 describe.each(allPlatforms)("application-menu, given platform is '%s'", (platform) => {
   let builder: ApplicationBuilder;
-  let populateApplicationMenuMock: vi.Mock;
+  let populateApplicationMenuMock: Mock;
 
   beforeEach(async () => {
     testUsingFakeTime();

--- a/packages/core/src/features/application-menu/handling-of-orphan-application-menu-items.test.ts
+++ b/packages/core/src/features/application-menu/handling-of-orphan-application-menu-items.test.ts
@@ -13,12 +13,14 @@ import { advanceFakeTime, testUsingFakeTime } from "../../test-utils/use-fake-ti
 import applicationMenuItemInjectionToken from "./main/menu-items/application-menu-item-injection-token";
 import populateApplicationMenuInjectable from "./main/populate-application-menu.injectable";
 
+import type { Mock } from "vitest";
+
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
 describe("handling-of-orphan-application-menu-items, given orphan menu item", () => {
   let builder: ApplicationBuilder;
-  let populateApplicationMenuMock: vi.Mock;
-  let logErrorMock: vi.Mock;
+  let populateApplicationMenuMock: Mock;
+  let logErrorMock: Mock;
 
   beforeEach(async () => {
     testUsingFakeTime();

--- a/packages/core/src/features/catalog/entity-running.test.tsx
+++ b/packages/core/src/features/catalog/entity-running.test.tsx
@@ -16,6 +16,7 @@ import { advanceFakeTime, testUsingFakeTime } from "../../test-utils/use-fake-ti
 
 import type { DiContainer } from "@ogre-tools/injectable";
 import type { RenderResult } from "@testing-library/react";
+import type { MockedFunction } from "vitest";
 
 import type { AppEvent } from "../../common/app-event-bus/event-bus";
 import type { CatalogEntityActionContext } from "../../common/catalog";
@@ -82,8 +83,8 @@ describe("entity running technical tests", () => {
   let builder: ApplicationBuilder;
   let windowDi: DiContainer;
   let rendered: RenderResult;
-  let appEventListener: vi.MockedFunction<(event: AppEvent) => void>;
-  let onRun: vi.MockedFunction<(context: CatalogEntityActionContext) => void | Promise<void>>;
+  let appEventListener: MockedFunction<(event: AppEvent) => void>;
+  let onRun: MockedFunction<(context: CatalogEntityActionContext) => void | Promise<void>>;
   let catalogEntityRegistry: CatalogEntityRegistry;
 
   beforeEach(async () => {

--- a/packages/core/src/features/cluster/execute/renderer/__tests__/execute-on-cluster.test.ts
+++ b/packages/core/src/features/cluster/execute/renderer/__tests__/execute-on-cluster.test.ts
@@ -9,12 +9,13 @@ import { executeOnClusterChannel } from "../../common/channels";
 import executeOnClusterInjectable from "../execute-on-cluster.injectable";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock } from "vitest";
 
 import type { ExecuteOnClusterResponse } from "../../common/types";
 
 describe("executeOnCluster", () => {
   let di: DiContainer;
-  let requestFromChannelMock: vi.Mock;
+  let requestFromChannelMock: Mock;
 
   beforeEach(() => {
     di = getDiForUnitTesting();

--- a/packages/core/src/features/cluster/execute/renderer/__tests__/k8s-api.test.ts
+++ b/packages/core/src/features/cluster/execute/renderer/__tests__/k8s-api.test.ts
@@ -12,6 +12,7 @@ import { createMockClusterEntity } from "../../common/testing";
 import executeOnClusterInjectable from "../execute-on-cluster.injectable";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock } from "vitest";
 
 import type { CatalogEntityRegistry } from "../../../../../renderer/api/catalog/entity/registry";
 import type { ExecuteOnClusterResponse } from "../../common/types";
@@ -22,7 +23,7 @@ import type { ExecuteOnClusterResponse } from "../../common/types";
 
 describe("K8s extension API functions (via injectable)", () => {
   let di: DiContainer;
-  let requestFromChannelMock: vi.Mock;
+  let requestFromChannelMock: Mock;
   let catalogEntityRegistry: CatalogEntityRegistry;
 
   beforeEach(() => {

--- a/packages/core/src/features/cluster/execute/renderer/__tests__/k8s-mutations.test.ts
+++ b/packages/core/src/features/cluster/execute/renderer/__tests__/k8s-mutations.test.ts
@@ -8,6 +8,7 @@ import { getDiForUnitTesting } from "../../../../../renderer/getDiForUnitTesting
 import executeOnClusterInjectable from "../execute-on-cluster.injectable";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock } from "vitest";
 
 import type { ExecuteOnClusterRequest, ExecuteOnClusterResponse } from "../../common/types";
 
@@ -17,7 +18,7 @@ import type { ExecuteOnClusterRequest, ExecuteOnClusterResponse } from "../../co
  */
 describe("K8s mutation functions (via injectable)", () => {
   let di: DiContainer;
-  let requestFromChannelMock: vi.Mock;
+  let requestFromChannelMock: Mock;
   let executeOnCluster: (request: ExecuteOnClusterRequest) => Promise<ExecuteOnClusterResponse>;
 
   beforeEach(() => {

--- a/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
+++ b/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
@@ -27,6 +27,7 @@ import type { ShowNotification } from "@freelensapp/notifications";
 import type { AsyncFnMock } from "@async-fn/vitest";
 import type { DiContainer } from "@ogre-tools/injectable";
 import type { RenderResult } from "@testing-library/react";
+import type { MockedFunction } from "vitest";
 
 import type { ApplicationBuilder } from "../../../renderer/components/test-utils/get-application-builder";
 import type { ApiKubeGet } from "../../../renderer/k8s/api-kube-get.injectable";
@@ -36,8 +37,8 @@ describe("cluster/namespaces - edit namespace from new tab", () => {
   let builder: ApplicationBuilder;
   let apiKubePatchMock: AsyncFnMock<ApiKubePatch>;
   let apiKubeGetMock: AsyncFnMock<ApiKubeGet>;
-  let showSuccessNotificationMock: vi.MockedFunction<ShowNotification>;
-  let showErrorNotificationMock: vi.MockedFunction<ShowNotification>;
+  let showSuccessNotificationMock: MockedFunction<ShowNotification>;
+  let showErrorNotificationMock: MockedFunction<ShowNotification>;
 
   beforeEach(() => {
     builder = getApplicationBuilder();

--- a/packages/core/src/features/extensions/navigation-using-application-menu.test.ts
+++ b/packages/core/src/features/extensions/navigation-using-application-menu.test.ts
@@ -8,6 +8,7 @@ import { getApplicationBuilder } from "../../renderer/components/test-utils/get-
 import focusWindowInjectable from "../../renderer/navigation/focus-window.injectable";
 
 import type { RenderResult } from "@testing-library/react";
+import type { Mock } from "vitest";
 
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
@@ -17,7 +18,7 @@ vi.mock("../../renderer/components/input/input");
 describe("extensions - navigation using application menu", () => {
   let builder: ApplicationBuilder;
   let rendered: RenderResult;
-  let focusWindowMock: vi.Mock;
+  let focusWindowMock: Mock;
 
   beforeEach(async () => {
     builder = getApplicationBuilder();

--- a/packages/core/src/features/helm-charts/add-custom-helm-repository-in-preferences.test.ts
+++ b/packages/core/src/features/helm-charts/add-custom-helm-repository-in-preferences.test.ts
@@ -19,6 +19,7 @@ import type { AsyncResult } from "@freelensapp/utilities";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
 import type { RenderResult } from "@testing-library/react";
+import type { Mock } from "vitest";
 
 import type { ExecFile } from "../../common/fs/exec-file.injectable";
 import type { HelmRepo } from "../../common/helm/helm-repo";
@@ -26,8 +27,8 @@ import type { ApplicationBuilder } from "../../renderer/components/test-utils/ge
 
 describe("add custom helm repository in preferences", () => {
   let builder: ApplicationBuilder;
-  let showSuccessNotificationMock: vi.Mock;
-  let showErrorNotificationMock: vi.Mock;
+  let showSuccessNotificationMock: Mock;
+  let showErrorNotificationMock: Mock;
   let rendered: RenderResult;
   let execFileMock: AsyncFnMock<ExecFile>;
   let getActiveHelmRepositoriesMock: AsyncFnMock<() => AsyncResult<HelmRepo[]>>;

--- a/packages/core/src/features/helm-charts/add-helm-repository-from-list-in-preferences.test.ts
+++ b/packages/core/src/features/helm-charts/add-helm-repository-from-list-in-preferences.test.ts
@@ -17,6 +17,7 @@ import requestPublicHelmRepositoriesInjectable from "./child-features/preference
 import type { AsyncResult } from "@freelensapp/utilities";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
+import type { Mock } from "vitest";
 
 import type { ExecFile } from "../../common/fs/exec-file.injectable";
 import type { HelmRepo } from "../../common/helm/helm-repo";
@@ -24,8 +25,8 @@ import type { ApplicationBuilder } from "../../renderer/components/test-utils/ge
 
 describe("add helm repository from list in preferences", () => {
   let builder: ApplicationBuilder;
-  let showSuccessNotificationMock: vi.Mock;
-  let showErrorNotificationMock: vi.Mock;
+  let showSuccessNotificationMock: Mock;
+  let showErrorNotificationMock: Mock;
   let rendered: RenderResult;
   let execFileMock: AsyncFnMock<ExecFile>;
   let getActiveHelmRepositoriesMock: AsyncFnMock<() => AsyncResult<HelmRepo[]>>;

--- a/packages/core/src/features/helm-charts/installing-chart/opening-dock-tab-for-installing-helm-chart.test.ts
+++ b/packages/core/src/features/helm-charts/installing-chart/opening-dock-tab-for-installing-helm-chart.test.ts
@@ -22,6 +22,7 @@ import { getApplicationBuilder } from "../../../renderer/components/test-utils/g
 
 import type { AsyncFnMock } from "@async-fn/vitest";
 import type { RenderResult } from "@testing-library/react";
+import type { Mock } from "vitest";
 
 import type { RequestHelmCharts } from "../../../common/k8s-api/endpoints/helm-charts.api/request-charts.injectable";
 import type { RequestHelmChartReadme } from "../../../common/k8s-api/endpoints/helm-charts.api/request-readme.injectable";
@@ -33,7 +34,7 @@ describe("opening dock tab for installing helm chart", () => {
   let requestHelmChartsMock: AsyncFnMock<RequestHelmCharts>;
   let requestHelmChartVersionsMock: AsyncFnMock<RequestHelmChartVersions>;
   let requestHelmChartReadmeMock: AsyncFnMock<RequestHelmChartReadme>;
-  let requestHelmChartValuesMock: vi.Mock;
+  let requestHelmChartValuesMock: Mock;
 
   beforeEach(() => {
     builder = getApplicationBuilder(userEvent.setup({ delay: null }));

--- a/packages/core/src/features/helm-charts/listing-active-helm-repositories-in-preferences.test.ts
+++ b/packages/core/src/features/helm-charts/listing-active-helm-repositories-in-preferences.test.ts
@@ -18,6 +18,7 @@ import requestPublicHelmRepositoriesInjectable from "./child-features/preference
 import type { Logger } from "@freelensapp/logger";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
+import type { Mock } from "vitest";
 
 import type { ReadYamlFile } from "../../common/fs/read-yaml-file.injectable";
 import type { HelmRepositoriesFromYaml } from "../../main/helm/repositories/get-active-helm-repositories/get-active-helm-repositories.injectable";
@@ -29,7 +30,7 @@ describe("listing active helm repositories in preferences", () => {
   let readYamlFileMock: AsyncFnMock<ReadYamlFile>;
   let execFileMock: AsyncFnMock<ExecFile>;
   let loggerStub: Logger;
-  let showErrorNotificationMock: vi.Mock;
+  let showErrorNotificationMock: Mock;
 
   beforeEach(async () => {
     builder = getApplicationBuilder();

--- a/packages/core/src/features/helm-releases/showing-details-for-helm-release.test.ts
+++ b/packages/core/src/features/helm-releases/showing-details-for-helm-release.test.ts
@@ -25,6 +25,7 @@ import { testUsingFakeTime } from "../../test-utils/use-fake-time";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
 import type { RenderResult } from "@testing-library/react";
+import type { Mock } from "vitest";
 
 import type { RequestHelmCharts } from "../../common/k8s-api/endpoints/helm-charts.api/request-charts.injectable";
 import type { RequestHelmChartReadme } from "../../common/k8s-api/endpoints/helm-charts.api/request-readme.injectable";
@@ -45,8 +46,8 @@ describe("showing details for helm release", () => {
   let requestHelmChartVersionsMock: AsyncFnMock<RequestHelmChartVersions>;
   let requestHelmChartReadmeMock: AsyncFnMock<RequestHelmChartReadme>;
   let requestHelmChartValuesMock: AsyncFnMock<RequestHelmChartValues>;
-  let showSuccessNotificationMock: vi.Mock;
-  let showCheckedErrorNotificationMock: vi.Mock;
+  let showSuccessNotificationMock: Mock;
+  let showCheckedErrorNotificationMock: Mock;
   let listClusterHelmReleasesMock: AsyncFnMock<ListClusterHelmReleases>;
 
   beforeEach(() => {

--- a/packages/core/src/features/hotbar/storage/storage-technical.test.ts
+++ b/packages/core/src/features/hotbar/storage/storage-technical.test.ts
@@ -24,6 +24,7 @@ import type { Logger } from "@freelensapp/logger";
 
 import type { DiContainer } from "@ogre-tools/injectable";
 import type { IComputedValue } from "mobx";
+import type { Mocked } from "vitest";
 
 import type { CatalogEntity, CatalogEntityData, CatalogEntityKindData } from "../../../common/catalog";
 import type { AddHotbar } from "./common/add.injectable";
@@ -50,7 +51,7 @@ describe("Hotbars technical tests", () => {
   let testCluster: CatalogEntity;
   let kindCluster: CatalogEntity;
   let awsCluster: CatalogEntity;
-  let loggerMock: vi.Mocked<Logger>;
+  let loggerMock: Mocked<Logger>;
   let setAsActiveHotbar: SetAsActiveHotbar;
   let hotbars: IComputedValue<Hotbar[]>;
   let activeHotbar: IComputedValue<Hotbar | undefined>;

--- a/packages/core/src/features/persistent-storage/common/create.injectable.ts
+++ b/packages/core/src/features/persistent-storage/common/create.injectable.ts
@@ -20,7 +20,7 @@ import { persistStateToConfigInjectionToken } from "./save-to-file";
 
 import type { MessageChannel } from "@freelensapp/messaging";
 
-import type { Options } from "conf/dist/source";
+import type { Options } from "conf";
 import type { IEqualsComparer } from "mobx";
 
 import type { Migrations } from "./migrations.injectable";

--- a/packages/core/src/features/pod-logs/download-logs.test.tsx
+++ b/packages/core/src/features/pod-logs/download-logs.test.tsx
@@ -29,6 +29,7 @@ import type { Container } from "@freelensapp/kube-object";
 
 import type { DiContainer } from "@ogre-tools/injectable";
 import type { RenderResult } from "@testing-library/react";
+import type { Mock, MockedFunction } from "vitest";
 
 import type { CallForLogs } from "../../renderer/components/dock/logs/call-for-logs.injectable";
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
@@ -37,11 +38,11 @@ describe("download logs options in logs dock tab", () => {
   let windowDi: DiContainer;
   let rendered: RenderResult;
   let builder: ApplicationBuilder;
-  let openSaveFileDialogMock: vi.MockedFunction<() => void>;
-  let callForLogsMock: vi.MockedFunction<CallForLogs>;
-  let getLogsMock: vi.Mock;
-  let getSplitLogsMock: vi.Mock;
-  let showErrorNotificationMock: vi.Mock;
+  let openSaveFileDialogMock: MockedFunction<() => void>;
+  let callForLogsMock: MockedFunction<CallForLogs>;
+  let getLogsMock: Mock;
+  let getSplitLogsMock: Mock;
+  let showErrorNotificationMock: Mock;
   const logs = new Map([["timestamp", "some-logs"]]);
   const pod = dockerPod;
 

--- a/packages/core/src/features/population-of-logs-to-a-file/main/ipc-file-logger.test.ts
+++ b/packages/core/src/features/population-of-logs-to-a-file/main/ipc-file-logger.test.ts
@@ -8,12 +8,14 @@ import { getDiForUnitTesting } from "../../../main/getDiForUnitTesting";
 import createIpcFileLoggerTransportInjectable from "./create-ipc-file-transport.injectable";
 import ipcFileLoggerInjectable from "./ipc-file-logger.injectable";
 
+import type { Mock } from "vitest";
+
 import type { IpcFileLogger } from "./ipc-file-logger.injectable";
 
 describe("ipc file logger in main", () => {
-  let logMock: vi.Mock;
-  let closeMock: vi.Mock;
-  let createFileTransportMock: vi.Mock;
+  let logMock: Mock;
+  let closeMock: Mock;
+  let createFileTransportMock: Mock;
   let logger: IpcFileLogger;
 
   beforeEach(() => {

--- a/packages/core/src/features/population-of-logs-to-a-file/population-of-logs-to-a-file.test.ts
+++ b/packages/core/src/features/population-of-logs-to-a-file/population-of-logs-to-a-file.test.ts
@@ -15,6 +15,7 @@ import createIpcFileLoggerTransportInjectable from "./main/create-ipc-file-trans
 import closeRendererLogFileInjectable from "./renderer/close-renderer-log-file.injectable";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock } from "vitest";
 import type winston from "winston";
 
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
@@ -23,8 +24,8 @@ describe("Population of logs to a file", () => {
   let builder: ApplicationBuilder;
   let windowDi: DiContainer;
   let logWarningInRenderer: (message: string, ...args: any) => void;
-  let frameSpecificWinstonLogInMainMock: vi.Mock;
-  let frameSpecificCloseLogInMainMock: vi.Mock;
+  let frameSpecificWinstonLogInMainMock: Mock;
+  let frameSpecificCloseLogInMainMock: Mock;
 
   async function setUpTestApplication({ testFileId, isClusterFrame }: { testFileId: string; isClusterFrame: boolean }) {
     builder = getApplicationBuilder();

--- a/packages/core/src/features/preferences/navigation-to-extension-specific-preferences.test.tsx
+++ b/packages/core/src/features/preferences/navigation-to-extension-specific-preferences.test.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
 import type { RenderResult } from "@testing-library/react";
+import type { Mock } from "vitest";
 
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import "@testing-library/jest-dom/vitest";
@@ -28,7 +29,7 @@ describe("preferences - navigation to extension specific preferences", () => {
 
   describe("given in preferences, when rendered", () => {
     let rendered: RenderResult;
-    let logErrorMock: vi.Mock;
+    let logErrorMock: Mock;
     let discover: Discover;
 
     beforeEach(async () => {

--- a/packages/core/src/features/quitting-and-restarting-the-app/opening-application-window-using-tray.test.ts
+++ b/packages/core/src/features/quitting-and-restarting-the-app/opening-application-window-using-tray.test.ts
@@ -13,6 +13,7 @@ import splashWindowInjectable from "../../main/start-main-application/lens-windo
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
+import type { Mock } from "vitest";
 
 import type { CreateElectronWindow } from "../../main/start-main-application/lens-window/application-window/create-electron-window.injectable";
 import type { LensWindow } from "../../main/start-main-application/lens-window/application-window/create-lens-window.injectable";
@@ -21,11 +22,11 @@ import type { ApplicationBuilder } from "../../renderer/components/test-utils/ge
 describe("opening application window using tray", () => {
   describe("given application has started", () => {
     let builder: ApplicationBuilder;
-    let createElectronWindowMock: vi.Mock;
+    let createElectronWindowMock: Mock;
     let expectWindowsToBeOpen: (windowIds: string[]) => void;
     let callForSplashWindowHtmlMock: AsyncFnMock<(filePath: string) => Promise<void>>;
     let callForApplicationWindowHtmlMock: AsyncFnMock<(url: string) => Promise<void>>;
-    let focusApplicationMock: vi.Mock;
+    let focusApplicationMock: Mock;
 
     beforeEach(async () => {
       callForSplashWindowHtmlMock = asyncFn();

--- a/packages/core/src/features/quitting-and-restarting-the-app/quitting-the-app-using-application-menu.test.ts
+++ b/packages/core/src/features/quitting-and-restarting-the-app/quitting-the-app-using-application-menu.test.ts
@@ -8,12 +8,14 @@ import requestQuitOfAppInjectable from "../../main/electron-app/features/require
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import { testUsingFakeTime } from "../../test-utils/use-fake-time";
 
+import type { Mock } from "vitest";
+
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
 describe("quitting the app using application menu", () => {
   describe("given application has started", () => {
     let builder: ApplicationBuilder;
-    let requestQuitOfAppMock: vi.Mock;
+    let requestQuitOfAppMock: Mock;
 
     beforeEach(async () => {
       testUsingFakeTime("2015-10-21T07:28:00Z");

--- a/packages/core/src/features/shell-sync/main/compute-unix-shell-environment.test.ts
+++ b/packages/core/src/features/shell-sync/main/compute-unix-shell-environment.test.ts
@@ -16,6 +16,7 @@ import processExecPathInjectable from "./execPath.injectable";
 import type { ChildProcessWithoutNullStreams } from "child_process";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { MockedFunction } from "vitest";
 
 import type { Spawn } from "../../../main/child-process/spawn.injectable";
 import type { ComputeUnixShellEnvironment } from "./compute-unix-shell-environment.injectable";
@@ -33,7 +34,7 @@ const expectedEnv = {
 describe("computeUnixShellEnvironment technical tests", () => {
   let di: DiContainer;
   let computeUnixShellEnvironment: ComputeUnixShellEnvironment;
-  let spawnMock: vi.MockedFunction<Spawn>;
+  let spawnMock: MockedFunction<Spawn>;
   let shellProcessFake: ChildProcessWithoutNullStreams;
   let stdinValue: string;
   let shellStdin: MemoryStream;

--- a/packages/core/src/features/tray/clicking-tray-menu-item-originating-from-extension.test.ts
+++ b/packages/core/src/features/tray/clicking-tray-menu-item-originating-from-extension.test.ts
@@ -8,12 +8,14 @@ import { getRandomIdInjectionToken } from "@freelensapp/random";
 import logErrorInjectable from "../../common/log-error.injectable";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
+import type { Mock } from "vitest";
+
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import type { FakeExtensionOptions } from "../../renderer/components/test-utils/get-extension-fake";
 
 describe("clicking tray menu item originating from extension", () => {
   let builder: ApplicationBuilder;
-  let logErrorMock: vi.Mock;
+  let logErrorMock: Mock;
 
   beforeEach(async () => {
     builder = getApplicationBuilder();
@@ -30,7 +32,7 @@ describe("clicking tray menu item originating from extension", () => {
 
   describe("when extension is enabled", () => {
     let someExtension: FakeExtensionOptions;
-    let clickMock: vi.Mock;
+    let clickMock: Mock;
 
     beforeEach(() => {
       clickMock = vi.fn();

--- a/packages/core/src/main/__test__/kube-api-upgrade-request.test.ts
+++ b/packages/core/src/main/__test__/kube-api-upgrade-request.test.ts
@@ -22,6 +22,8 @@ import { getDiForUnitTesting } from "../getDiForUnitTesting";
 import kubeAuthProxyCertificateInjectable from "../kube-auth-proxy/kube-auth-proxy-certificate.injectable";
 import kubeApiUpgradeRequestInjectable from "../lens-proxy/proxy-functions/kube-api-upgrade-request.injectable";
 
+import type { MockedFunction } from "vitest";
+
 class MockSocket extends EventEmitter {
   destroyed = false;
   writable = true;
@@ -45,7 +47,7 @@ const mockConnectImplementation = (proxySocket: MockSocket) =>
 describe("kube api upgrade request", () => {
   it("forwards the upgrade request to the auth proxy", async () => {
     const di = getDiForUnitTesting();
-    const connectMock = connect as vi.MockedFunction<typeof connect>;
+    const connectMock = connect as MockedFunction<typeof connect>;
     const proxySocket = new MockSocket();
     const socket = new MockSocket();
     const head = Buffer.from("buffered-head");
@@ -115,7 +117,7 @@ describe("kube api upgrade request", () => {
 
   it("applies backpressure from the auth proxy socket to the client socket", async () => {
     const di = getDiForUnitTesting();
-    const connectMock = connect as vi.MockedFunction<typeof connect>;
+    const connectMock = connect as MockedFunction<typeof connect>;
     const proxySocket = new MockSocket();
     const socket = new MockSocket();
     const cluster = new Cluster({
@@ -170,7 +172,7 @@ describe("kube api upgrade request", () => {
 
   it("applies backpressure from the client socket to the auth proxy socket", async () => {
     const di = getDiForUnitTesting();
-    const connectMock = connect as vi.MockedFunction<typeof connect>;
+    const connectMock = connect as MockedFunction<typeof connect>;
     const proxySocket = new MockSocket();
     const socket = new MockSocket();
     const cluster = new Cluster({
@@ -225,7 +227,7 @@ describe("kube api upgrade request", () => {
 
   it("returns an http error before the upgraded stream starts", async () => {
     const di = getDiForUnitTesting();
-    const connectMock = connect as vi.MockedFunction<typeof connect>;
+    const connectMock = connect as MockedFunction<typeof connect>;
     const proxySocket = new MockSocket();
     const socket = new MockSocket();
     const cluster = new Cluster({

--- a/packages/core/src/main/__test__/kube-auth-proxy.test.ts
+++ b/packages/core/src/main/__test__/kube-auth-proxy.test.ts
@@ -24,6 +24,7 @@ import kubectlDownloadingNormalizedArchInjectable from "../kubectl/normalized-ar
 import type { ChildProcess } from "child_process";
 import type { Readable } from "stream";
 
+import type { Mock } from "vitest";
 import type { DeepMockProxy } from "vitest-mock-extended";
 
 import type { Cluster } from "../../common/cluster/cluster";
@@ -31,9 +32,9 @@ import type { GetBasenameOfPath } from "../../common/path/get-basename.injectabl
 import type { KubeAuthProxy } from "../kube-auth-proxy/create-kube-auth-proxy.injectable";
 
 describe("kube auth proxy tests", () => {
-  let spawnMock: vi.Mock;
-  let waitUntilPortIsUsedMock: vi.Mock;
-  let broadcastMessageMock: vi.Mock;
+  let spawnMock: Mock;
+  let waitUntilPortIsUsedMock: Mock;
+  let broadcastMessageMock: Mock;
   let getBasenameOfPath: GetBasenameOfPath;
   let cluster: Cluster;
   let kubeAuthProxy: KubeAuthProxy;

--- a/packages/core/src/main/__test__/kubeconfig-manager.test.ts
+++ b/packages/core/src/main/__test__/kubeconfig-manager.test.ts
@@ -28,6 +28,7 @@ import type { Logger } from "@freelensapp/logger";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mocked } from "vitest";
 
 import type { PathExists } from "../../common/fs/path-exists.injectable";
 import type { ReadFile } from "../../common/fs/read-file.injectable";
@@ -40,7 +41,7 @@ const clusterServerUrl = "https://192.168.64.3:8443";
 describe("kubeconfig manager tests", () => {
   let clusterFake: Cluster;
   let di: DiContainer;
-  let loggerMock: vi.Mocked<Logger>;
+  let loggerMock: Mocked<Logger>;
   let readFileMock: AsyncFnMock<ReadFile>;
   let deleteFileMock: AsyncFnMock<RemovePath>;
   let writeFileMock: AsyncFnMock<WriteFile>;

--- a/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
+++ b/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
@@ -32,6 +32,7 @@ import type { Logger } from "@freelensapp/logger";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock, Mocked } from "vitest";
 
 import type { CatalogEntity } from "../../../common/catalog";
 import type { Cluster } from "../../../common/cluster/cluster";
@@ -505,8 +506,8 @@ describe("kubeconfig-sync.source tests", () => {
     let manager: KubeconfigSyncManager;
     let localDi: DiContainer;
     let localKubeconfigSyncs: ObservableMap<string, KubeconfigSyncValue>;
-    let watchMock: vi.Mock;
-    let logger: vi.Mocked<Pick<Logger, "debug" | "warn" | "info" | "error">>;
+    let watchMock: Mock;
+    let logger: Mocked<Pick<Logger, "debug" | "warn" | "info" | "error">>;
 
     beforeEach(() => {
       localDi = getDiForUnitTesting();
@@ -556,7 +557,7 @@ describe("kubeconfig-sync.source tests", () => {
     let localDi: DiContainer;
     let localKubeconfigSyncs: ObservableMap<string, KubeconfigSyncValue>;
     let watchInstances: Map<string, Watcher<true>>;
-    let watchMock: vi.Mock;
+    let watchMock: Mock;
     let statMock: AsyncFnMock<Stat>;
 
     beforeEach(() => {
@@ -675,7 +676,7 @@ describe("kubeconfig-sync.source tests", () => {
         });
 
         // stopOldSync calls disposer which calls watcher.close()
-        expect((watcherBefore.close as vi.Mock).mock.calls.length).toBeGreaterThan(0);
+        expect((watcherBefore.close as Mock).mock.calls.length).toBeGreaterThan(0);
       });
 
       it("removes the source entry for the deleted path", () => {
@@ -719,7 +720,7 @@ describe("kubeconfig-sync.source tests", () => {
         });
 
         // directoryForKubeConfigs is always in desired set — watcher must NOT be stopped
-        expect((watcherBefore.close as vi.Mock).mock.calls.length).toBe(0);
+        expect((watcherBefore.close as Mock).mock.calls.length).toBe(0);
       });
     });
   });
@@ -728,7 +729,7 @@ describe("kubeconfig-sync.source tests", () => {
   describe("descriptor syncKubeconfigEntries.fromStore() IPC-reload path", () => {
     let localDi: DiContainer;
     let watchInstances: Map<string, Watcher<true>>;
-    let watchMock: vi.Mock;
+    let watchMock: Mock;
     let statMock: AsyncFnMock<Stat>;
 
     beforeEach(() => {
@@ -847,7 +848,7 @@ describe("kubeconfig-sync.source tests", () => {
         descriptors.syncKubeconfigEntries.fromStore([{ filePath: "/path/a" }]);
       });
 
-      expect((watcherForB.close as vi.Mock).mock.calls.length).toBeGreaterThan(0);
+      expect((watcherForB.close as Mock).mock.calls.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/core/src/main/helm/__tests__/helm-service.test.ts
+++ b/packages/core/src/main/helm/__tests__/helm-service.test.ts
@@ -12,11 +12,13 @@ import getActiveHelmRepositoriesInjectable from "../repositories/get-active-helm
 
 import type { AsyncResult } from "@freelensapp/utilities";
 
+import type { Mock } from "vitest";
+
 import type { HelmRepo } from "../../../common/helm/helm-repo";
 
 describe("Helm Service tests", () => {
   let listHelmCharts: () => Promise<any>;
-  let getActiveHelmRepositoriesMock: vi.Mock<AsyncResult<HelmRepo[]>>;
+  let getActiveHelmRepositoriesMock: Mock<AsyncResult<HelmRepo[]>>;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();

--- a/packages/core/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.test.ts
+++ b/packages/core/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.test.ts
@@ -12,11 +12,13 @@ import nonPromiseExecFileInjectable from "./non-promise-exec-file.injectable";
 
 import type { AsyncResult } from "@freelensapp/utilities";
 
+import type { Mock } from "vitest";
+
 import type { ExecFileWithInput } from "./exec-file-with-input.injectable";
 
 describe("exec-file-with-input", () => {
   let execFileWithInput: ExecFileWithInput;
-  let execFileMock: vi.Mock;
+  let execFileMock: Mock;
 
   let executionStub: EventEmitter & {
     stdin: { end: (chunk: any) => void };

--- a/packages/core/src/main/protocol-handler/__test__/router.test.ts
+++ b/packages/core/src/main/protocol-handler/__test__/router.test.ts
@@ -23,6 +23,7 @@ import lensProtocolRouterMainInjectable from "../lens-protocol-router-main/lens-
 import type { LegacyLensExtension, LensExtensionId } from "@freelensapp/legacy-extensions";
 
 import type { ObservableMap } from "mobx";
+import type { Mock } from "vitest";
 
 import type { LensExtensionState } from "../../../features/extensions/enabled/common/state.injectable";
 import type { LensProtocolRouterMain } from "../lens-protocol-router-main/lens-protocol-router-main";
@@ -37,7 +38,7 @@ describe("protocol router tests", () => {
   let extensionInstances: ObservableMap<LensExtensionId, LegacyLensExtension>;
   let lpr: LensProtocolRouterMain;
   let enabledExtensions: ObservableMap<LensExtensionId, LensExtensionState>;
-  let broadcastMessageMock: vi.Mock;
+  let broadcastMessageMock: Mock;
 
   beforeEach(async () => {
     const di = getDiForUnitTesting();

--- a/packages/core/src/main/shell-session/local-shell-session/techincal.test.ts
+++ b/packages/core/src/main/shell-session/local-shell-session/techincal.test.ts
@@ -22,6 +22,7 @@ import spawnPtyInjectable from "../spawn-pty.injectable";
 import openLocalShellSessionInjectable from "./open.injectable";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { MockedFunction } from "vitest";
 import type WebSocket from "ws";
 
 import type { KubeconfigManager } from "../../kubeconfig-manager/kubeconfig-manager";
@@ -58,7 +59,7 @@ describe("technical unit tests for local shell sessions", () => {
 
   describe("when on windows", () => {
     let openLocalShellSession: OpenShellSession;
-    let spawnPtyMock: vi.MockedFunction<SpawnPty>;
+    let spawnPtyMock: MockedFunction<SpawnPty>;
 
     beforeEach(() => {
       di.override(platformInjectable, () => "win32");

--- a/packages/core/src/main/utils/resolve-system-proxy/resolve-system-proxy-from-electron.test.ts
+++ b/packages/core/src/main/utils/resolve-system-proxy/resolve-system-proxy-from-electron.test.ts
@@ -14,10 +14,11 @@ import resolveSystemProxyWindowInjectable from "./resolve-system-proxy-window.in
 import type { AsyncFnMock } from "@async-fn/vitest";
 import type { DiContainer } from "@ogre-tools/injectable";
 import type { BrowserWindow, Session, WebContents } from "electron";
+import type { Mock } from "vitest";
 
 describe("technical: resolve-system-proxy-from-electron", () => {
   let resolveSystemProxyMock: AsyncFnMock<(url: string) => Promise<string>>;
-  let logErrorMock: vi.Mock;
+  let logErrorMock: Mock;
   let di: DiContainer;
   let actualPromise: Promise<string>;
 

--- a/packages/core/src/renderer/components/cluster-settings/__tests__/cluster-local-terminal-settings.test.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/__tests__/cluster-local-terminal-settings.test.tsx
@@ -17,14 +17,15 @@ import { ClusterLocalTerminalSetting } from "../local-terminal-settings";
 import type { Stats } from "fs";
 
 import type { UserEvent } from "@testing-library/user-event";
+import type { Mock } from "vitest";
 
 import type { DiRender } from "../../test-utils/renderFor";
 
 describe("ClusterLocalTerminalSettings", () => {
   let render: DiRender;
-  let showErrorNotificationMock: vi.Mock;
-  let statMock: vi.Mock;
-  let loadKubeconfigMock: vi.Mock;
+  let showErrorNotificationMock: Mock;
+  let statMock: Mock;
+  let loadKubeconfigMock: Mock;
   let user: UserEvent;
 
   beforeEach(() => {

--- a/packages/core/src/renderer/components/countdown/countdown.test.tsx
+++ b/packages/core/src/renderer/components/countdown/countdown.test.tsx
@@ -16,6 +16,7 @@ import countdownStateInjectable from "./countdown-state.injectable";
 import type { DiContainer } from "@ogre-tools/injectable";
 import type { RenderResult } from "@testing-library/react";
 import type { IComputedValue } from "mobx";
+import type { Mock } from "vitest";
 
 import type { DiRender } from "../test-utils/renderFor";
 
@@ -35,7 +36,7 @@ describe("countdown", () => {
 
   describe("when rendering countdown", () => {
     let rendered: RenderResult;
-    let onZeroMock: vi.Mock;
+    let onZeroMock: Mock;
 
     beforeEach(() => {
       onZeroMock = vi.fn();
@@ -104,7 +105,7 @@ describe("countdown", () => {
   });
 
   describe("given observed", () => {
-    let onZeroMock: vi.Mock;
+    let onZeroMock: Mock;
     let unobserve: () => void;
     let secondsTill: IComputedValue<number>;
 

--- a/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.test.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.test.tsx
@@ -10,6 +10,8 @@ import { EditResourceModel } from "./edit-resource-model.injectable";
 
 import type { ShowNotification } from "@freelensapp/notifications";
 
+import type { MockedFunction } from "vitest";
+
 import type { EditingResource, EditResourceTabStore } from "../store";
 import type { RequestKubeResource } from "./request-kube-resource.injectable";
 import type { RequestPatchKubeResource } from "./request-patch-kube-resource.injectable";
@@ -17,10 +19,10 @@ import type { RequestPatchKubeResource } from "./request-patch-kube-resource.inj
 const selfLink = "/api/v1/namespaces/default/pods/test-pod";
 
 describe("edit-resource-model", () => {
-  const requestKubeResource = vi.fn() as vi.MockedFunction<RequestKubeResource>;
+  const requestKubeResource = vi.fn() as MockedFunction<RequestKubeResource>;
   const waitForEditingResource = vi.fn(async () => undefined as never);
-  const showSuccessNotification = vi.fn() as vi.MockedFunction<ShowNotification>;
-  const showErrorNotification = vi.fn() as vi.MockedFunction<ShowNotification>;
+  const showSuccessNotification = vi.fn() as MockedFunction<ShowNotification>;
+  const showErrorNotification = vi.fn() as MockedFunction<ShowNotification>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,7 +41,7 @@ describe("edit-resource-model", () => {
           kind: "Pod",
           name: "test-pod",
         },
-      }))) as vi.MockedFunction<RequestPatchKubeResource>;
+      }))) as MockedFunction<RequestPatchKubeResource>;
 
     const model = new EditResourceModel({
       requestKubeResource,

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
@@ -5,6 +5,8 @@
  */
 
 import React from "react";
+
+import type { MockedFunction } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import userEvent from "@testing-library/user-event";
 import assert from "assert";
@@ -146,7 +148,7 @@ describe("<LogResourceSelector />", () => {
 
   describe("with several pods", () => {
     let model: LogTabViewModel;
-    let renameTab: vi.MockedFunction<LogTabViewModelDependencies["renameTab"]>;
+    let renameTab: MockedFunction<LogTabViewModelDependencies["renameTab"]>;
 
     beforeEach(() => {
       renameTab = vi.fn();

--- a/packages/core/src/renderer/components/extensions/__tests__/extensions.test.tsx
+++ b/packages/core/src/renderer/components/extensions/__tests__/extensions.test.tsx
@@ -4,6 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import type { MockedFunction } from "vitest";
+
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import assert from "assert";
@@ -33,11 +35,11 @@ import type { InstallExtensionFromInput } from "../install-extension-from-input.
 describe("Extensions", () => {
   let extensionLoader: ExtensionLoader;
   let extensionDiscovery: ExtensionDiscovery;
-  let installExtensionFromInput: vi.MockedFunction<InstallExtensionFromInput>;
+  let installExtensionFromInput: MockedFunction<InstallExtensionFromInput>;
   let extensionInstallationStateStore: ExtensionInstallationStateStore;
   let render: DiRender;
-  let deleteFileMock: vi.MockedFunction<RemovePath>;
-  let downloadBinary: vi.MockedFunction<DownloadBinary>;
+  let deleteFileMock: MockedFunction<RemovePath>;
+  let downloadBinary: MockedFunction<DownloadBinary>;
 
   beforeEach(() => {
     try {

--- a/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
+++ b/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
@@ -8,6 +8,7 @@ import { screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 import type { RenderResult } from "@testing-library/react";
+import type { Mocked } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
 import { KubeObject } from "@freelensapp/kube-object";
@@ -101,7 +102,7 @@ describe("kube-object-menu", () => {
 
   describe("given kube object", () => {
     let result: RenderResult;
-    let kubeObjectDeleteServiceMock: vi.Mocked<KubeObjectDeleteService>;
+    let kubeObjectDeleteServiceMock: Mocked<KubeObjectDeleteService>;
     let deletePendingPromise: Promise<void>;
     let resolveDelete: () => void;
 

--- a/packages/core/src/renderer/components/layout/top-bar/top-bar.test.tsx
+++ b/packages/core/src/renderer/components/layout/top-bar/top-bar.test.tsx
@@ -6,6 +6,8 @@
 
 import { fireEvent } from "@testing-library/react";
 import React from "react";
+
+import type { MockedFunction } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
 import { computed, observable } from "mobx";
@@ -30,12 +32,12 @@ import type { DiRender } from "../../test-utils/renderFor";
 describe("<TopBar/>", () => {
   let di: DiContainer;
   let render: DiRender;
-  let goBack: vi.MockedFunction<() => void>;
-  let goForward: vi.MockedFunction<() => void>;
-  let openAppContextMenu: vi.MockedFunction<() => void>;
-  let closeWindow: vi.MockedFunction<() => void>;
-  let maximizeWindow: vi.MockedFunction<() => void>;
-  let toggleMaximizeWindow: vi.MockedFunction<() => void>;
+  let goBack: MockedFunction<() => void>;
+  let goForward: MockedFunction<() => void>;
+  let openAppContextMenu: MockedFunction<() => void>;
+  let closeWindow: MockedFunction<() => void>;
+  let maximizeWindow: MockedFunction<() => void>;
+  let toggleMaximizeWindow: MockedFunction<() => void>;
 
   beforeEach(() => {
     di = getDiForUnitTesting();

--- a/packages/core/src/renderer/components/node-pod-menu/__tests__/node-menu.test.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/__tests__/node-menu.test.tsx
@@ -9,6 +9,7 @@ import { type DiRender, renderFor } from "../../test-utils/renderFor";
 import { NodeMenu } from "../node-menu";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock } from "vitest";
 
 vi.mock("../../menu", () => ({
   __esModule: true,
@@ -22,10 +23,10 @@ vi.mock("../../menu", () => ({
 describe("pod-node-menu", () => {
   let di: DiContainer;
   let render: DiRender;
-  let createTerminalTabMock: vi.Mock;
-  let openConfirmDialogMock: vi.Mock;
-  let sendCommandMock: vi.Mock;
-  let hideDetailsMock: vi.Mock;
+  let createTerminalTabMock: Mock;
+  let openConfirmDialogMock: Mock;
+  let sendCommandMock: Mock;
+  let hideDetailsMock: Mock;
 
   beforeEach(() => {
     di = getDiForUnitTesting();

--- a/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-attach-menu.test.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-attach-menu.test.tsx
@@ -8,6 +8,7 @@ import { type DiRender, renderFor } from "../../test-utils/renderFor";
 import { PodAttachMenu } from "../pod-attach-menu";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock } from "vitest";
 
 vi.mock("uuid", () => ({
   v4: vi.fn(() => "mocked-id"),
@@ -28,9 +29,9 @@ vi.mock("../pod-menu-item", () => ({
 describe("pod-attach-menu", () => {
   let di: DiContainer;
   let render: DiRender;
-  let createTerminalTabMock: vi.Mock;
-  let sendCommandMock: vi.Mock;
-  let hideDetailsMock: vi.Mock;
+  let createTerminalTabMock: Mock;
+  let sendCommandMock: Mock;
+  let hideDetailsMock: Mock;
 
   beforeEach(() => {
     di = getDiForUnitTesting();

--- a/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-logs-menu.test.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-logs-menu.test.tsx
@@ -6,6 +6,7 @@ import { type DiRender, renderFor } from "../../test-utils/renderFor";
 import { PodLogsMenu } from "../pod-logs-menu";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock } from "vitest";
 
 let showLogs: (container: { name: string }) => void = () => {};
 
@@ -22,8 +23,8 @@ vi.mock("../pod-menu-item", () => ({
 describe("pod-logs-menu", () => {
   let di: DiContainer;
   let render: DiRender;
-  let hideDetailsMock: vi.Mock;
-  let createPodLogsTabMock: vi.Mock;
+  let hideDetailsMock: Mock;
+  let createPodLogsTabMock: Mock;
 
   beforeEach(() => {
     di = getDiForUnitTesting();

--- a/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-menu-item.test.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-menu-item.test.tsx
@@ -7,6 +7,7 @@ import PodMenuItem from "../pod-menu-item";
 import type { ContainerWithType } from "@freelensapp/kube-object";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock } from "vitest";
 
 vi.mock("../../menu", async (importOriginal) => {
   const actualMenu = await importOriginal<object>();
@@ -25,7 +26,7 @@ vi.mock("../../menu", async (importOriginal) => {
 describe("pod-menu-item", () => {
   let di: DiContainer;
   let render: DiRender;
-  let callback: vi.Mock;
+  let callback: Mock;
 
   beforeEach(() => {
     di = getDiForUnitTesting();

--- a/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-shell-menu.test.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-shell-menu.test.tsx
@@ -8,6 +8,7 @@ import { type DiRender, renderFor } from "../../test-utils/renderFor";
 import { PodShellMenu } from "../pod-shell-menu";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock } from "vitest";
 
 vi.mock("uuid", () => ({
   v4: vi.fn(() => "mocked-id"),
@@ -28,9 +29,9 @@ vi.mock("../pod-menu-item", () => ({
 describe("pod-shell-menu", () => {
   let di: DiContainer;
   let render: DiRender;
-  let createTerminalTabMock: vi.Mock;
-  let sendCommandMock: vi.Mock;
-  let hideDetailsMock: vi.Mock;
+  let createTerminalTabMock: Mock;
+  let sendCommandMock: Mock;
+  let hideDetailsMock: Mock;
 
   beforeEach(() => {
     di = getDiForUnitTesting();

--- a/packages/core/src/renderer/components/welcome/new-version-notification.injectable.test.tsx
+++ b/packages/core/src/renderer/components/welcome/new-version-notification.injectable.test.tsx
@@ -13,10 +13,11 @@ import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import newVersionNotificationInjectable from "./new-version-notification.injectable";
 
 import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mock } from "vitest";
 
 describe("new-version-notification.injectable", () => {
   let di: DiContainer;
-  let showInfoMock: vi.Mock;
+  let showInfoMock: Mock;
 
   beforeEach(() => {
     di = getDiForUnitTesting();

--- a/packages/core/src/renderer/components/workloads-pods/__tests__/pod-container-env.test.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/__tests__/pod-container-env.test.tsx
@@ -14,14 +14,16 @@ import { ContainerEnvironment } from "../pod-container-env";
 
 import type { Container } from "@freelensapp/kube-object";
 
+import type { Mocked } from "vitest";
+
 import type { ConfigMapStore } from "../../config-maps/store";
 import type { SecretStore } from "../../config-secrets/store";
 import type { DiRender } from "../../test-utils/renderFor";
 
 describe("<ContainerEnv />", () => {
   let render: DiRender;
-  let secretStore: vi.Mocked<Pick<SecretStore, "load" | "getByName">>;
-  let configMapStore: vi.Mocked<Pick<ConfigMapStore, "load" | "getByName">>;
+  let secretStore: Mocked<Pick<SecretStore, "load" | "getByName">>;
+  let configMapStore: Mocked<Pick<ConfigMapStore, "load" | "getByName">>;
 
   beforeEach(() => {
     const di = getDiForUnitTesting();
@@ -39,8 +41,8 @@ describe("<ContainerEnv />", () => {
       getByName: vi.fn(),
     };
 
-    di.override(secretStoreInjectable, () => secretStore as vi.Mocked<SecretStore>);
-    di.override(configMapStoreInjectable, () => configMapStore as vi.Mocked<ConfigMapStore>);
+    di.override(secretStoreInjectable, () => secretStore as Mocked<SecretStore>);
+    di.override(configMapStoreInjectable, () => configMapStore as Mocked<ConfigMapStore>);
 
     render = renderFor(di);
   });

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -32,13 +32,53 @@
     "clean:node_modules": "pnpm dlx rimraf@6.1.3 node_modules",
     "prepack": "pnpm build:dist"
   },
+  "dependencies": {
+    "@mui/material": "^5.17.1",
+    "@ogre-tools/injectable": "^17.11.1",
+    "@ogre-tools/injectable-react": "^17.11.1",
+    "@types/chart.js": "^2.9.41",
+    "@types/history": "^4.7.11",
+    "@types/lodash": "^4.17.24",
+    "@types/node": "~24.12.4",
+    "@types/react": "^17.0.93",
+    "@types/react-router": "^5.1.20",
+    "@types/react-router-dom": "^5.3.3",
+    "@types/react-table": "^7.7.20",
+    "@types/react-window": "^1.8.8",
+    "@xterm/xterm": "^6.0.0",
+    "chart.js": "^2.9.4",
+    "conf": "^10.2.0",
+    "history": "^4.10.1",
+    "immer": "^11.1.8",
+    "lodash": "^4.18.1",
+    "mobx": "^6.15.0",
+    "mobx-observable-history": "^2.0.3",
+    "monaco-editor": "^0.54.0",
+    "node-fetch": "^3.3.2",
+    "react": "^17.0.2",
+    "react-router": "^5.3.4",
+    "react-router-dom": "^5.3.4",
+    "react-select": "^5.10.2",
+    "react-table": "^7.8.0",
+    "react-window": "^1.8.11",
+    "rfc6902": "^5.2.0",
+    "type-fest": "^5.6.0",
+    "typed-emitter": "^1.4.0"
+  },
   "devDependencies": {
     "@freelensapp/core": "workspace:^",
-    "@types/node": "~24.12.4",
     "rollup": "^4.62.2",
     "rollup-plugin-dts": "^6.4.1",
     "typescript": "^5.9.3",
     "typescript-plugin-css-modules": "^5.2.0"
+  },
+  "peerDependencies": {
+    "electron": ">=41.0.0"
+  },
+  "peerDependenciesMeta": {
+    "electron": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/extensions/scripts/build-shim.mjs
+++ b/packages/extensions/scripts/build-shim.mjs
@@ -3,17 +3,17 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-// Compiles the runtime shim (src/extension-api.ts) to a single ESM file in
-// dist/. The shim only re-exports `globalThis.FreelensExtensionApi`; its
-// imports are type-only and are elided by the transpile, so the emitted file
-// has no runtime dependencies.
+// Compiles the runtime shim (src/runtime-shim.ts) to a single ESM file in
+// dist/. The shim only re-exports `globalThis.FreelensExtensionApi`, so the
+// emitted file has no runtime dependencies. The matching types are the d.ts
+// rollup of src/extension-api.ts (see rollup.dts.config.mjs).
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import ts from "typescript";
 
 const packageRoot = path.resolve(import.meta.dirname, "..");
-const source = readFileSync(path.join(packageRoot, "src/extension-api.ts"), "utf8");
+const source = readFileSync(path.join(packageRoot, "src/runtime-shim.ts"), "utf8");
 
 const { outputText } = ts.transpileModule(source, {
   compilerOptions: {

--- a/packages/extensions/src/extension-api.ts
+++ b/packages/extensions/src/extension-api.ts
@@ -4,27 +4,31 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-// Phase 4 (D5): `@freelensapp/extensions` is a thin runtime shim over the
-// extension API. The app assigns the API object to a global at startup
-// (`globalThis.FreelensExtensionApi`, see `freelens/src/{main,renderer}/index.ts`).
-// Extensions depend on this package for types; at runtime the members resolve
-// to the global regardless of whether an extension bundles this shim or marks
-// it external.
+// Phase 4 (D5): the type-level entry of `@freelensapp/extensions`. The
+// published package pairs the d.ts rollup of this module with the runtime
+// shim (`./runtime-shim.ts`, emitted as `dist/extension-api.js`), which
+// resolves the same members from `globalThis.FreelensExtensionApi` at
+// runtime. The app assigns that global at startup (see
+// `freelens/src/{main,renderer}/index.ts`).
 //
-// The type-only imports below give extension authors the full API surface for
-// every process. At runtime `Main` is undefined in the renderer and `Renderer`
-// is undefined in the main process; extensions only touch the namespace for the
-// process they run in.
+// `Common`, `Main`, and `Renderer` are re-exported as namespaces (not consts)
+// so extension authors can use them in type positions —
+// `Renderer.Component.IconProps`, `Common.PackageJson` — exactly as with the
+// v1 extension API. At runtime `Main` is undefined in the renderer and
+// `Renderer` is undefined in the main process; extensions only touch the
+// namespace for the process they run in.
 //
-// TODO(D5): the published package ships a rolled-up, self-contained `.d.ts`
-// (e.g. `rollup-plugin-dts`) with no `@freelensapp/*` imports, since internal
-// packages become `private` in Phase 5. That declaration emit is the fiddliest
-// deliverable of this phase (see plan §6) and needs local iteration.
+// This module is never executed in the workspace (the package's runtime entry
+// everywhere is the shim); it exists for declaration emit and workspace type
+// resolution only.
 
 /// <reference path="../../core/types/mocks.d.ts" />
 
 import type { commonExtensionApi, mainExtensionApi } from "@freelensapp/core/main";
 import type { rendererExtensionApi } from "@freelensapp/core/renderer";
+
+export { commonExtensionApi as Common, mainExtensionApi as Main } from "@freelensapp/core/main";
+export { rendererExtensionApi as Renderer } from "@freelensapp/core/renderer";
 
 declare global {
   // eslint-disable-next-line no-var
@@ -34,9 +38,3 @@ declare global {
     Renderer?: typeof rendererExtensionApi;
   };
 }
-
-const api = globalThis.FreelensExtensionApi;
-
-export const Common = api.Common;
-export const Main = api.Main as typeof mainExtensionApi;
-export const Renderer = api.Renderer as typeof rendererExtensionApi;

--- a/packages/extensions/src/runtime-shim.ts
+++ b/packages/extensions/src/runtime-shim.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+// The runtime shim of `@freelensapp/extensions`, transpiled verbatim to
+// `dist/extension-api.js` (see `scripts/build-shim.mjs`). It only re-exports
+// `globalThis.FreelensExtensionApi`, which the app assigns at startup, so the
+// emitted file has no runtime dependencies. The published types come from the
+// d.ts rollup of `./extension-api.ts` instead; this file is intentionally
+// untyped beyond the ambient global declared there.
+
+const api = globalThis.FreelensExtensionApi;
+
+export const Common = api.Common;
+export const Main = api.Main!;
+export const Renderer = api.Renderer!;

--- a/packages/technical-features/application/application-for-electron-main/src/starting-of-electron-main-application.test.ts
+++ b/packages/technical-features/application/application-for-electron-main/src/starting-of-electron-main-application.test.ts
@@ -6,10 +6,12 @@ import { applicationFeatureForElectronMain } from "./feature";
 import * as timeSlots from "./start-application/time-slots";
 import whenAppIsReadyInjectable from "./start-application/when-app-is-ready.injectable";
 
+import type { Mock } from "vitest";
+
 describe("starting-of-electron-main-application", () => {
   let di: DiContainer;
-  let beforeAnythingMock: vi.Mock;
-  let beforeElectronIsReadyMock: vi.Mock;
+  let beforeAnythingMock: Mock;
+  let beforeElectronIsReadyMock: Mock;
   let beforeApplicationIsLoadingMock: AsyncFnMock<() => Promise<void>>;
   let whenAppIsReadyMock: AsyncFnMock<() => Promise<void>>;
 

--- a/packages/technical-features/messaging/messaging-fake-bridge/src/get-message-bridge-fake/get-message-bridge-fake.test.ts
+++ b/packages/technical-features/messaging/messaging-fake-bridge/src/get-message-bridge-fake/get-message-bridge-fake.test.ts
@@ -18,6 +18,8 @@ import { registerMobX } from "@ogre-tools/injectable-extension-for-mobx";
 import { runInAction } from "mobx";
 import { getMessageBridgeFake } from "./get-message-bridge-fake";
 
+import type { Mock } from "vitest";
+
 type SomeMessageChannel = MessageChannel<string>;
 type SomeRequestChannel = RequestChannel<string, number>;
 
@@ -75,9 +77,9 @@ const someRequestChannelWithoutListeners: SomeRequestChannel = {
       });
 
       describe("given there are message listeners", () => {
-        let someHandler1MockInDi1: vi.Mock;
-        let someHandler1MockInDi2: vi.Mock;
-        let someHandler2MockInDi2: vi.Mock;
+        let someHandler1MockInDi1: Mock;
+        let someHandler1MockInDi2: Mock;
+        let someHandler2MockInDi2: Mock;
         let someListener1InDi2: Injectable<unknown, unknown>;
 
         beforeEach(() => {
@@ -142,7 +144,7 @@ const someRequestChannelWithoutListeners: SomeRequestChannel = {
               : "immediately";
 
             describe(scenarioTitle, () => {
-              let someWrapper: vi.Mock;
+              let someWrapper: Mock;
 
               beforeEach(async () => {
                 someWrapper = vi.fn((propagation) => propagation());
@@ -227,7 +229,7 @@ const someRequestChannelWithoutListeners: SomeRequestChannel = {
 
           scenarioIsAsync &&
             describe("when messages are propagated using a wrapper, such as act() in react testing lib", () => {
-              let someWrapper: vi.Mock;
+              let someWrapper: Mock;
 
               beforeEach(async () => {
                 someWrapper = vi.fn((observation) => observation());

--- a/packages/technical-features/messaging/messaging-for-main/src/channel-listeners/enlist-message-channel-listener.test.ts
+++ b/packages/technical-features/messaging/messaging-for-main/src/channel-listeners/enlist-message-channel-listener.test.ts
@@ -5,12 +5,13 @@ import { messagingFeatureForMain } from "../feature";
 import ipcMainInjectable from "../ipc-main/ipc-main.injectable";
 
 import type { IpcMain, IpcMainEvent } from "electron";
+import type { Mock } from "vitest";
 
 describe("enlist message channel listener in main", () => {
   let enlistMessageChannelListener: EnlistMessageChannelListener;
   let ipcMainStub: IpcMain;
-  let onMock: vi.Mock;
-  let offMock: vi.Mock;
+  let onMock: Mock;
+  let offMock: Mock;
 
   beforeEach(() => {
     const di = createContainer("irrelevant");
@@ -31,7 +32,7 @@ describe("enlist message channel listener in main", () => {
   });
 
   describe("when called", () => {
-    let handlerMock: vi.Mock;
+    let handlerMock: Mock;
     let disposer: () => void;
 
     beforeEach(() => {

--- a/packages/technical-features/messaging/messaging-for-main/src/channel-listeners/enlist-request-channel-listener.test.ts
+++ b/packages/technical-features/messaging/messaging-for-main/src/channel-listeners/enlist-request-channel-listener.test.ts
@@ -10,6 +10,7 @@ import type { RequestChannel, RequestChannelHandler } from "@freelensapp/messagi
 
 import type { AsyncFnMock } from "@async-fn/vitest";
 import type { IpcMain, IpcMainInvokeEvent } from "electron";
+import type { Mock } from "vitest";
 
 import type { EnlistRequestChannelListener } from "./enlist-request-channel-listener.injectable";
 
@@ -22,8 +23,8 @@ const testRequestChannel: TestRequestChannel = {
 describe("enlist request channel listener in main", () => {
   let enlistRequestChannelListener: EnlistRequestChannelListener;
   let ipcMainStub: IpcMain;
-  let handleMock: vi.Mock;
-  let offMock: vi.Mock;
+  let handleMock: Mock;
+  let offMock: Mock;
 
   beforeEach(() => {
     const di = createContainer("irrelevant");

--- a/packages/technical-features/messaging/messaging-for-main/src/send-message-to-channel/send-message-to-channel.injectable.test.ts
+++ b/packages/technical-features/messaging/messaging-for-main/src/send-message-to-channel/send-message-to-channel.injectable.test.ts
@@ -6,6 +6,7 @@ import allowCommunicationListenerInjectable from "./allow-communication-listener
 import getWebContentsInjectable from "./get-web-contents.injectable";
 
 import type { WebContents } from "electron";
+import type { Mock } from "vitest";
 
 const someChannel = getMessageChannel<string>("some-channel");
 
@@ -27,8 +28,8 @@ describe("send-message-to-channel", () => {
   });
 
   describe("given web content that is alive", () => {
-    let sendToFrameMock: vi.Mock;
-    let sendMessageMock: vi.Mock;
+    let sendToFrameMock: Mock;
+    let sendMessageMock: Mock;
 
     beforeEach(() => {
       sendToFrameMock = vi.fn();

--- a/packages/technical-features/messaging/messaging-for-renderer/src/allow-communication-to-iframe.test.ts
+++ b/packages/technical-features/messaging/messaging-for-renderer/src/allow-communication-to-iframe.test.ts
@@ -8,9 +8,11 @@ import { frameCommunicationAdminChannel } from "./allow-communication-to-iframe.
 import { messagingFeatureForRenderer } from "./feature";
 import ipcRendererInjectable from "./ipc/ipc-renderer.injectable";
 
+import type { Mock } from "vitest";
+
 describe("allow communication to iframe", () => {
   let di: DiContainer;
-  let sendMessageToChannelMock: vi.Mock;
+  let sendMessageToChannelMock: Mock;
 
   beforeEach(() => {
     di = createContainer("irrelevant");

--- a/packages/technical-features/messaging/messaging-for-renderer/src/listening-of-messages/enlist-message-channel-listener.test.ts
+++ b/packages/technical-features/messaging/messaging-for-renderer/src/listening-of-messages/enlist-message-channel-listener.test.ts
@@ -5,12 +5,13 @@ import { messagingFeatureForRenderer } from "../feature";
 import ipcRendererInjectable from "../ipc/ipc-renderer.injectable";
 
 import type { IpcRenderer, IpcRendererEvent } from "electron";
+import type { Mock } from "vitest";
 
 describe("enlist message channel listener in renderer", () => {
   let enlistMessageChannelListener: EnlistMessageChannelListener;
   let ipcRendererStub: IpcRenderer;
-  let onMock: vi.Mock;
-  let offMock: vi.Mock;
+  let onMock: Mock;
+  let offMock: Mock;
 
   beforeEach(() => {
     const di = createContainer("irrelevant");
@@ -31,7 +32,7 @@ describe("enlist message channel listener in renderer", () => {
   });
 
   describe("when called", () => {
-    let handlerMock: vi.Mock;
+    let handlerMock: Mock;
     let disposer: () => void;
 
     beforeEach(() => {

--- a/packages/technical-features/messaging/messaging/src/listening-of-messages.test.ts
+++ b/packages/technical-features/messaging/messaging/src/listening-of-messages.test.ts
@@ -16,11 +16,13 @@ import {
 } from "./features/actual/message/message-channel-listener-injection-token";
 import { messagingFeatureForUnitTesting } from "./features/unit-testing";
 
+import type { Mock, MockedFunction } from "vitest";
+
 describe("listening-of-messages", () => {
   let di: DiContainer;
-  let enlistMessageChannelListenerMock: vi.MockedFunction<EnlistMessageChannelListener>;
-  let disposeSomeListenerMock: vi.Mock;
-  let disposeSomeUnrelatedListenerMock: vi.Mock;
+  let enlistMessageChannelListenerMock: MockedFunction<EnlistMessageChannelListener>;
+  let disposeSomeListenerMock: Mock;
+  let disposeSomeUnrelatedListenerMock: Mock;
 
   beforeEach(() => {
     di = createContainer("irrelevant");

--- a/packages/technical-features/messaging/messaging/src/listening-of-requests.test.ts
+++ b/packages/technical-features/messaging/messaging/src/listening-of-requests.test.ts
@@ -17,11 +17,13 @@ import {
 } from "./features/actual/request/request-channel-listener-injection-token";
 import { messagingFeatureForUnitTesting } from "./features/unit-testing";
 
+import type { Mock, MockedFunction } from "vitest";
+
 describe("listening-of-requests", () => {
   let di: DiContainer;
-  let enlistRequestChannelListenerMock: vi.MockedFunction<EnlistRequestChannelListener>;
-  let disposeSomeListenerMock: vi.Mock;
-  let disposeSomeUnrelatedListenerMock: vi.Mock;
+  let enlistRequestChannelListenerMock: MockedFunction<EnlistRequestChannelListener>;
+  let disposeSomeListenerMock: Mock;
+  let disposeSomeUnrelatedListenerMock: Mock;
 
   beforeEach(() => {
     configure({

--- a/packages/ui-components/tooltip/src/tooltip.test.tsx
+++ b/packages/ui-components/tooltip/src/tooltip.test.tsx
@@ -12,6 +12,7 @@ import { computeNextPosition, RectangleDimensions } from "./helpers";
 import { Tooltip, TooltipPosition } from "./tooltip";
 
 import type { RenderResult } from "@testing-library/react";
+import type { MockInstance } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
 const getRectangle = (parts: Omit<RectangleDimensions, "width" | "height">): RectangleDimensions => {
@@ -26,7 +27,7 @@ const getRectangle = (parts: Omit<RectangleDimensions, "width" | "height">): Rec
 };
 
 describe("<Tooltip />", () => {
-  let requestAnimationFrameSpy: jest.SpyInstance<number, [callback: FrameRequestCallback]>;
+  let requestAnimationFrameSpy: MockInstance<(callback: FrameRequestCallback) => number>;
   let user: UserEvent;
 
   beforeEach(() => {

--- a/packages/utility-features/kube-api/src/endpoints/deployment.api.test.ts
+++ b/packages/utility-features/kube-api/src/endpoints/deployment.api.test.ts
@@ -7,9 +7,11 @@
 import { KubeJsonApi } from "../kube-json-api";
 import { DeploymentApi } from "./deployment.api";
 
+import type { Mocked } from "vitest";
+
 describe("DeploymentApi", () => {
   let deploymentApi: DeploymentApi;
-  let kubeJsonApi: vi.Mocked<KubeJsonApi>;
+  let kubeJsonApi: Mocked<KubeJsonApi>;
 
   beforeEach(() => {
     kubeJsonApi = {

--- a/packages/utility-features/kube-api/src/kube-api.test.ts
+++ b/packages/utility-features/kube-api/src/kube-api.test.ts
@@ -17,6 +17,7 @@ import type { Logger } from "@freelensapp/logger";
 
 import type { AsyncFnMock } from "@async-fn/vitest";
 import type Fetch from "node-fetch";
+import type { MockedFunction } from "vitest";
 
 import type { KubeApiWatchCallback } from "./kube-api";
 import type { IKubeWatchEvent } from "./kube-watch-event";
@@ -480,7 +481,7 @@ describe("KubeApi", () => {
 
     describe("when watching in a namespace", () => {
       let stopWatch: () => void;
-      let callback: vi.MockedFunction<KubeApiWatchCallback>;
+      let callback: MockedFunction<KubeApiWatchCallback>;
 
       beforeEach(async () => {
         callback = vi.fn();
@@ -585,7 +586,7 @@ describe("KubeApi", () => {
     });
 
     describe("when watching in a namespace with an abort controller provided", () => {
-      let callback: vi.MockedFunction<KubeApiWatchCallback>;
+      let callback: MockedFunction<KubeApiWatchCallback>;
       let abortController: AbortController;
 
       beforeEach(async () => {
@@ -690,7 +691,7 @@ describe("KubeApi", () => {
 
     describe("when watching in a namespace with a timeout", () => {
       let stopWatch: () => void;
-      let callback: vi.MockedFunction<KubeApiWatchCallback>;
+      let callback: MockedFunction<KubeApiWatchCallback>;
 
       beforeEach(async () => {
         callback = vi.fn();

--- a/packages/utility-features/run-many/src/run-many-sync-for.test.ts
+++ b/packages/utility-features/run-many/src/run-many-sync-for.test.ts
@@ -7,11 +7,13 @@
 import { createContainer, getInjectable, getInjectionToken } from "@ogre-tools/injectable";
 import { runManySyncFor } from "./run-many-sync-for";
 
+import type { Mock } from "vitest";
+
 import type { RunnableSync } from "./types";
 
 describe("runManySyncFor", () => {
   describe("given hierarchy, when running many", () => {
-    let runMock: vi.Mock;
+    let runMock: Mock;
 
     beforeEach(() => {
       const rootDi = createContainer("irrelevant");
@@ -51,7 +53,7 @@ describe("runManySyncFor", () => {
   });
 
   describe("given hierarchy that is three levels deep, when running many", () => {
-    let runMock: vi.Mock<(arg: string) => void>;
+    let runMock: Mock<(arg: string) => void>;
 
     beforeEach(() => {
       const di = createContainer("irrelevant");
@@ -140,7 +142,7 @@ describe("runManySyncFor", () => {
   });
 
   describe("when running many with parameter", () => {
-    let runMock: vi.Mock<(arg: string, arg2: string) => undefined>;
+    let runMock: Mock<(arg: string, arg2: string) => undefined>;
 
     beforeEach(() => {
       const rootDi = createContainer("irrelevant");

--- a/packages/utility-features/startable-stoppable/src/get-startable-stoppable.test.ts
+++ b/packages/utility-features/startable-stoppable/src/get-startable-stoppable.test.ts
@@ -1,10 +1,12 @@
 import { getStartableStoppable } from "./get-startable-stoppable";
 
+import type { MockedFunction } from "vitest";
+
 import type { StartableStoppable } from "./get-startable-stoppable";
 
 describe("getStartableStoppable", () => {
-  let stopMock: vi.MockedFunction<() => void>;
-  let startMock: vi.MockedFunction<() => () => void>;
+  let stopMock: MockedFunction<() => void>;
+  let startMock: MockedFunction<() => () => void>;
   let actual: StartableStoppable;
 
   beforeEach(() => {

--- a/packages/utility-features/utilities/src/observable-crate.test.ts
+++ b/packages/utility-features/utilities/src/observable-crate.test.ts
@@ -6,6 +6,8 @@
 
 import { observableCrate } from "./observable-crate";
 
+import type { MockedFunction } from "vitest";
+
 import type { ObservableCrate } from "./observable-crate";
 
 describe("observable-crate", () => {
@@ -33,8 +35,8 @@ describe("observable-crate", () => {
     }
 
     let crate: ObservableCrate<Test>;
-    let correctHandler: vi.MockedFunction<() => void>;
-    let incorrectHandler: vi.MockedFunction<() => void>;
+    let correctHandler: MockedFunction<() => void>;
+    let incorrectHandler: MockedFunction<() => void>;
 
     beforeEach(() => {
       correctHandler = vi.fn();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1035,13 +1035,107 @@ importers:
         version: 5.9.3
 
   packages/extensions:
+    dependencies:
+      '@mui/material':
+        specifier: ^5.17.1
+        version: 5.17.1(@emotion/react@11.14.0(@types/react@17.0.93)(react@17.0.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@17.0.93)(react@17.0.2))(@types/react@17.0.93)(react@17.0.2))(@types/react@17.0.93)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@ogre-tools/injectable':
+        specifier: ^17.11.1
+        version: 17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(lodash@4.18.1)
+      '@ogre-tools/injectable-react':
+        specifier: ^17.11.1
+        version: 17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(@ogre-tools/injectable@17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(lodash@4.18.1))(lodash@4.18.1)(mobx-react@7.6.0(mobx@6.15.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(mobx@6.15.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@types/chart.js':
+        specifier: ^2.9.41
+        version: 2.9.41
+      '@types/history':
+        specifier: ^4.7.11
+        version: 4.7.11
+      '@types/lodash':
+        specifier: ^4.17.24
+        version: 4.17.24
+      '@types/node':
+        specifier: ~24.12.4
+        version: 24.12.4
+      '@types/react':
+        specifier: ^17.0.93
+        version: 17.0.93
+      '@types/react-router':
+        specifier: ^5.1.20
+        version: 5.1.20
+      '@types/react-router-dom':
+        specifier: ^5.3.3
+        version: 5.3.3
+      '@types/react-table':
+        specifier: ^7.7.20
+        version: 7.7.20
+      '@types/react-window':
+        specifier: ^1.8.8
+        version: 1.8.8
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0(patch_hash=fb7ebbc29ef246137af8ea109596e698df4691ccaa0b87ed5969259bcb27e435)
+      chart.js:
+        specifier: ^2.9.4
+        version: 2.9.4
+      conf:
+        specifier: ^10.2.0
+        version: 10.2.0
+      electron:
+        specifier: '>=41.0.0'
+        version: 41.10.0
+      history:
+        specifier: ^4.10.1
+        version: 4.10.1
+      immer:
+        specifier: ^11.1.8
+        version: 11.1.8
+      lodash:
+        specifier: ^4.18.1
+        version: 4.18.1
+      mobx:
+        specifier: ^6.15.0
+        version: 6.15.0
+      mobx-observable-history:
+        specifier: ^2.0.3
+        version: 2.0.3
+      monaco-editor:
+        specifier: ^0.54.0
+        version: 0.54.0
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
+      react:
+        specifier: ^17.0.2
+        version: 17.0.2
+      react-router:
+        specifier: ^5.3.4
+        version: 5.3.4(react@17.0.2)
+      react-router-dom:
+        specifier: ^5.3.4
+        version: 5.3.4(react@17.0.2)
+      react-select:
+        specifier: ^5.10.2
+        version: 5.10.2(@types/react@17.0.93)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react-table:
+        specifier: ^7.8.0
+        version: 7.8.0(react@17.0.2)
+      react-window:
+        specifier: ^1.8.11
+        version: 1.8.11(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      rfc6902:
+        specifier: ^5.2.0
+        version: 5.2.0
+      type-fest:
+        specifier: ^5.6.0
+        version: 5.6.0
+      typed-emitter:
+        specifier: ^1.4.0
+        version: 1.4.0
     devDependencies:
       '@freelensapp/core':
         specifier: workspace:^
         version: link:../core
-      '@types/node':
-        specifier: ~24.12.4
-        version: 24.12.4
       rollup:
         specifier: ^4.62.2
         version: 4.62.2


### PR DESCRIPTION
Continues #2102 on the v2 branch (Phase 4 completion plus a Phase 7 item from docs/v2-plan.md).

- Common/Main/Renderer are re-exported as real namespaces so they work in type positions (Renderer.Component.IconProps, Common.PackageJson) exactly as in the v1 API; the runtime shim moves to src/runtime-shim.ts and stays a dependency-free ESM file.
- The bundled extension-api.d.ts loses its conf/dist/source deep import and the invalid PackageJson namespace re-export (TS2708).
- @freelensapp/extensions declares its ~30 type-level dependencies; electron is an optional peer.
- The extension migration guide documents the loader semantics (require(esm), no top-level await), the consumer tsconfig floors, and the namespace-type usage.
- The 69 test files with vi.Mocked/vi.Mock/vi.MockedFunction type-annotation artifacts now import the types from vitest; the last jest.SpyInstance is gone.

Verified: strict-mode scratch consumer type-checks against the bundled d.ts; affected Vitest projects green; electron-vite build green.

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-fable-5`