### PR TITLE
Bump version to 2.0.0-0

### DIFF
--- a/freelens/package.json
+++ b/freelens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freelens",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Freelens - Free IDE for Kubernetes",
   "keywords": [],

--- a/packages/business-features/keyboard-shortcuts/package.json
+++ b/packages/business-features/keyboard-shortcuts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/keyboard-shortcuts",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Keyboard shortcuts for Freelens",
   "homepage": "https://freelens.app",

--- a/packages/cluster-settings/package.json
+++ b/packages/cluster-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/cluster-settings",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Injection token exporter for cluster settings configuration",
   "homepage": "https://freelens.app",

--- a/packages/cluster-sidebar/package.json
+++ b/packages/cluster-sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/cluster-sidebar",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Injection tokens for adding new sidebar items within the Cluster View",
   "homepage": "https://freelens.app",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/core",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Freelens Core",
   "keywords": [],

--- a/packages/ensure-binaries/package.json
+++ b/packages/ensure-binaries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/ensure-binaries",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "CLI for downloading configured versions of the bundled versions of CLIs",
   "homepage": "https://freelens.app",

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/extensions",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "description": "Freelens - Free IDE for Kubernetes: extensions",
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/generate-license/package.json
+++ b/packages/generate-license/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/generate-license",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "CLI for generating license files",
   "homepage": "https://freelens.app",

--- a/packages/generate-tray-icons/package.json
+++ b/packages/generate-tray-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/generate-tray-icons",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "CLI generating tray icons for building a lens-like application",
   "homepage": "https://freelens.app",

--- a/packages/infrastructure/typescript/package.json
+++ b/packages/infrastructure/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/typescript",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Typescript configuration for Freelens packages.",
   "homepage": "https://freelens.app",

--- a/packages/kube-object/package.json
+++ b/packages/kube-object/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/kube-object",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Injection tokens for list layout",
   "homepage": "https://freelens.app",

--- a/packages/kubectl-versions/package.json
+++ b/packages/kubectl-versions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/kubectl-versions",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Package of kubectl versions at build time",
   "homepage": "https://freelens.app",

--- a/packages/legacy-global-di/package.json
+++ b/packages/legacy-global-di/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/legacy-global-di",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Injection tokens for implementing metrics for Freelens",
   "homepage": "https://freelens.app",

--- a/packages/list-layout/package.json
+++ b/packages/list-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/list-layout",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Injection tokens for list layout",
   "homepage": "https://freelens.app",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/logger",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable logger in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/metrics",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Injection tokens for implementing metrics for Freelens",
   "homepage": "https://freelens.app",

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/random",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable random in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/resource-templates/package.json
+++ b/packages/resource-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/resource-templates",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "homepage": "https://freelens.app",
   "bugs": {

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/routing",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable routing in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/semver",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "CLI over semver package for picking parts of a version",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/application/application-for-electron-main/package.json
+++ b/packages/technical-features/application/application-for-electron-main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/application-for-electron-main",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Electron's main specifics for creating Freelens applications",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/application/application/package.json
+++ b/packages/technical-features/application/application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/application",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Package for creating Freelens applications",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/application/legacy-extensions/package.json
+++ b/packages/technical-features/application/legacy-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/legacy-extensions",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Package for Lens extensions using the v1 API",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/feature-core/package.json
+++ b/packages/technical-features/feature-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/feature-core",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Code that is common to all Features and those registering them.",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/messaging/computed-channel/package.json
+++ b/packages/technical-features/messaging/computed-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/computed-channel",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "MobX-like computed between channels",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/messaging/messaging-fake-bridge/package.json
+++ b/packages/technical-features/messaging/messaging-fake-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/messaging-fake-bridge",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Fake implementation to bridge multiple dependency injection containers.",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/messaging/messaging-for-main/package.json
+++ b/packages/technical-features/messaging/messaging-for-main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/messaging-for-main",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Implementations for 'messaging' in Electron main",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/messaging/messaging-for-renderer/package.json
+++ b/packages/technical-features/messaging/messaging-for-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/messaging-for-renderer",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Implementations for 'messaging' in Electron renderer",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/messaging/messaging/package.json
+++ b/packages/technical-features/messaging/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/messaging",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "An abstraction for messaging between Lens environments",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/prometheus/package.json
+++ b/packages/technical-features/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/prometheus",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Prometheus support for Freelens",
   "homepage": "https://freelens.app",

--- a/packages/technical-features/react-application/package.json
+++ b/packages/technical-features/react-application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/react-application",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Package for React Application",
   "homepage": "https://freelens.app",

--- a/packages/ui-components/animate/package.json
+++ b/packages/ui-components/animate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/animate",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable animate in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/ui-components/button/package.json
+++ b/packages/ui-components/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/button",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable button in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/ui-components/error-boundary/package.json
+++ b/packages/ui-components/error-boundary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/error-boundary",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable error-boundary in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/ui-components/icon/package.json
+++ b/packages/ui-components/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/icon",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable icon in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/ui-components/notifications/package.json
+++ b/packages/ui-components/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/notifications",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable notifications in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/ui-components/resizing-anchor/package.json
+++ b/packages/ui-components/resizing-anchor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/resizing-anchor",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable resizing-anchor in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/ui-components/spinner/package.json
+++ b/packages/ui-components/spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/spinner",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable spinner in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/ui-components/tooltip/package.json
+++ b/packages/ui-components/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/tooltip",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Highly extendable tooltip in the Freelens.",
   "homepage": "https://freelens.app",

--- a/packages/utility-features/event-emitter/package.json
+++ b/packages/utility-features/event-emitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/event-emitter",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Event emitter",
   "homepage": "https://freelens.app",

--- a/packages/utility-features/json-api/package.json
+++ b/packages/utility-features/json-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/json-api",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "JSON api client",
   "homepage": "https://freelens.app",

--- a/packages/utility-features/kube-api-specifics/package.json
+++ b/packages/utility-features/kube-api-specifics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/kube-api-specifics",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Kube api",
   "homepage": "https://freelens.app",

--- a/packages/utility-features/kube-api/package.json
+++ b/packages/utility-features/kube-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/kube-api",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "Kube api",
   "homepage": "https://freelens.app",

--- a/packages/utility-features/react-testing-library-discovery/package.json
+++ b/packages/utility-features/react-testing-library-discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/react-testing-library-discovery",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "A way to discover HTML-elements using react-testing-library",
   "homepage": "https://freelens.app",

--- a/packages/utility-features/run-many/package.json
+++ b/packages/utility-features/run-many/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/run-many",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "A package containing runMany and runManySync",
   "homepage": "https://freelens.app",

--- a/packages/utility-features/startable-stoppable/package.json
+++ b/packages/utility-features/startable-stoppable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/startable-stoppable",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "TBD",
   "homepage": "https://freelens.app",

--- a/packages/utility-features/test-utils/package.json
+++ b/packages/utility-features/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/test-utils",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "A collection of utilities for testing",
   "homepage": "https://freelens.app",

--- a/packages/utility-features/utilities/package.json
+++ b/packages/utility-features/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelensapp/utilities",
-  "version": "1.10.4-0",
+  "version": "2.0.0-0",
   "private": true,
   "description": "A collection of useful types",
   "homepage": "https://freelens.app",


### PR DESCRIPTION
Bump all workspace packages from `1.10.4-0` to `2.0.0-0` for the v2 line.

## Changes

- Ran `pnpm bump-version 2.0.0-0`, which sets the `version` field of every workspace `package.json` (48 files) to `2.0.0-0`.
- Cross-package dependencies use `workspace:^`, so no `pnpm-lock.yaml` change is required and none is included.

## Validation

- `git diff` contains only `"version": "1.10.4-0"` → `"version": "2.0.0-0"` lines (48 insertions / 48 deletions), nothing else.
- `trunk`/biome clean on the changed files.

Targets the `v2` branch.