### PR TITLE
Remove unused electron-winstaller from pnpm allowBuilds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,10 @@
-
 packages:
   - freelens
   - packages/**
+
 allowBuilds:
   '@parcel/watcher': true
   electron: true
-  electron-winstaller: true
   node-pty: true
   sharp: true
 


### PR DESCRIPTION
## What

- Remove `electron-winstaller` from `allowBuilds` in `pnpm-workspace.yaml`.
- Normalize the file formatting: drop the leading blank line and keep a single blank line before each top-level option.

## Why

`electron-winstaller` is a **transitive dependency only** — nothing in the workspace references it (it appears solely in `allowBuilds` and the lockfile). Freelens packages its releases with **electron-builder**, not the Squirrel.Windows / `electron-winstaller` flow, so its install script (`select-7z-arch.js`) is never invoked. Approving it in `allowBuilds` therefore had no effect on the build — this drops a dead entry.

The remaining `allowBuilds` entries are unchanged:

- `electron` — required (its postinstall downloads and extracts the Electron binary).
- `node-pty`, `sharp`, `@parcel/watcher` — kept as a cheap safety net for the build-from-source fallback path (currently no-ops because each ships prebuilt platform binaries).

## Notes

This is the safe, self-contained part of a wider review of pnpm build-script approvals. Larger follow-ups (e.g. re-evaluating the `electron-rebuild`/node-gyp step, which only targets the N-API `node-pty` whose rebuilt output is already discarded at packaging) are intentionally **out of scope** here because they need cross-platform verification.

No lockfile change: `allowBuilds` does not affect resolution. On the next install pnpm simply moves `electron-winstaller` to its ignored-builds list.

Validated with `pnpm trunk check pnpm-workspace.yaml` (no issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
