### PR TITLE
Register the Tailwind PostCSS plugin in the Vite renderer CSS pipeline

### DIFF
--- a/freelens/electron.vite.config.ts
+++ b/freelens/electron.vite.config.ts
@@ -33,6 +33,7 @@ import { readFileSync } from "node:fs";
 import { builtinModules, createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import tailwindcss from "@tailwindcss/postcss";
 import react from "@vitejs/plugin-react";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 
@@ -365,6 +366,16 @@ export default defineConfig({
       },
     },
     css: {
+      // D11: port the Tailwind PostCSS plugin from the old webpack pipeline
+      // (packages/core/webpack/renderer.ts ran sass-loader -> postcss-loader
+      // with @tailwindcss/postcss -> css-loader). Vite handles the sass step
+      // via sass-embedded on its own, but the PostCSS plugin must be
+      // registered explicitly; without it the `@import "tailwindcss"`,
+      // `@config` and `@apply` directives used across the core SCSS are left
+      // unprocessed and Tailwind utilities emit no CSS.
+      postcss: {
+        plugins: [tailwindcss()],
+      },
       // D11: preserve CSS Modules scoped names; code accesses kebab-case
       // keys, so no localsConvention. auto: /\.module\./ is Vite's default.
       modules: { generateScopedName: "[name]__[local]--[hash:base64:5]" },

--- a/freelens/package.json
+++ b/freelens/package.json
@@ -137,6 +137,7 @@
     "@freelensapp/tooltip": "workspace:^",
     "@freelensapp/utilities": "workspace:^",
     "@ogre-tools/injectable-react": "^17.11.1",
+    "@tailwindcss/postcss": "^4.2.4",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash": "^4.17.24",
     "@types/node": "~24.12.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       '@ogre-tools/injectable-react':
         specifier: ^17.11.1
         version: 17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(@ogre-tools/injectable@17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(lodash@4.18.1))(lodash@4.18.1)(mobx-react@7.6.0(mobx@6.15.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(mobx@6.15.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@tailwindcss/postcss':
+        specifier: ^4.2.4
+        version: 4.2.4
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4


### PR DESCRIPTION
## Summary

Fixes #2138.

The v2 electron-vite migration (decision D11 in docs/v2-plan.md) was meant to port the old webpack CSS pipeline into Vite. The webpack pipeline (packages/core/webpack/renderer.ts) ran sass-loader -> postcss-loader with the @tailwindcss/postcss plugin -> css-loader. Vite handles the sass step via sass-embedded automatically, but the Tailwind PostCSS plugin was never wired into freelens/electron.vite.config.ts.

As a result the @import "tailwindcss", @config and @apply directives used across the core SCSS (app.scss, list.module.scss, sidebar.module.scss, ...) were emitted unprocessed and Tailwind utilities produced no CSS - so CSS was generally broken in v2.

## Changes

- Register @tailwindcss/postcss in the renderer css.postcss.plugins of freelens/electron.vite.config.ts.
- Declare @tailwindcss/postcss as a devDependency of the freelens app so the config import resolves.

## Verification

Compiled packages/core/src/renderer/components/app.scss through sass-embedded + PostCSS(@tailwindcss/postcss) and confirmed Tailwind utilities (.flex, .items-center) are now generated (~22 KB of processed CSS).

Base branch is v2.

Generated with [Claude Code](https://claude.ai/code)