### PR TITLE
Establish v2 styling conventions and auto-inject extension stylesheets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,27 @@ Uses pnpm workspaces for:
 - Faster builds
 - Type safety across packages
 
+## Styling
+
+Freelens v2 carries four styling systems (theme CSS custom properties, global
+plain SCSS, CSS Modules, and Tailwind v4), plus legacy `flexbox.scss`
+utilities. Which one to use is not a matter of taste — each has a defined role.
+Before adding or changing any stylesheet or `className`, read
+[`docs/v2-styling.md`](./docs/v2-styling.md). In short:
+
+- **Theme values** (colors, fonts): CSS custom properties from the TS theme
+  system (`var(--…)`) — the single contract every other system reads.
+- **Shared components** (`packages/ui-components`) and anything an extension
+  may restyle: global PascalCase class + plain SCSS + `var(--…)`. No Tailwind
+  (its JIT only scans core TSX), no CSS Modules (the class names are public
+  API).
+- **Core single components / full views**: CSS Modules (`*.module.scss`).
+- **Local layout inside core-only TSX**: Tailwind utilities. Do not add new
+  `flexbox.scss` usages (that file is frozen for extension compatibility) and
+  do not mix the two utility vocabularies in one `className`.
+- **Extensions**: see the styling section of
+  [`docs/v2-extension-migration.md`](./docs/v2-extension-migration.md).
+
 ## Best Practices
 
 1. **Always regenerate DI files** after adding/moving injectables

--- a/docs/v2-extension-migration.md
+++ b/docs/v2-extension-migration.md
@@ -105,10 +105,65 @@ namespace path, re-check it against the current
 between `Common`, `Main`, and `Renderer`. The concrete rename table is filled
 in from the freelens-example-extension port and will be appended here.
 
+## Styling and CSS
+
+In v1 the extension bundler ran a `style-loader`, which injected each imported
+stylesheet into the document at runtime. In v2 extensions are built by their
+authors in Vite **library mode**, which does the opposite: it *extracts* CSS to
+a sibling asset next to the JS entry and injects nothing. The host loads an
+extension by `require()`-ing its JS entry, so without help that extracted CSS
+would never reach the page — which is why early v2 extensions had to import
+each stylesheet twice and inline it through a manual `<style>` tag:
+
+```tsx
+// The workaround you no longer need:
+import styles from "./available-version.module.scss"; // mangled class names
+import stylesInline from "./available-version.module.scss?inline"; // raw CSS text
+// ...
+<style>{stylesInline}</style>;
+```
+
+**The host now injects the extension's stylesheet for you.** When the renderer
+loads an extension, the extension loader looks next to the renderer entry for a
+sibling stylesheet — either `<entry-name>.css` (e.g. `renderer.js` →
+`renderer.css`) or a `style.css` in the same folder — and, if present, appends
+its contents to the document as a `<style>` element. So you can import your
+SCSS the normal way and drop the `?inline` copy and the `<style>` tag:
+
+```tsx
+import styles from "./available-version.module.scss"; // class names only
+// no ?inline import, no <style> tag — the host loads the emitted CSS
+```
+
+To rely on this, make your Vite library build emit **one** CSS asset next to
+the renderer entry:
+
+- Keep Vite's default single-file CSS extraction (it emits `style.css`), or
+  name it after the entry. Either is picked up automatically.
+- If your build splits CSS per module (for example with
+  `output.preserveModules: true`), consolidate it into a single asset, or add a
+  runtime CSS-injection plugin such as `vite-plugin-css-injected-by-js` (which
+  embeds the CSS into the JS bundle and injects it itself — also fine, since
+  extensions run in the host window).
+
+Use **CSS Modules** (`*.module.scss`) to scope an extension's own component
+styles; the class names are mangled at build time so they never collide with
+the host or with other extensions. For the host's shared component classes
+(`.Tooltip`, `.Button`, …), which are global and part of the public API, you
+may target them directly — do not redefine them. See
+[`docs/v2-styling.md`](./v2-styling.md) for the full styling model.
+
+> Note: Tailwind utilities do **not** work in extensions. The host's Tailwind
+> JIT only scans core's own source, so a Tailwind class in an extension emits
+> no CSS. Write extension styles as SCSS/CSS.
+
 ## Checklist
 
 - [ ] Replace any direct `@freelensapp/*` internal dependency with
       `@freelensapp/extensions` (types only).
+- [ ] Import stylesheets normally (side-effect or CSS-module import); drop any
+      `?inline` + `<style>` CSS workaround, and make sure your build emits a
+      single CSS asset next to the renderer entry.
 - [ ] Confirm your entrypoints are ESM or CommonJS and, if ESM, that
       `package.json` declares it.
 - [ ] Access only the process-appropriate namespace (`Main` in main,

--- a/docs/v2-styling.md
+++ b/docs/v2-styling.md
@@ -1,0 +1,128 @@
+# Styling conventions in Freelens v2
+
+This document is the canonical guide for **how to style UI in Freelens v2**.
+It exists because the v2 Vite migration (see [`docs/v2-plan.md`](./v2-plan.md),
+decision **D11**) carried four different styling systems forward, and without a
+written contract new code drifts between them. Read this before adding or
+changing any stylesheet or `className`.
+
+## The styling systems in play
+
+Four mechanisms coexist. They are not interchangeable — each has a distinct
+role (see [Roles](#roles-which-mechanism-to-use)):
+
+1. **Theme tokens (CSS custom properties).** The TS theme objects
+   (`packages/core/src/renderer/themes/lens-dark.injectable.ts`, `lens-light…`)
+   are written to `:root` as `--<name>` custom properties at runtime by
+   `themes/apply-lens-theme.injectable.ts`. Everything else reads these:
+   SCSS as `var(--textColorPrimary)`, Tailwind through the four bridged color
+   utilities. **This layer is the one contract all other systems agree on** —
+   it is what makes theming work regardless of which mechanism draws a rule.
+2. **Global plain SCSS** (~200 files). Side-effect `import "./pods.scss"`,
+   scoped by convention: one PascalCase root class matching the component
+   (`.Pods`, `.Drawer`, `.IngressDetails`) with plain nested selectors inside.
+3. **CSS Modules** (`*.module.scss`). Mangled class names via
+   `generateScopedName: "[name]__[local]--[hash:base64:5]"`
+   (`freelens/electron.vite.config.ts`). The component imports the generated
+   name map and references `styles.someClass`.
+4. **Tailwind v4** utilities. `@import "tailwindcss"` + `@config` live only in
+   `packages/core/src/renderer/components/app.scss`; utility classes appear
+   inline in core TSX.
+
+A fifth, legacy layer overlaps Tailwind: the in-house **flexbox utilities**
+(`packages/core/src/renderer/components/flexbox.scss` — `.flex`, `.column`,
+`.gaps`, `.align-center`, `.box`, `.grow`). They predate Tailwind and are still
+loaded globally. See [Utility vocabulary](#utility-vocabulary-flexboxscss-vs-tailwind).
+
+## Roles: which mechanism to use
+
+| Context | Mechanism | Why |
+|---|---|---|
+| Theme values (colors, fonts, spacing tokens) | CSS custom properties from the TS theme system (`var(--…)`) | The single cross-system contract; the only way a value re-themes at runtime |
+| **Shared components** (`packages/ui-components`) and anything an extension may restyle | Global PascalCase class + plain SCSS + `var(--…)`. **No Tailwind, no CSS Modules** | The class names (`.Tooltip`, `.Button`, `.Icon`) are **public API** — extensions target and override them; mangled ids would break that. Tailwind cannot reach here at all (see below) |
+| **Core single components / full views** | CSS Modules (`*.module.scss`, mangled ids) | Component-private styling that should not leak into the global namespace |
+| Local layout/spacing **inside core-only TSX** | Tailwind utilities | Throwaway layout that never needs to be themed beyond the bridged tokens or restyled from outside |
+| Extensions | CSS Modules + a working injection mechanism | See [`docs/v2-extension-migration.md`](./v2-extension-migration.md#styling-and-css) |
+
+So the answer to "Tailwind or mangled CSS ids?" is **both, with a boundary**:
+Tailwind for disposable layout in core-only TSX; CSS Modules for anything that
+*is* a component's styling; global classes only where the class name is part of
+the public surface.
+
+### Why Tailwind is core-only
+
+`packages/core/tailwind.config.js` sets `content: ["src/**/*.tsx"]`, so the
+Tailwind JIT scans **only core's own TSX**. A Tailwind class written in
+`packages/ui-components` or in an extension that core does not *also* happen to
+use produces **no CSS** — it silently does nothing. Never use Tailwind
+utilities outside core TSX.
+
+### Why ui-components stay global
+
+The shared components in `packages/ui-components` all follow one pattern —
+side-effect `import "./tooltip.scss"`, a global PascalCase class via
+`cssNames("Tooltip", …)`, colors from `var(--…)`. Keep it. The class names are
+consumed by extensions and by the host's already-loaded global stylesheet;
+mangling them (CSS Modules) or moving them to Tailwind (unreachable, above)
+would break that public contract.
+
+## Utility vocabulary: flexbox.scss vs Tailwind
+
+The most common inconsistency today is mixing three utility vocabularies in a
+single `className`, e.g. `className="flex justify-center Welcome align-center"`
+— `justify-center` is Tailwind, `align-center` is legacy `flexbox.scss`,
+`Welcome` is a global component class. Near-synonyms (`align-center` vs
+`items-center`, `column` vs `flex-col`) invite silent mistakes.
+
+Convention going forward:
+
+- **In new or touched core TSX, use Tailwind for layout utilities**
+  (`flex`, `items-center`, `justify-center`, `flex-col`, `gap-*`). Do not
+  reach for `flexbox.scss` classes.
+- **Do not delete `flexbox.scss`.** Its classes are extension-visible
+  (shared components such as `error-boundary` ship `"flex column gaps"`), so
+  removing it is a breaking change. It is **frozen**: no new usages in core,
+  migrate existing ones opportunistically.
+- Do not mix the two vocabularies in the same `className`.
+
+## Tailwind configuration caveats
+
+- **Only four theme colors are bridged into Tailwind**
+  (`textAccent`, `textPrimary`, `textTertiary`, `textDimmed` in
+  `tailwind.config.js`). Tailwind cannot express any other themable color —
+  for those, use `var(--…)` in a stylesheet. Do not hardcode colors in
+  Tailwind utilities.
+- **Dark mode follows the real theme mechanism.** The theme system toggles
+  `body.theme-light` (dark is the default, light adds the class). The
+  Tailwind `dark:` variant is wired to that selector via `@custom-variant`
+  in `app.scss`; a bare `darkMode: "class"` (expecting a `.dark` class) would
+  be dead. Prefer `var(--…)` theme tokens over `dark:` variants — the token
+  layer already re-themes automatically, which is why `dark:` is rarely
+  needed.
+
+## `@apply` in stylesheets
+
+Seven SCSS files use `@apply` (`table/react-table.scss`,
+`layout/sidebar.module.scss`, `catalog/catalog.module.scss`, …), which couples
+the stylesheet to the Tailwind build for rules that are usually shorter as
+plain CSS (`@apply flex items-center` → `display: flex; align-items: center;`).
+Avoid `@apply` in new stylesheets; prefer plain CSS so the SCSS does not depend
+on the Tailwind pipeline. Existing usages can be inlined opportunistically.
+
+## Inline styles
+
+Inline `style={{…}}` is fine when the value is genuinely dynamic (progress-bar
+widths, tree-indentation depth). Do not use it for static styling that belongs
+in a stylesheet.
+
+## Cleanup backlog (opportunistic, no big-bang migration)
+
+- New/touched core components use idiomatic CSS Modules (one class per rule),
+  not a single mangled wrapper written in the global idiom.
+- Convert the same-directory inconsistent pairs first
+  (`network-ingresses/`, `events/` have a `.module.scss` next to a plain
+  `.scss` for structurally identical components).
+- Pick **one** loading mechanism for `packages/ui-components` styles — the
+  component-level side-effect import *or* the `/styles` entry re-import in
+  `freelens/src/renderer/index.ts`, not both.
+- Inline the seven `@apply` usages.

--- a/packages/core/src/extensions/extension-loader/extension-loader.injectable.ts
+++ b/packages/core/src/extensions/extension-loader/extension-loader.injectable.ts
@@ -7,6 +7,8 @@
 import { bundledExtensionInjectionToken } from "@freelensapp/legacy-extensions";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
+import pathExistsInjectable from "../../common/fs/path-exists.injectable";
+import readFileInjectable from "../../common/fs/read-file.injectable";
 import getDirnameOfPathInjectable from "../../common/path/get-dirname.injectable";
 import joinPathsInjectable from "../../common/path/join-paths.injectable";
 import updateExtensionsStateInjectable from "../../features/extensions/enabled/common/update-state.injectable";
@@ -28,6 +30,8 @@ const extensionLoaderInjectable = getInjectable({
       logger: di.inject(loggerInjectionToken),
       joinPaths: di.inject(joinPathsInjectable),
       getDirnameOfPath: di.inject(getDirnameOfPathInjectable),
+      readFile: di.inject(readFileInjectable),
+      pathExists: di.inject(pathExistsInjectable),
     }),
 });
 

--- a/packages/core/src/extensions/extension-loader/extension-loader.ts
+++ b/packages/core/src/extensions/extension-loader/extension-loader.ts
@@ -31,6 +31,8 @@ import type { Logger } from "@freelensapp/logger";
 
 import type { ObservableMap } from "mobx";
 
+import type { PathExists } from "../../common/fs/path-exists.injectable";
+import type { ReadFile } from "../../common/fs/read-file.injectable";
 import type { GetDirnameOfPath } from "../../common/path/get-dirname.injectable";
 import type { JoinPaths } from "../../common/path/join-paths.injectable";
 import type { UpdateExtensionsState } from "../../features/extensions/enabled/common/update-state.injectable";
@@ -56,6 +58,8 @@ interface Dependencies {
   getExtension: (instance: LegacyLensExtension) => Extension;
   joinPaths: JoinPaths;
   getDirnameOfPath: GetDirnameOfPath;
+  readFile: ReadFile;
+  pathExists: PathExists;
 }
 
 interface ExtensionBeingActivated {
@@ -90,6 +94,11 @@ export class ExtensionLoader {
   );
 
   private readonly onRemoveExtensionId = new EventEmitter<[string]>();
+
+  // Absolute paths of extension stylesheets already injected into the renderer
+  // document, so a reload (the toJSON reaction re-requires user extensions)
+  // does not append the same <style> twice.
+  private readonly injectedStylePaths = new Set<string>();
 
   readonly isLoaded = observable.box(false);
 
@@ -409,7 +418,17 @@ export class ExtensionLoader {
     );
 
     try {
-      return extensionRequire(extAbsolutePath).default;
+      const extensionModule = extensionRequire(extAbsolutePath);
+
+      // Load the extension's renderer stylesheet, if any. Extensions are built
+      // in Vite library mode, which extracts CSS to a sibling asset and injects
+      // nothing (unlike the host's own application build). Without this, an
+      // extension has to import its SCSS twice and inline it through a manual
+      // `<style>` tag (see docs/v2-extension-migration.md). Fire-and-forget:
+      // requiring the entry is synchronous, style injection is a side effect.
+      void this.injectRendererStyles(extAbsolutePath, extension);
+
+      return extensionModule.default;
     } catch (error) {
       const message = (error instanceof Error ? error.stack : undefined) || error;
 
@@ -420,6 +439,69 @@ export class ExtensionLoader {
     }
 
     return null;
+  }
+
+  /**
+   * Inject an extension's renderer stylesheet into the host document.
+   *
+   * Vite library builds emit the extension's CSS as an asset next to the
+   * renderer entry (either `<entry>.css` or a `style.css` in the same folder)
+   * but, unlike an application build, do not inject it. The host loads the
+   * entry with `require()` and would otherwise never load that CSS. This reads
+   * the sibling stylesheet and appends it as a `<style>` element, so plain
+   * side-effect and CSS-module imports in an extension "just work" without the
+   * `?inline` + `<style>` workaround.
+   *
+   * A no-op when there is no sibling stylesheet, so existing extensions are
+   * unaffected. Renderer-only: guarded on the entry-point name and on the
+   * presence of `document`.
+   */
+  private async injectRendererStyles(extEntryPath: string, extension: ExternalInstalledExtension): Promise<void> {
+    if (this.dependencies.extensionEntryPointName !== "renderer" || typeof document === "undefined") {
+      return;
+    }
+
+    const entryDir = this.dependencies.getDirnameOfPath(extEntryPath);
+    // Prefer a stylesheet named after the entry (renderer.js -> renderer.css),
+    // then Vite's default library CSS asset name (style.css).
+    const candidates = [
+      extEntryPath.replace(/\.[^./\\]+$/, ".css"),
+      this.dependencies.joinPaths(entryDir, "style.css"),
+    ];
+
+    for (const cssPath of candidates) {
+      if (cssPath === extEntryPath || this.injectedStylePaths.has(cssPath)) {
+        continue;
+      }
+
+      try {
+        if (!(await this.dependencies.pathExists(cssPath))) {
+          continue;
+        }
+
+        const css = await this.dependencies.readFile(cssPath);
+
+        // Guard again: another async candidate may have won the race meanwhile.
+        if (this.injectedStylePaths.has(cssPath)) {
+          continue;
+        }
+        this.injectedStylePaths.add(cssPath);
+
+        const style = document.createElement("style");
+
+        style.dataset.freelensExtension = extension.manifest.name;
+        style.textContent = css;
+        document.head.appendChild(style);
+
+        this.dependencies.logger.debug(
+          `${logModule}: injected stylesheet "${cssPath}" for "${extension.manifest.name}"`,
+        );
+      } catch (error) {
+        this.dependencies.logger.warn(
+          `${logModule}: failed to inject stylesheet "${cssPath}" for "${extension.manifest.name}": ${error}`,
+        );
+      }
+    }
   }
 
   getExtensionById(extId: LensExtensionId) {

--- a/packages/core/src/renderer/components/app.scss
+++ b/packages/core/src/renderer/components/app.scss
@@ -15,6 +15,14 @@
 
 @config "../../../tailwind.config.js";
 
+// Wire Tailwind's `dark:` variant to the real theme mechanism. The theme
+// system keeps dark as the default and toggles `body.theme-light` for light
+// (themes/apply-lens-theme.injectable.ts) — there is no `.dark` class, so
+// Tailwind's stock `darkMode: "class"` would never match. This makes `dark:`
+// apply to any element that is not inside a light-themed body. Prefer the
+// `var(--…)` theme tokens over `dark:`; they re-theme automatically.
+@custom-variant dark (&:where(body:not(.theme-light), body:not(.theme-light) *));
+
 :root {
   --flex-gap: #{$padding};
   --unit: 8px;

--- a/packages/core/src/renderer/components/app.scss
+++ b/packages/core/src/renderer/components/app.scss
@@ -15,12 +15,18 @@
 
 @config "../../../tailwind.config.js";
 
-// Wire Tailwind's `dark:` variant to the real theme mechanism. The theme
-// system keeps dark as the default and toggles `body.theme-light` for light
-// (themes/apply-lens-theme.injectable.ts) — there is no `.dark` class, so
-// Tailwind's stock `darkMode: "class"` would never match. This makes `dark:`
-// apply to any element that is not inside a light-themed body. Prefer the
-// `var(--…)` theme tokens over `dark:`; they re-theme automatically.
+/*
+ * Wire the Tailwind "dark:" variant to the real theme mechanism. The theme
+ * system keeps dark as the default and toggles "body.theme-light" for light
+ * (themes/apply-lens-theme.injectable.ts) — there is no ".dark" class, so
+ * the Tailwind stock "darkMode: class" would never match. This makes "dark:"
+ * apply to any element that is not inside a light-themed body. Prefer the
+ * "var(--…)" theme tokens over "dark:"; they re-theme automatically.
+ *
+ * NOTE: this must be a CSS block comment, not a "//" line comment. The file is
+ * processed by the Tailwind PostCSS plugin, whose CSS parser does not treat
+ * "//" as a comment and would read an apostrophe as an unterminated string.
+ */
 @custom-variant dark (&:where(body:not(.theme-light), body:not(.theme-light) *));
 
 :root {

--- a/packages/core/tailwind.config.js
+++ b/packages/core/tailwind.config.js
@@ -6,7 +6,14 @@
 
 module.exports = {
   content: ["src/**/*.tsx"],
-  darkMode: "class",
+  // No `darkMode` here on purpose. The theme system does not toggle a `.dark`
+  // class; it toggles `body.theme-light` (dark is the default, light adds the
+  // class — see themes/apply-lens-theme.injectable.ts). The `dark:` variant is
+  // wired to that real selector via `@custom-variant` in
+  // renderer/components/app.scss. A `darkMode: "class"` here would generate a
+  // `dark:` variant matching a `.dark` class that never exists, so it is
+  // omitted. Prefer `var(--…)` theme tokens over `dark:` — they re-theme
+  // automatically.
   theme: {
     fontFamily: {
       sans: ["Roboto", "Helvetica", "Arial", "sans-serif"],


### PR DESCRIPTION
## Summary

Implements the style-patterns audit plan from #2138 (v2 branch) and fills the extension CSS gap. One commit per fix.

- **Document the v2 styling conventions** in `docs/v2-styling.md` (the four styling systems that coexist in v2 + a roles table for which mechanism to use where) and link it from AGENTS.md. (Recommendation A)
- **Fix the misleading Tailwind `darkMode` config.** The theme system toggles `body.theme-light` (dark is default), not a `.dark` class, so `darkMode: "class"` was dead. Remove it and wire the `dark:` variant to the real selector via `@custom-variant` in `app.scss`. Verified the compiled selector expands to `.dark\:flex:where(body:not(.theme-light), body:not(.theme-light) *)`. (Recommendation C)
- **Auto-inject extension stylesheets** in the renderer extension loader so extensions no longer need the `?inline` + `<style>` double-import workaround, and document the extension styling model in `docs/v2-extension-migration.md` (which previously said nothing about CSS). The injection is renderer-only, idempotent, and a no-op when no sibling stylesheet exists, so existing extensions are unaffected. (Recommendation D / the extension gap)

Base branch is **v2** (not main — these changes reference the v2 Vite migration).

## Not done (documented as an opportunistic backlog in docs/v2-styling.md)
- Converting the same-directory global-vs-module inconsistent pairs.
- Inlining the 7 `@apply` usages.
- Picking one loading mechanism for ui-components styles.

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`