### PR TITLE
Migrate legacy flexbox classes to Tailwind: Phase 3 structural .box decoupling

### DIFF
--- a/packages/core/src/features/__snapshots__/extension-special-characters-in-page-registrations.test.tsx.snap
+++ b/packages/core/src/features/__snapshots__/extension-special-characters-in-page-registrations.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`extension special characters in page registrations > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -379,7 +379,7 @@ exports[`extension special characters in page registrations > renders 1`] = `
 exports[`extension special characters in page registrations > when navigating to route with ID having special characters > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/__snapshots__/navigate-to-extension-page.test.tsx.snap
+++ b/packages/core/src/features/__snapshots__/navigate-to-extension-page.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`navigate to extension page > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -379,7 +379,7 @@ exports[`navigate to extension page > renders 1`] = `
 exports[`navigate to extension page > when extension navigates to child route > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -600,7 +600,7 @@ exports[`navigate to extension page > when extension navigates to child route > 
 exports[`navigate to extension page > when extension navigates to route with parameters > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -837,7 +837,7 @@ exports[`navigate to extension page > when extension navigates to route with par
 exports[`navigate to extension page > when extension navigates to route without parameters > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -1074,7 +1074,7 @@ exports[`navigate to extension page > when extension navigates to route without 
 exports[`navigate to extension page > when extension navigates to route without parameters > when changing page parameters > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/__snapshots__/navigating-between-routes.test.tsx.snap
+++ b/packages/core/src/features/__snapshots__/navigating-between-routes.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`navigating between routes > given route with optional path parameters > when navigating to route with path parameters > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -227,7 +227,7 @@ exports[`navigating between routes > given route with optional path parameters >
 exports[`navigating between routes > given route without path parameters > when navigating to route > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/add-cluster/__snapshots__/navigation-using-application-menu.test.tsx.snap
+++ b/packages/core/src/features/add-cluster/__snapshots__/navigation-using-application-menu.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`add-cluster - navigation using application menu > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -379,7 +379,7 @@ exports[`add-cluster - navigation using application menu > renders 1`] = `
 exports[`add-cluster - navigation using application menu > when navigating to add cluster using application menu > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/catalog/__snapshots__/custom-columns.test.tsx.snap
+++ b/packages/core/src/features/catalog/__snapshots__/custom-columns.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`custom category columns for catalog > renders 1`] = `
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -697,7 +697,7 @@ exports[`custom category columns for catalog > when category is added using defa
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1421,7 +1421,7 @@ exports[`custom category columns for catalog > when category is added using defa
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2135,7 +2135,7 @@ exports[`custom category columns for catalog > when category is added using defa
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2835,7 +2835,7 @@ exports[`custom category columns for catalog > when category is added with custo
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -3559,7 +3559,7 @@ exports[`custom category columns for catalog > when category is added with custo
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -4211,7 +4211,7 @@ exports[`custom category columns for catalog > when category is added without de
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -4935,7 +4935,7 @@ exports[`custom category columns for catalog > when category is added without de
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/catalog/__snapshots__/entity-running.test.tsx.snap
+++ b/packages/core/src/features/catalog/__snapshots__/entity-running.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`entity running technical tests > when navigated to catalog > renders 1`
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -822,7 +822,7 @@ exports[`entity running technical tests > when navigated to catalog > when detai
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/catalog/__snapshots__/opening-entity-details.test.tsx.snap
+++ b/packages/core/src/features/catalog/__snapshots__/opening-entity-details.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`opening catalog entity details panel > renders 1`] = `
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -382,7 +382,7 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1330,7 +1330,7 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2310,7 +2310,7 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -3290,7 +3290,7 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -4522,7 +4522,7 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -5490,7 +5490,7 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -6458,7 +6458,7 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -7597,7 +7597,7 @@ exports[`opening catalog entity details panel > when not navigated to the catalo
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/cluster/__snapshots__/custom-resources-in-sidebar.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/custom-resources-in-sidebar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`cluster - custom resources in sidebar > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"
@@ -673,7 +673,7 @@ exports[`cluster - custom resources in sidebar > renders 1`] = `
 exports[`cluster - custom resources in sidebar > when custom resource definitions are an allowed resource > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1380,7 +1380,7 @@ exports[`cluster - custom resources in sidebar > when custom resource definition
 exports[`cluster - custom resources in sidebar > when custom resource exists > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2050,7 +2050,7 @@ exports[`cluster - custom resources in sidebar > when custom resource exists > r
 exports[`cluster - custom resources in sidebar > when custom resource exists > when custom resource definitions are an allowed resource > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2757,7 +2757,7 @@ exports[`cluster - custom resources in sidebar > when custom resource exists > w
 exports[`cluster - custom resources in sidebar > when custom resource exists > when custom resource definitions are an allowed resource > when custom resources sidebar item is expanded > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -3504,7 +3504,7 @@ exports[`cluster - custom resources in sidebar > when custom resource exists > w
 exports[`cluster - custom resources in sidebar > when custom resource exists > when specific custom resource is an allowed resource > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -4174,7 +4174,7 @@ exports[`cluster - custom resources in sidebar > when custom resource exists > w
 exports[`cluster - custom resources in sidebar > when custom resource exists > when specific custom resource is an allowed resource > when custom resources sidebar item is expanded > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -4912,7 +4912,7 @@ exports[`cluster - custom resources in sidebar > when custom resource exists > w
 exports[`cluster - custom resources in sidebar > when custom resource exists > when specific custom resource is an allowed resource > when custom resources sidebar item is expanded > when custom resources group sidebar item is expanded > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/__snapshots__/favorites-overview.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/favorites-overview.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`favorites overview > when navigating to favorites overview > renders 1`
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/__snapshots__/legacy-extension-adding-cluster-frame-components.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/legacy-extension-adding-cluster-frame-components.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`legacy extension adding cluster frame components > given custom components for cluster view available > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-core.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-core.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`cluster - sidebar and tab navigation for core > given core registrations > given empty state for expanded sidebar items already exists, when rendered > renders without errors 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"
@@ -711,7 +711,7 @@ exports[`cluster - sidebar and tab navigation for core > given core registration
 exports[`cluster - sidebar and tab navigation for core > given core registrations > given no initially persisted state for sidebar items, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"
@@ -1419,7 +1419,7 @@ exports[`cluster - sidebar and tab navigation for core > given core registration
 exports[`cluster - sidebar and tab navigation for core > given core registrations > given no initially persisted state for sidebar items, when rendered > when a parent sidebar item is expanded > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2167,7 +2167,7 @@ exports[`cluster - sidebar and tab navigation for core > given core registration
 exports[`cluster - sidebar and tab navigation for core > given core registrations > given no initially persisted state for sidebar items, when rendered > when a parent sidebar item is expanded > when a child of the parent is selected > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2791,7 +2791,7 @@ exports[`cluster - sidebar and tab navigation for core > given core registration
 exports[`cluster - sidebar and tab navigation for core > given core registrations > given no state for expanded sidebar items exists, and navigated to child sidebar item, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -3374,7 +3374,7 @@ exports[`cluster - sidebar and tab navigation for core > given core registration
 exports[`cluster - sidebar and tab navigation for core > given core registrations > given state for expanded sidebar items already exists, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"
@@ -4122,7 +4122,7 @@ exports[`cluster - sidebar and tab navigation for core > given core registration
 exports[`cluster - sidebar and tab navigation for core > given core registrations > given state for expanded unknown sidebar items already exists, when rendered > renders without errors 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"

--- a/packages/core/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-extensions.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-extensions.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`cluster - sidebar and tab navigation for extensions > given extension with cluster pages and cluster page menus > given empty state for expanded sidebar items already exists, when rendered > renders without errors 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -719,7 +719,7 @@ exports[`cluster - sidebar and tab navigation for extensions > given extension w
 exports[`cluster - sidebar and tab navigation for extensions > given extension with cluster pages and cluster page menus > given no initially persisted state for sidebar items, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1435,7 +1435,7 @@ exports[`cluster - sidebar and tab navigation for extensions > given extension w
 exports[`cluster - sidebar and tab navigation for extensions > given extension with cluster pages and cluster page menus > given no initially persisted state for sidebar items, when rendered > when a parent sidebar item is expanded > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2227,7 +2227,7 @@ exports[`cluster - sidebar and tab navigation for extensions > given extension w
 exports[`cluster - sidebar and tab navigation for extensions > given extension with cluster pages and cluster page menus > given no initially persisted state for sidebar items, when rendered > when a parent sidebar item is expanded > when a child of the parent is selected > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2936,7 +2936,7 @@ exports[`cluster - sidebar and tab navigation for extensions > given extension w
 exports[`cluster - sidebar and tab navigation for extensions > given extension with cluster pages and cluster page menus > given no initially persisted state for sidebar items, when rendered > when a parent sidebar item is expanded > when a child of the parent is selected > when selecting sibling tab > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -3645,7 +3645,7 @@ exports[`cluster - sidebar and tab navigation for extensions > given extension w
 exports[`cluster - sidebar and tab navigation for extensions > given extension with cluster pages and cluster page menus > given no state for expanded sidebar items exists, and navigated to child sidebar item, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -4277,7 +4277,7 @@ exports[`cluster - sidebar and tab navigation for extensions > given extension w
 exports[`cluster - sidebar and tab navigation for extensions > given extension with cluster pages and cluster page menus > given state for expanded sidebar items already exists, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -5069,7 +5069,7 @@ exports[`cluster - sidebar and tab navigation for extensions > given extension w
 exports[`cluster - sidebar and tab navigation for extensions > given extension with cluster pages and cluster page menus > given state for expanded unknown sidebar items already exists, when rendered > renders without errors 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -5785,7 +5785,7 @@ exports[`cluster - sidebar and tab navigation for extensions > given extension w
 exports[`cluster - sidebar and tab navigation for extensions > given extension with cluster pages and cluster page menus with explicit 'orderNumber' > given no state for expanded sidebar items exists, and navigated to child sidebar item, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/__snapshots__/visibility-of-sidebar-items.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/visibility-of-sidebar-items.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`cluster - visibility of sidebar items > given kube resource for route is not allowed > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"
@@ -681,7 +681,7 @@ exports[`cluster - visibility of sidebar items > given kube resource for route i
 exports[`cluster - visibility of sidebar items > given kube resource for route is not allowed > when kube resource becomes allowed > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/__snapshots__/workload-overview.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/workload-overview.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`workload overview > when navigating to workload overview > renders 1`] 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/delete-dialog/__snapshots__/delete-cluster-dialog.test.tsx.snap
+++ b/packages/core/src/features/cluster/delete-dialog/__snapshots__/delete-cluster-dialog.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Deleting a cluster > when an internal kubeconfig cluster is used > when
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -753,7 +753,7 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1535,7 +1535,7 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2398,7 +2398,7 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -3261,7 +3261,7 @@ exports[`Deleting a cluster > when the kubeconfig has only one cluster > when th
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/cluster/delete-dialog/__snapshots__/delete-cluster-dialog.test.tsx.snap
+++ b/packages/core/src/features/cluster/delete-dialog/__snapshots__/delete-cluster-dialog.test.tsx.snap
@@ -691,12 +691,12 @@ exports[`Deleting a cluster > when an internal kubeconfig cluster is used > when
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center dialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center dialog modal enter"
     data-testid="delete-cluster-dialog"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="dialogContent"
@@ -1440,12 +1440,12 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center dialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center dialog modal enter"
     data-testid="delete-cluster-dialog"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="dialogContent"
@@ -2222,12 +2222,12 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center dialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center dialog modal enter"
     data-testid="delete-cluster-dialog"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="dialogContent"
@@ -3085,12 +3085,12 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center dialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center dialog modal enter"
     data-testid="delete-cluster-dialog"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="dialogContent"
@@ -3948,12 +3948,12 @@ exports[`Deleting a cluster > when the kubeconfig has only one cluster > when th
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center dialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center dialog modal enter"
     data-testid="delete-cluster-dialog"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="dialogContent"

--- a/packages/core/src/features/cluster/delete-dialog/__snapshots__/delete-cluster-dialog.test.tsx.snap
+++ b/packages/core/src/features/cluster/delete-dialog/__snapshots__/delete-cluster-dialog.test.tsx.snap
@@ -1494,7 +1494,7 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
               type="checkbox"
             />
             <i
-              class="box flex align-center"
+              class="check-icon flex items-center"
             />
             <span
               class="label"
@@ -2276,7 +2276,7 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
               type="checkbox"
             />
             <i
-              class="box flex align-center"
+              class="check-icon flex items-center"
             />
             <span
               class="label"
@@ -3140,7 +3140,7 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
               type="checkbox"
             />
             <i
-              class="box flex align-center"
+              class="check-icon flex items-center"
             />
             <span
               class="label"

--- a/packages/core/src/features/cluster/extension-api/__snapshots__/disable-cluster-pages-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/extension-api/__snapshots__/disable-cluster-pages-when-cluster-is-not-relevant.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant > given extension sh
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -552,7 +552,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant > given extension sh
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1224,7 +1224,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant > given not yet know
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"

--- a/packages/core/src/features/cluster/extension-api/__snapshots__/disable-sidebar-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/extension-api/__snapshots__/disable-sidebar-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`disable sidebar items when cluster is not relevant > given extension sh
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -703,7 +703,7 @@ exports[`disable sidebar items when cluster is not relevant > given extension sh
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1383,7 +1383,7 @@ exports[`disable sidebar items when cluster is not relevant > given not yet know
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`disable kube object detail items when cluster is not relevant > given e
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -755,7 +755,7 @@ exports[`disable kube object detail items when cluster is not relevant > given e
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1501,7 +1501,7 @@ exports[`disable kube object detail items when cluster is not relevant > given n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/reactively-hide-kube-object-detail-item.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/reactively-hide-kube-object-detail-item.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`reactively hide kube object detail item > renders 1`] = `
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -750,7 +750,7 @@ exports[`reactively hide kube object detail item > when the item is shown > rend
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/kube-object-menu/extension-api/__snapshots__/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-menu/extension-api/__snapshots__/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`disable kube object menu items when cluster is not relevant > given ext
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -559,7 +559,7 @@ exports[`disable kube object menu items when cluster is not relevant > given ext
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1108,7 +1108,7 @@ exports[`disable kube object menu items when cluster is not relevant > given not
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -826,7 +826,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1653,7 +1653,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2579,7 +2579,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -3453,7 +3453,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -4429,7 +4429,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -5407,7 +5407,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -6347,7 +6347,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -7282,7 +7282,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -8208,7 +8208,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -9134,7 +9134,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -10060,7 +10060,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -10791,7 +10791,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -11726,7 +11726,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -12652,7 +12652,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -13578,7 +13578,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
@@ -525,7 +525,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -1347,7 +1347,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -2174,7 +2174,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -2502,7 +2502,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -2517,7 +2517,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -3100,7 +3100,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -3974,7 +3974,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -4354,7 +4354,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -4369,7 +4369,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -4950,7 +4950,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -5330,7 +5330,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -5345,7 +5345,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -5928,7 +5928,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -6256,7 +6256,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -6271,7 +6271,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -6868,7 +6868,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -7196,7 +7196,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -7211,7 +7211,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -7803,7 +7803,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -8131,7 +8131,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -8146,7 +8146,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -8729,7 +8729,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -9057,7 +9057,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -9072,7 +9072,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -9655,7 +9655,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -9983,7 +9983,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -9998,7 +9998,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -10581,7 +10581,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -11312,7 +11312,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -11640,7 +11640,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -11655,7 +11655,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -12247,7 +12247,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -12575,7 +12575,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -12590,7 +12590,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -13173,7 +13173,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -13501,7 +13501,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -13516,7 +13516,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -14099,7 +14099,7 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>

--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-previously-opened-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-previously-opened-tab.test.tsx.snap
@@ -1447,7 +1447,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab > given
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -1462,7 +1462,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab > given
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"

--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-previously-opened-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-previously-opened-tab.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab > given
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"
@@ -712,7 +712,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab > given
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/workloads/__snapshots__/pods.test.tsx.snap
+++ b/packages/core/src/features/cluster/workloads/__snapshots__/pods.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`workloads / pods > when navigating to workloads / pods view > given a n
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1186,7 +1186,7 @@ exports[`workloads / pods > when navigating to workloads / pods view > given no 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2220,7 +2220,7 @@ exports[`workloads / pods > when navigating to workloads / pods view > given pod
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/cluster/workloads/__snapshots__/pods.test.tsx.snap
+++ b/packages/core/src/features/cluster/workloads/__snapshots__/pods.test.tsx.snap
@@ -610,7 +610,7 @@ exports[`workloads / pods > when navigating to workloads / pods view > given a n
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -911,7 +911,7 @@ exports[`workloads / pods > when navigating to workloads / pods view > given a n
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -1792,7 +1792,7 @@ exports[`workloads / pods > when navigating to workloads / pods view > given no 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -2826,7 +2826,7 @@ exports[`workloads / pods > when navigating to workloads / pods view > given pod
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>

--- a/packages/core/src/features/cluster/workloads/overview/extension-api/__snapshots__/disable-workloads-overview-details-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/workloads/overview/extension-api/__snapshots__/disable-workloads-overview-details-when-cluster-is-not-relevant.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`disable workloads overview details when cluster is not relevant > given
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -681,7 +681,7 @@ exports[`disable workloads overview details when cluster is not relevant > given
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1353,7 +1353,7 @@ exports[`disable workloads overview details when cluster is not relevant > given
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/command-pallet/__snapshots__/keyboard-shortcuts.test.tsx.snap
+++ b/packages/core/src/features/command-pallet/__snapshots__/keyboard-shortcuts.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Command Pallet: keyboard shortcut tests > when on linux > renders 1`] =
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -473,7 +473,7 @@ exports[`Command Pallet: keyboard shortcut tests > when on linux > when pressing
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -942,7 +942,7 @@ exports[`Command Pallet: keyboard shortcut tests > when on linux > when pressing
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1423,7 +1423,7 @@ exports[`Command Pallet: keyboard shortcut tests > when on linux > when pressing
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1892,7 +1892,7 @@ exports[`Command Pallet: keyboard shortcut tests > when on macOS > renders 1`] =
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2270,7 +2270,7 @@ exports[`Command Pallet: keyboard shortcut tests > when on macOS > when pressing
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2648,7 +2648,7 @@ exports[`Command Pallet: keyboard shortcut tests > when on macOS > when pressing
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -3038,7 +3038,7 @@ exports[`Command Pallet: keyboard shortcut tests > when on macOS > when pressing
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/command-pallet/__snapshots__/keyboard-shortcuts.test.tsx.snap
+++ b/packages/core/src/features/command-pallet/__snapshots__/keyboard-shortcuts.test.tsx.snap
@@ -1405,10 +1405,10 @@ exports[`Command Pallet: keyboard shortcut tests > when on linux > when pressing
     </div>
   </div>
   <div
-    class="Dialog flex center"
+    class="Dialog flex items-center justify-center"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="CommandContainer"
@@ -3020,10 +3020,10 @@ exports[`Command Pallet: keyboard shortcut tests > when on macOS > when pressing
     </div>
   </div>
   <div
-    class="Dialog flex center"
+    class="Dialog flex items-center justify-center"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="CommandContainer"

--- a/packages/core/src/features/custom-resources/__snapshots__/view-with-extra-columns.test.ts.snap
+++ b/packages/core/src/features/custom-resources/__snapshots__/view-with-extra-columns.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Viewing Custom Resources with extra columns > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/custom-resources/__snapshots__/view-with-extra-columns.test.ts.snap
+++ b/packages/core/src/features/custom-resources/__snapshots__/view-with-extra-columns.test.ts.snap
@@ -497,7 +497,7 @@ exports[`Viewing Custom Resources with extra columns > renders 1`] = `
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                     </label>
                   </div>
@@ -620,7 +620,7 @@ exports[`Viewing Custom Resources with extra columns > renders 1`] = `
                                   type="checkbox"
                                 />
                                 <i
-                                  class="box flex align-center"
+                                  class="check-icon flex items-center"
                                 />
                               </label>
                             </div>

--- a/packages/core/src/features/entity-settings/__snapshots__/showing-settings-for-correct-entity.test.tsx.snap
+++ b/packages/core/src/features/entity-settings/__snapshots__/showing-settings-for-correct-entity.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Showing correct entity settings > renders 1`] = `
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -382,7 +382,7 @@ exports[`Showing correct entity settings > when navigating to local cluster enti
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -761,7 +761,7 @@ exports[`Showing correct entity settings > when navigating to non-local cluster 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1161,7 +1161,7 @@ exports[`Showing correct entity settings > when navigating to weblink entity set
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/extensions/__snapshots__/navigation-using-application-menu.test.ts.snap
+++ b/packages/core/src/features/extensions/__snapshots__/navigation-using-application-menu.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`extensions - navigation using application menu > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -379,7 +379,7 @@ exports[`extensions - navigation using application menu > renders 1`] = `
 exports[`extensions - navigation using application menu > when navigating to extensions using application menu > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
+++ b/packages/core/src/features/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
@@ -2532,11 +2532,11 @@ exports[`add custom helm repository in preferences > when navigating to preferen
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center AddHelmRepoDialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center AddHelmRepoDialog modal enter"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="Wizard"
@@ -3491,11 +3491,11 @@ exports[`add custom helm repository in preferences > when navigating to preferen
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center AddHelmRepoDialog modal enter leave"
+    class="Animate opacity-scale Dialog flex items-center justify-center AddHelmRepoDialog modal enter leave"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     />
   </div>
 </body>
@@ -4347,11 +4347,11 @@ exports[`add custom helm repository in preferences > when navigating to preferen
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center AddHelmRepoDialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center AddHelmRepoDialog modal enter"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="Wizard"
@@ -5306,11 +5306,11 @@ exports[`add custom helm repository in preferences > when navigating to preferen
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center AddHelmRepoDialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center AddHelmRepoDialog modal enter"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="Wizard"
@@ -6447,11 +6447,11 @@ exports[`add custom helm repository in preferences > when navigating to preferen
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center AddHelmRepoDialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center AddHelmRepoDialog modal enter"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="Wizard"
@@ -7406,11 +7406,11 @@ exports[`add custom helm repository in preferences > when navigating to preferen
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center AddHelmRepoDialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center AddHelmRepoDialog modal enter"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="Wizard"
@@ -8547,11 +8547,11 @@ exports[`add custom helm repository in preferences > when navigating to preferen
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center AddHelmRepoDialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center AddHelmRepoDialog modal enter"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="Wizard"
@@ -9507,11 +9507,11 @@ exports[`add custom helm repository in preferences > when navigating to preferen
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center AddHelmRepoDialog modal enter leave"
+    class="Animate opacity-scale Dialog flex items-center justify-center AddHelmRepoDialog modal enter leave"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     />
   </div>
 </body>
@@ -10353,11 +10353,11 @@ exports[`add custom helm repository in preferences > when navigating to preferen
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center AddHelmRepoDialog modal enter leave"
+    class="Animate opacity-scale Dialog flex items-center justify-center AddHelmRepoDialog modal enter leave"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     />
   </div>
 </body>
@@ -11199,11 +11199,11 @@ exports[`add custom helm repository in preferences > when navigating to preferen
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center AddHelmRepoDialog modal enter leave"
+    class="Animate opacity-scale Dialog flex items-center justify-center AddHelmRepoDialog modal enter leave"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="Wizard"

--- a/packages/core/src/features/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
+++ b/packages/core/src/features/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
@@ -5409,7 +5409,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
                     type="checkbox"
                   />
                   <i
-                    class="box flex align-center"
+                    class="check-icon flex items-center"
                   />
                   <span
                     class="label"
@@ -7509,7 +7509,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
                     type="checkbox"
                   />
                   <i
-                    class="box flex align-center"
+                    class="check-icon flex items-center"
                   />
                   <span
                     class="label"

--- a/packages/core/src/features/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
+++ b/packages/core/src/features/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
@@ -4,7 +4,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -842,7 +842,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1690,7 +1690,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2649,7 +2649,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -3505,7 +3505,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -4464,7 +4464,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -5605,7 +5605,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -6564,7 +6564,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -7705,7 +7705,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -8665,7 +8665,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -9521,7 +9521,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -10367,7 +10367,7 @@ exports[`add custom helm repository in preferences > when navigating to preferen
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/helm-charts/__snapshots__/add-helm-repository-from-list-in-preferences.test.ts.snap
+++ b/packages/core/src/features/helm-charts/__snapshots__/add-helm-repository-from-list-in-preferences.test.ts.snap
@@ -4,7 +4,7 @@ exports[`add helm repository from list in preferences > when navigating to prefe
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -814,7 +814,7 @@ exports[`add helm repository from list in preferences > when navigating to prefe
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1662,7 +1662,7 @@ exports[`add helm repository from list in preferences > when navigating to prefe
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2568,7 +2568,7 @@ exports[`add helm repository from list in preferences > when navigating to prefe
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -3416,7 +3416,7 @@ exports[`add helm repository from list in preferences > when navigating to prefe
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -4264,7 +4264,7 @@ exports[`add helm repository from list in preferences > when navigating to prefe
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -5102,7 +5102,7 @@ exports[`add helm repository from list in preferences > when navigating to prefe
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -5984,7 +5984,7 @@ exports[`add helm repository from list in preferences > when navigating to prefe
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -6934,7 +6934,7 @@ exports[`add helm repository from list in preferences > when navigating to prefe
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -7816,7 +7816,7 @@ exports[`add helm repository from list in preferences > when navigating to prefe
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/helm-charts/__snapshots__/listing-active-helm-repositories-in-preferences.test.ts.snap
+++ b/packages/core/src/features/helm-charts/__snapshots__/listing-active-helm-repositories-in-preferences.test.ts.snap
@@ -4,7 +4,7 @@ exports[`listing active helm repositories in preferences > when navigating to pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -842,7 +842,7 @@ exports[`listing active helm repositories in preferences > when navigating to pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1680,7 +1680,7 @@ exports[`listing active helm repositories in preferences > when navigating to pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2407,7 +2407,7 @@ exports[`listing active helm repositories in preferences > when navigating to pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -3220,7 +3220,7 @@ exports[`listing active helm repositories in preferences > when navigating to pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -4102,7 +4102,7 @@ exports[`listing active helm repositories in preferences > when navigating to pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -4829,7 +4829,7 @@ exports[`listing active helm repositories in preferences > when navigating to pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -5556,7 +5556,7 @@ exports[`listing active helm repositories in preferences > when navigating to pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/helm-charts/__snapshots__/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts.snap
+++ b/packages/core/src/features/helm-charts/__snapshots__/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts.snap
@@ -4,7 +4,7 @@ exports[`remove helm repository from list of active repositories in preferences 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -842,7 +842,7 @@ exports[`remove helm repository from list of active repositories in preferences 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1662,7 +1662,7 @@ exports[`remove helm repository from list of active repositories in preferences 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2510,7 +2510,7 @@ exports[`remove helm repository from list of active repositories in preferences 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
@@ -3751,7 +3751,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -4967,7 +4967,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -6153,7 +6153,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -7334,7 +7334,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -8515,7 +8515,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -9719,7 +9719,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -10935,7 +10935,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -12116,7 +12116,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -13852,7 +13852,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -16400,7 +16400,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -18849,7 +18849,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -20082,7 +20082,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -21263,7 +21263,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -22444,7 +22444,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
@@ -4,7 +4,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -595,7 +595,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1666,7 +1666,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2615,7 +2615,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -3832,7 +3832,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -5018,7 +5018,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -6199,7 +6199,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -7380,7 +7380,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -8583,7 +8583,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -9800,7 +9800,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -10981,7 +10981,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -12170,14 +12170,14 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     >
       <div
-        class="Animate opacity notification flex ok enter"
+        class="Animate opacity notification ok enter"
         style="--enter-duration: 100ms; --leave-duration: 100ms;"
       >
         <div
-          class="box"
+          class="info-icon"
         >
           <i
             class="Icon material focusable"
@@ -12191,7 +12191,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
           </i>
         </div>
         <div
-          class="message box grow"
+          class="message"
         >
           <p>
             Chart Release 
@@ -12202,7 +12202,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
           </p>
         </div>
         <div
-          class="box close-icon"
+          class="close-icon"
         >
           <i
             class="Icon close material interactive focusable"
@@ -13199,14 +13199,14 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     >
       <div
-        class="Animate opacity notification flex ok enter"
+        class="Animate opacity notification ok enter"
         style="--enter-duration: 100ms; --leave-duration: 100ms;"
       >
         <div
-          class="box"
+          class="info-icon"
         >
           <i
             class="Icon material focusable"
@@ -13220,7 +13220,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
           </i>
         </div>
         <div
-          class="message box grow"
+          class="message"
         >
           <p>
             Chart Release 
@@ -13231,7 +13231,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
           </p>
         </div>
         <div
-          class="box close-icon"
+          class="close-icon"
         >
           <i
             class="Icon close material interactive focusable"
@@ -14176,14 +14176,14 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     >
       <div
-        class="Animate opacity notification flex ok enter"
+        class="Animate opacity notification ok enter"
         style="--enter-duration: 100ms; --leave-duration: 100ms;"
       >
         <div
-          class="box"
+          class="info-icon"
         >
           <i
             class="Icon material focusable"
@@ -14197,7 +14197,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
           </i>
         </div>
         <div
-          class="message box grow"
+          class="message"
         >
           <p>
             Chart Release 
@@ -14208,7 +14208,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
           </p>
         </div>
         <div
-          class="box close-icon"
+          class="close-icon"
         >
           <i
             class="Icon close material interactive focusable"
@@ -15265,7 +15265,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -16659,7 +16659,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -17660,7 +17660,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -18895,7 +18895,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -20128,7 +20128,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -21309,7 +21309,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -22490,7 +22490,7 @@ exports[`installing helm chart from new tab > given tab for installing chart was
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
@@ -15199,12 +15199,12 @@ exports[`installing helm chart from new tab > given tab for installing chart was
     </div>
   </div>
   <div
-    class="Animate opacity-scale Dialog flex center LogsDialog modal enter"
+    class="Animate opacity-scale Dialog flex items-center justify-center LogsDialog modal enter"
     data-testid="logs-dialog-for-helm-chart-install"
     style="--enter-duration: 100ms; --leave-duration: 100ms;"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="Wizard"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-previously-opened-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-previously-opened-tab.test.ts.snap
@@ -4,7 +4,7 @@ exports[`installing helm chart from previously opened tab > given tab for instal
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"
@@ -686,7 +686,7 @@ exports[`installing helm chart from previously opened tab > given tab for instal
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-previously-opened-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-previously-opened-tab.test.ts.snap
@@ -1554,7 +1554,7 @@ exports[`installing helm chart from previously opened tab > given tab for instal
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/opening-dock-tab-for-installing-helm-chart.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/opening-dock-tab-for-installing-helm-chart.test.ts.snap
@@ -4,7 +4,7 @@ exports[`opening dock tab for installing helm chart > given application is start
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -694,7 +694,7 @@ exports[`opening dock tab for installing helm chart > given application is start
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1552,7 +1552,7 @@ exports[`opening dock tab for installing helm chart > given application is start
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2467,7 +2467,7 @@ exports[`opening dock tab for installing helm chart > given application is start
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -3532,7 +3532,7 @@ exports[`opening dock tab for installing helm chart > given application is start
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -4607,7 +4607,7 @@ exports[`opening dock tab for installing helm chart > given application is start
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -5672,7 +5672,7 @@ exports[`opening dock tab for installing helm chart > given application is start
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -6741,7 +6741,7 @@ exports[`opening dock tab for installing helm chart > given application is start
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -7816,7 +7816,7 @@ exports[`opening dock tab for installing helm chart > given application is start
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/helm-charts/upgrade-chart/__snapshots__/upgrade-chart-new-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/upgrade-chart/__snapshots__/upgrade-chart-new-tab.test.ts.snap
@@ -610,7 +610,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -1474,7 +1474,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -1691,7 +1691,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -2480,7 +2480,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -2697,7 +2697,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -3502,7 +3502,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -3719,7 +3719,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -4560,7 +4560,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -4777,7 +4777,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -5159,7 +5159,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -5775,7 +5775,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -5992,7 +5992,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -6374,7 +6374,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                         type="checkbox"
                       />
                       <i
-                        class="box flex align-center"
+                        class="check-icon flex items-center"
                       />
                       <span
                         class="label"
@@ -6992,7 +6992,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -7209,7 +7209,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>

--- a/packages/core/src/features/helm-charts/upgrade-chart/__snapshots__/upgrade-chart-new-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/upgrade-chart/__snapshots__/upgrade-chart-new-tab.test.ts.snap
@@ -4,7 +4,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -868,7 +868,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -1874,7 +1874,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2934,7 +2934,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="mainLayout"
@@ -3992,7 +3992,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="mainLayout"
@@ -5207,7 +5207,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="mainLayout"
@@ -6424,7 +6424,7 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="mainLayout"

--- a/packages/core/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
+++ b/packages/core/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
@@ -610,7 +610,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -1555,7 +1555,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -1772,7 +1772,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -1903,7 +1903,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -2773,7 +2773,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -2990,7 +2990,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -3121,7 +3121,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -4052,7 +4052,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -4269,7 +4269,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -4400,7 +4400,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -5331,7 +5331,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -5548,7 +5548,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -5679,7 +5679,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -6156,7 +6156,7 @@ exports[`showing details for helm release > given application is started > when 
                   type="checkbox"
                 />
                 <i
-                  class="box flex align-center"
+                  class="check-icon flex items-center"
                 />
                 <span
                   class="label"
@@ -6856,7 +6856,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -7073,7 +7073,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -7204,7 +7204,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -7681,7 +7681,7 @@ exports[`showing details for helm release > given application is started > when 
                   type="checkbox"
                 />
                 <i
-                  class="box flex align-center"
+                  class="check-icon flex items-center"
                 />
                 <span
                   class="label"
@@ -8381,7 +8381,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -8598,7 +8598,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -8729,7 +8729,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -9206,7 +9206,7 @@ exports[`showing details for helm release > given application is started > when 
                   type="checkbox"
                 />
                 <i
-                  class="box flex align-center"
+                  class="check-icon flex items-center"
                 />
                 <span
                   class="label"
@@ -9906,7 +9906,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -10458,7 +10458,7 @@ exports[`showing details for helm release > given application is started > when 
                   type="checkbox"
                 />
                 <i
-                  class="box flex align-center"
+                  class="check-icon flex items-center"
                 />
                 <span
                   class="label"
@@ -11158,7 +11158,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -11711,7 +11711,7 @@ exports[`showing details for helm release > given application is started > when 
                   type="checkbox"
                 />
                 <i
-                  class="box flex align-center"
+                  class="check-icon flex items-center"
                 />
                 <span
                   class="label"
@@ -12412,7 +12412,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -12629,7 +12629,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -12760,7 +12760,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -13237,7 +13237,7 @@ exports[`showing details for helm release > given application is started > when 
                   type="checkbox"
                 />
                 <i
-                  class="box flex align-center"
+                  class="check-icon flex items-center"
                 />
                 <span
                   class="label"
@@ -13937,7 +13937,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -14154,7 +14154,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -14285,7 +14285,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -15216,7 +15216,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -15433,7 +15433,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -15564,7 +15564,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -16497,7 +16497,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -16714,7 +16714,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -16845,7 +16845,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -17715,7 +17715,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -17932,7 +17932,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -18063,7 +18063,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -18994,7 +18994,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -19211,7 +19211,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -19342,7 +19342,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -20273,7 +20273,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -20490,7 +20490,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -20621,7 +20621,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -21552,7 +21552,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>
@@ -21769,7 +21769,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -21900,7 +21900,7 @@ exports[`showing details for helm release > given application is started > when 
                                     type="checkbox"
                                   />
                                   <i
-                                    class="box flex align-center"
+                                    class="check-icon flex items-center"
                                   />
                                 </label>
                               </div>
@@ -22831,7 +22831,7 @@ exports[`showing details for helm release > given application is started > when 
                           type="checkbox"
                         />
                         <i
-                          class="box flex align-center"
+                          class="check-icon flex items-center"
                         />
                       </label>
                     </div>

--- a/packages/core/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
+++ b/packages/core/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
@@ -4,7 +4,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -949,7 +949,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -2167,7 +2167,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -3446,7 +3446,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -4725,7 +4725,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -6250,7 +6250,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -7775,7 +7775,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -9300,7 +9300,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -10552,7 +10552,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -11806,7 +11806,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -13331,7 +13331,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -14610,7 +14610,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -15891,7 +15891,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -17109,7 +17109,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -18388,7 +18388,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -19667,7 +19667,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -20946,7 +20946,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"
@@ -22225,7 +22225,7 @@ exports[`showing details for helm release > given application is started > when 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter leave"

--- a/packages/core/src/features/hotbar/__snapshots__/hovering-hotbar-menu.test.ts.snap
+++ b/packages/core/src/features/hotbar/__snapshots__/hovering-hotbar-menu.test.ts.snap
@@ -4,7 +4,7 @@ exports[`hovering hotbar menu tests > renders 1`] = `
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/closing-preferences.test.tsx.snap
+++ b/packages/core/src/features/preferences/__snapshots__/closing-preferences.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`preferences - closing-preferences > given accessing preferences directly > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -782,7 +782,7 @@ exports[`preferences - closing-preferences > given accessing preferences directl
 exports[`preferences - closing-preferences > given accessing preferences directly > when navigating to a tab in preferences > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -1147,7 +1147,7 @@ exports[`preferences - closing-preferences > given accessing preferences directl
 exports[`preferences - closing-preferences > given accessing preferences directly > when navigating to a tab in preferences > when preferences are closed > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -1370,7 +1370,7 @@ exports[`preferences - closing-preferences > given accessing preferences directl
 exports[`preferences - closing-preferences > given accessing preferences directly > when preferences are closed > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -1593,7 +1593,7 @@ exports[`preferences - closing-preferences > given accessing preferences directl
 exports[`preferences - closing-preferences > given already in a page and then navigated to preferences > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -2372,7 +2372,7 @@ exports[`preferences - closing-preferences > given already in a page and then na
 exports[`preferences - closing-preferences > given already in a page and then navigated to preferences > when navigating to a tab in preferences > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -2737,7 +2737,7 @@ exports[`preferences - closing-preferences > given already in a page and then na
 exports[`preferences - closing-preferences > given already in a page and then navigated to preferences > when navigating to a tab in preferences > when preferences are closed > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -2960,7 +2960,7 @@ exports[`preferences - closing-preferences > given already in a page and then na
 exports[`preferences - closing-preferences > given already in a page and then navigated to preferences > when preferences are closed > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/extension-adding-preference-tabs.test.tsx.snap
+++ b/packages/core/src/features/preferences/__snapshots__/extension-adding-preference-tabs.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`preferences: extension adding preference tabs > given in preferences, w
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/hiding-of-empty-branches.test.tsx.snap
+++ b/packages/core/src/features/preferences/__snapshots__/hiding-of-empty-branches.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`preferences - hiding-of-empty-branches, given in preferences page > given tab group and empty tabs > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -770,7 +770,7 @@ exports[`preferences - hiding-of-empty-branches, given in preferences page > giv
 exports[`preferences - hiding-of-empty-branches, given in preferences page > given tab group and empty tabs > when an item appears for one of the tabs > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -1565,7 +1565,7 @@ exports[`preferences - hiding-of-empty-branches, given in preferences page > giv
 exports[`preferences - hiding-of-empty-branches, given in preferences page > given tab group and empty tabs > when an item appears for one of the tabs > when an item appears for the remaining tab > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/navigation-to-application-preferences.test.tsx.snap
+++ b/packages/core/src/features/preferences/__snapshots__/navigation-to-application-preferences.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`preferences - navigation to application preferences > given in preferences, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -770,7 +770,7 @@ exports[`preferences - navigation to application preferences > given in preferen
 exports[`preferences - navigation to application preferences > given in preferences, when rendered > when extension with application preference items gets enabled > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -1568,7 +1568,7 @@ exports[`preferences - navigation to application preferences > given in preferen
 exports[`preferences - navigation to application preferences > given in some child page of preferences, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -1991,7 +1991,7 @@ exports[`preferences - navigation to application preferences > given in some chi
 exports[`preferences - navigation to application preferences > given in some child page of preferences, when rendered > when navigating to application preferences using navigation > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -2759,7 +2759,7 @@ exports[`preferences - navigation to application preferences > given in some chi
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/navigation-to-editor-preferences.test.ts.snap
+++ b/packages/core/src/features/preferences/__snapshots__/navigation-to-editor-preferences.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`preferences - navigation to editor preferences > given in preferences, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -770,7 +770,7 @@ exports[`preferences - navigation to editor preferences > given in preferences, 
 exports[`preferences - navigation to editor preferences > given in preferences, when rendered > when navigating to editor preferences using navigation > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/navigation-to-extension-specific-preferences.test.tsx.snap
+++ b/packages/core/src/features/preferences/__snapshots__/navigation-to-extension-specific-preferences.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`preferences - navigation to extension specific preferences > given in p
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -784,7 +784,7 @@ exports[`preferences - navigation to extension specific preferences > given in p
 exports[`preferences - navigation to extension specific preferences > given in preferences, when rendered > given extension with registered tab > when navigating to specific extension tab > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -1180,7 +1180,7 @@ exports[`preferences - navigation to extension specific preferences > given in p
 exports[`preferences - navigation to extension specific preferences > given in preferences, when rendered > given extensions with tabs having same id > when navigating to first extension tab > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -1588,7 +1588,7 @@ exports[`preferences - navigation to extension specific preferences > given in p
 exports[`preferences - navigation to extension specific preferences > given in preferences, when rendered > given extensions with tabs having same id > when navigating to second extension tab > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -1996,7 +1996,7 @@ exports[`preferences - navigation to extension specific preferences > given in p
 exports[`preferences - navigation to extension specific preferences > given in preferences, when rendered > given multiple extensions with specific preferences, when navigating to extension specific preferences page > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -2430,7 +2430,7 @@ exports[`preferences - navigation to extension specific preferences > given in p
 exports[`preferences - navigation to extension specific preferences > given in preferences, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -3197,7 +3197,7 @@ exports[`preferences - navigation to extension specific preferences > given in p
 exports[`preferences - navigation to extension specific preferences > given in preferences, when rendered > when extension with specific preferences is enabled > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -4002,7 +4002,7 @@ exports[`preferences - navigation to extension specific preferences > given in p
 exports[`preferences - navigation to extension specific preferences > given in preferences, when rendered > when extension with specific preferences is enabled > when navigating to extension preferences using navigation > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -4425,7 +4425,7 @@ exports[`preferences - navigation to extension specific preferences > given in p
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/navigation-to-kubernetes-preferences.test.ts.snap
+++ b/packages/core/src/features/preferences/__snapshots__/navigation-to-kubernetes-preferences.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`preferences - navigation to kubernetes preferences > given in preferences, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -770,7 +770,7 @@ exports[`preferences - navigation to kubernetes preferences > given in preferenc
 exports[`preferences - navigation to kubernetes preferences > given in preferences, when rendered > when navigating to kubernetes preferences using navigation > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/navigation-to-proxy-preferences.test.ts.snap
+++ b/packages/core/src/features/preferences/__snapshots__/navigation-to-proxy-preferences.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`preferences - navigation to proxy preferences > given in preferences, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -770,7 +770,7 @@ exports[`preferences - navigation to proxy preferences > given in preferences, w
 exports[`preferences - navigation to proxy preferences > given in preferences, when rendered > when navigating to proxy preferences using navigation > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/navigation-to-terminal-preferences.test.ts.snap
+++ b/packages/core/src/features/preferences/__snapshots__/navigation-to-terminal-preferences.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`preferences - navigation to terminal preferences > given in preferences, when rendered > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -770,7 +770,7 @@ exports[`preferences - navigation to terminal preferences > given in preferences
 exports[`preferences - navigation to terminal preferences > given in preferences, when rendered > when navigating to terminal preferences using navigation > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/navigation-using-application-menu.test.ts.snap
+++ b/packages/core/src/features/preferences/__snapshots__/navigation-using-application-menu.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`preferences - navigation using application menu > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -379,7 +379,7 @@ exports[`preferences - navigation using application menu > renders 1`] = `
 exports[`preferences - navigation using application menu > when navigating to preferences using application menu > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/navigation-using-tray.test.ts.snap
+++ b/packages/core/src/features/preferences/__snapshots__/navigation-using-tray.test.ts.snap
@@ -4,7 +4,7 @@ exports[`show-about-using-tray > renders 1`] = `
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -382,7 +382,7 @@ exports[`show-about-using-tray > when navigating using tray > renders 1`] = `
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/preferences/__snapshots__/urls-of-legacy-extensions.test.tsx.snap
+++ b/packages/core/src/features/preferences/__snapshots__/urls-of-legacy-extensions.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`preferences: URLs of legacy extensions > given extension with both cust
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -450,7 +450,7 @@ exports[`preferences: URLs of legacy extensions > given extension with both cust
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -896,7 +896,7 @@ exports[`preferences: URLs of legacy extensions > given extension with custom pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1304,7 +1304,7 @@ exports[`preferences: URLs of legacy extensions > given extension with custom pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1686,7 +1686,7 @@ exports[`preferences: URLs of legacy extensions > given extension with custom pr
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/status-bar/__snapshots__/status-bar-items-originating-from-extensions.test.tsx.snap
+++ b/packages/core/src/features/status-bar/__snapshots__/status-bar-items-originating-from-extensions.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`status-bar-items-originating-from-extensions > when application starts 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/top-bar/extension-api/__snapshots__/extendability-using-extension-api.test.tsx.snap
+++ b/packages/core/src/features/top-bar/extension-api/__snapshots__/extendability-using-extension-api.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`extendability-using-extension-api > given an extension with a weakly ty
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -382,7 +382,7 @@ exports[`extendability-using-extension-api > given an extension with top-bar ite
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -769,7 +769,7 @@ exports[`extendability-using-extension-api > given an extension with top-bar ite
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1147,7 +1147,7 @@ exports[`extendability-using-extension-api > renders 1`] = `
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/features/welcome/__snapshots__/navigation-using-application-menu.test.ts.snap
+++ b/packages/core/src/features/welcome/__snapshots__/navigation-using-application-menu.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`welcome - navigation using application menu > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"
@@ -380,7 +380,7 @@ exports[`welcome - navigation using application menu > when navigated somewhere 
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1148,7 +1148,7 @@ exports[`welcome - navigation using application menu > when navigated somewhere 
 exports[`welcome - navigation using application menu > when navigated somewhere else > when navigated to welcome using application menu > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="ClusterManager"

--- a/packages/core/src/renderer/components/checkbox/checkbox.scss
+++ b/packages/core/src/renderer/components/checkbox/checkbox.scss
@@ -34,7 +34,7 @@
     display: none;
 
     &:checked {
-      ~ .box {
+      ~ .check-icon {
         color: var(--checkbox-color-active);
         background: var(--checkbox-bgc-active);
         border-color: var(--checkbox-bgc-active);
@@ -46,7 +46,7 @@
     }
 
     &:disabled {
-      ~ .box {
+      ~ .check-icon {
         color: var(--checkbox-color);
       }
 
@@ -65,7 +65,7 @@
     margin-right: $margin;
   }
 
-  > .box {
+  > .check-icon {
     $boxSize: math.round(1.7 * $unit);
 
     position: relative;

--- a/packages/core/src/renderer/components/checkbox/checkbox.tsx
+++ b/packages/core/src/renderer/components/checkbox/checkbox.tsx
@@ -46,7 +46,7 @@ export function Checkbox({
         disabled={disabled}
         onChange={(event) => onChange(event.target.checked, event)}
       />
-      <i className="box flex align-center" />
+      <i className="check-icon flex items-center" />
       {label ? <span className="label">{label}</span> : null}
       {children}
     </label>

--- a/packages/core/src/renderer/components/confirm-dialog/confirm-dialog.scss
+++ b/packages/core/src/renderer/components/confirm-dialog/confirm-dialog.scss
@@ -15,7 +15,7 @@
     }
   }
 
-  > .box {
+  > .dialog-content {
     max-width: 50vw;
     min-width: 45 * $unit;
     background-color: white;

--- a/packages/core/src/renderer/components/dialog/dialog.tsx
+++ b/packages/core/src/renderer/components/dialog/dialog.tsx
@@ -159,12 +159,12 @@ class NonInjectedDialog extends React.PureComponent<
 
     let dialog = (
       <div
-        className={cssNames("Dialog flex center", className, { modal, pinned })}
+        className={cssNames("Dialog flex items-center justify-center", className, { modal, pinned })}
         onClick={stopPropagation}
         ref={this.ref}
         data-testid={testId}
       >
-        <div className="box" ref={this.contentElem}>
+        <div className="dialog-content" ref={this.contentElem}>
           {this.props.children}
         </div>
       </div>

--- a/packages/core/src/renderer/components/kube-object-list-layout/__snapshots__/kube-object-list-layout.test.tsx.snap
+++ b/packages/core/src/renderer/components/kube-object-list-layout/__snapshots__/kube-object-list-layout.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`kube-object-list-layout > given pod store > renders 1`] = `
                     type="checkbox"
                   />
                   <i
-                    class="box flex align-center"
+                    class="check-icon flex items-center"
                   />
                 </label>
               </div>

--- a/packages/core/src/renderer/components/kube-object-menu/__snapshots__/kube-object-menu.test.tsx.snap
+++ b/packages/core/src/renderer/components/kube-object-menu/__snapshots__/kube-object-menu.test.tsx.snap
@@ -88,11 +88,11 @@ exports[`kube-object-menu > given kube object > when removing kube object > rend
     </div>
   </div>
   <div
-    class="Dialog flex center ConfirmDialog modal"
+    class="Dialog flex items-center justify-center ConfirmDialog modal"
     data-testid="confirmation-dialog"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="confirm-content"
@@ -225,11 +225,11 @@ exports[`kube-object-menu > given kube object > when rerendered with different k
     </div>
   </div>
   <div
-    class="Dialog flex center ConfirmDialog modal"
+    class="Dialog flex items-center justify-center ConfirmDialog modal"
     data-testid="confirmation-dialog"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="confirm-content"
@@ -323,11 +323,11 @@ exports[`kube-object-menu > given kube object with namespace > when removing kub
     </div>
   </div>
   <div
-    class="Dialog flex center ConfirmDialog modal"
+    class="Dialog flex items-center justify-center ConfirmDialog modal"
     data-testid="confirmation-dialog"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="confirm-content"
@@ -421,11 +421,11 @@ exports[`kube-object-menu > given kube object without namespace > when removing 
     </div>
   </div>
   <div
-    class="Dialog flex center ConfirmDialog modal"
+    class="Dialog flex items-center justify-center ConfirmDialog modal"
     data-testid="confirmation-dialog"
   >
     <div
-      class="box"
+      class="dialog-content"
     >
       <div
         class="confirm-content"

--- a/packages/core/src/renderer/components/status-bar/__snapshots__/status-bar.test.tsx.snap
+++ b/packages/core/src/renderer/components/status-bar/__snapshots__/status-bar.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<StatusBar /> > when StatusBar's status is set to %p > renders 1`] = `
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -382,7 +382,7 @@ exports[`<StatusBar /> > when StatusBar's status is set to %p > renders 2`] = `
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -760,7 +760,7 @@ exports[`<StatusBar /> > when an extension is enabled specifying the side the el
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1180,7 +1180,7 @@ exports[`<StatusBar /> > when an extension is enabled with an invalid data type,
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1558,7 +1558,7 @@ exports[`<StatusBar /> > when an extension is enabled with an invalid data type,
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -1936,7 +1936,7 @@ exports[`<StatusBar /> > when an extension is enabled with an invalid data type,
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2314,7 +2314,7 @@ exports[`<StatusBar /> > when an extension is enabled with an invalid data type,
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -2692,7 +2692,7 @@ exports[`<StatusBar /> > when an extension is enabled with an invalid data type,
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -3070,7 +3070,7 @@ exports[`<StatusBar /> > when an extension is enabled with an invalid data type,
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -3448,7 +3448,7 @@ exports[`<StatusBar /> > when an extension is enabled with an invalid data type,
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"
@@ -3826,7 +3826,7 @@ exports[`<StatusBar /> > when an extension is enabled with no status items > ren
 <body>
   <div>
     <div
-      class="Notifications flex column align-flex-end"
+      class="Notifications"
     />
     <div
       class="ClusterManager"

--- a/packages/core/src/renderer/frames/cluster-frame/__snapshots__/cluster-frame.test.tsx.snap
+++ b/packages/core/src/renderer/frames/cluster-frame/__snapshots__/cluster-frame.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ClusterFrame /> > given cluster with list nodes and namespaces permissions > given no matching component > given current url is starting url > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"
@@ -656,7 +656,7 @@ exports[`<ClusterFrame /> > given cluster with list nodes and namespaces permiss
 exports[`<ClusterFrame /> > given cluster with list nodes and namespaces permissions > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"
@@ -1316,7 +1316,7 @@ exports[`<ClusterFrame /> > given cluster with list nodes and namespaces permiss
 exports[`<ClusterFrame /> > given cluster without list nodes, but with namespaces permissions > renders 1`] = `
 <div>
   <div
-    class="Notifications flex column align-flex-end"
+    class="Notifications"
   />
   <div
     class="Animate slide-right Drawer KubeObjectDetails flex flex-col right enter"

--- a/packages/ui-components/error-boundary/src/error-boundary.scss
+++ b/packages/ui-components/error-boundary/src/error-boundary.scss
@@ -5,10 +5,15 @@
  */
 
 .ErrorBoundary {
-  --flex-gap: #{8px * 2};
-
-  padding: var(--flex-gap);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
   word-break: break-all;
+
+  .back-button {
+    align-self: flex-start;
+  }
 
   .wrapper {
     display: grid;

--- a/packages/ui-components/error-boundary/src/error-boundary.tsx
+++ b/packages/ui-components/error-boundary/src/error-boundary.tsx
@@ -50,7 +50,7 @@ class NonInjectedErrorBoundary extends React.Component<ErrorBoundaryProps & Depe
 
     if (error) {
       return (
-        <div className="ErrorBoundary flex column gaps">
+        <div className="ErrorBoundary">
           <h5>
             {"App crash at "}
             <span className="contrast">{window.location.pathname}</span>
@@ -72,7 +72,7 @@ class NonInjectedErrorBoundary extends React.Component<ErrorBoundaryProps & Depe
               {error.stack}
             </code>
           </div>
-          <Button className="box self-flex-start" primary label="Back" onClick={this.back} />
+          <Button className="back-button" primary label="Back" onClick={this.back} />
         </div>
       );
     }

--- a/packages/ui-components/notifications/src/notifications.scss
+++ b/packages/ui-components/notifications/src/notifications.scss
@@ -19,6 +19,9 @@ $color-white: rgb(255, 255, 255);
 .Notifications {
   @include hidden-scrollbar;
 
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   position: absolute;
   right: 0;
   top: 0;
@@ -32,6 +35,7 @@ $color-white: rgb(255, 255, 255);
   }
 
   .notification {
+    display: flex;
     flex: 0 0;
     padding: 8px * 1.5;
     border-radius: 3px;
@@ -44,6 +48,7 @@ $color-white: rgb(255, 255, 255);
     }
 
     > .message {
+      flex: 1 0;
       white-space: pre-line;
       padding-left: 8px;
       padding-right: 8px * 2;
@@ -69,7 +74,7 @@ $color-white: rgb(255, 255, 255);
       }
     }
 
-    .box.close-icon {
+    .close-icon {
       padding: 2px;
     }
   }

--- a/packages/ui-components/notifications/src/notifications.tsx
+++ b/packages/ui-components/notifications/src/notifications.tsx
@@ -71,7 +71,7 @@ class NonInjectedNotifications extends React.Component<Dependencies> {
     const { notifications, remove, addAutoHideTimer, removeAutoHideTimer } = this.props.store;
 
     return (
-      <div className="Notifications flex column align-flex-end" ref={(e) => (this.elem = e)}>
+      <div className="Notifications" ref={(e) => (this.elem = e)}>
         {notifications.map((notification) => {
           const { id, status, onClose } = notification;
           const msgText = this.getMessage(notification);
@@ -79,16 +79,16 @@ class NonInjectedNotifications extends React.Component<Dependencies> {
           return (
             <Animate key={id}>
               <div
-                className={cssNames("notification flex", status)}
+                className={cssNames("notification", status)}
                 onMouseLeave={() => addAutoHideTimer(id)}
                 onMouseEnter={() => removeAutoHideTimer(id)}
               >
-                <div className="box">
+                <div className="info-icon">
                   <Icon material="info_outline" />
                 </div>
-                <div className="message box grow">{msgText}</div>
+                <div className="message">{msgText}</div>
                 <div
-                  className="box close-icon"
+                  className="close-icon"
                   onClick={prevDefault(() => {
                     remove(id);
                     onClose?.();

--- a/scripts/legacy-flexbox-baseline.json
+++ b/scripts/legacy-flexbox-baseline.json
@@ -1,9 +1,8 @@
 {
   "comment": "Ratchet baseline for the legacy flexbox -> Tailwind migration. This number may only decrease. See scripts/check-legacy-flexbox.mjs and docs/v2-styling.md.",
-  "total": 48,
+  "total": 46,
   "files": {
     "packages/core/src/features/catalog/custom-columns.test.tsx": 23,
-    "packages/core/src/renderer/components/dialog/dialog.tsx": 2,
     "packages/core/src/renderer/components/input/input.tsx": 11,
     "packages/core/src/renderer/components/item-object-list/__tests__/column-resize.test.tsx": 1,
     "packages/core/src/renderer/components/layout/wizard-layout.tsx": 8,

--- a/scripts/legacy-flexbox-baseline.json
+++ b/scripts/legacy-flexbox-baseline.json
@@ -1,9 +1,8 @@
 {
   "comment": "Ratchet baseline for the legacy flexbox -> Tailwind migration. This number may only decrease. See scripts/check-legacy-flexbox.mjs and docs/v2-styling.md.",
-  "total": 50,
+  "total": 48,
   "files": {
     "packages/core/src/features/catalog/custom-columns.test.tsx": 23,
-    "packages/core/src/renderer/components/checkbox/checkbox.tsx": 2,
     "packages/core/src/renderer/components/dialog/dialog.tsx": 2,
     "packages/core/src/renderer/components/input/input.tsx": 11,
     "packages/core/src/renderer/components/item-object-list/__tests__/column-resize.test.tsx": 1,


### PR DESCRIPTION
Phase 3 of the flexbox.scss -> Tailwind migration: decouples every structural `.box` selector so the remaining renames are purely mechanical. One commit per component.

- `checkbox` — tick `box flex align-center` -> `check-icon flex items-center`; three `.box` selectors rewritten
- `dialog` / `confirm-dialog` — `Dialog flex center` + content `box` -> `Dialog flex items-center justify-center` + named `dialog-content`
- `error-boundary` (ui-components) — legacy utilities -> plain SCSS (no Tailwind)
- `notifications` (ui-components) — `.box.close-icon` + legacy utilities -> plain SCSS (no Tailwind)

Guardrail baseline ratcheted 50 -> 46; snapshots refreshed. After this batch the only definition of `.box` is flexbox.scss itself.

Refs #2145

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`