### PR TITLE
feat: custom theme and accent color customization

### DIFF
--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { action } from "mobx";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import React from "react";
@@ -21,6 +22,24 @@ interface Dependencies {
   themes: LensTheme[];
 }
 
+const accentColorNames = [
+  "primary",
+  "blue",
+  "buttonPrimaryBackground",
+  "menuActiveBackground",
+  "helmStableRepo",
+];
+
+const getDerivedColors = (accent: string): Record<string, string> => {
+  const colors: Record<string, string> = {};
+
+  for (const name of accentColorNames) {
+    colors[name] = accent;
+  }
+
+  return colors;
+};
+
 const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
   const themeOptions = [
     {
@@ -33,6 +52,8 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
     })),
   ];
 
+  const currentAccent = state.customThemeColors?.primary ?? "";
+
   return (
     <section id="appearance">
       <SubTitle title="Theme" />
@@ -43,6 +64,30 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
         onChange={(value) => (state.colorTheme = value?.value ?? defaultColorThemePreference)}
         themeName="lens"
       />
+      <div style={{ marginTop: "16px" }}>
+        <SubTitle title="Accent Color" />
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <input
+            type="color"
+            value={currentAccent || "#00a7a0"}
+            onChange={action((e: React.ChangeEvent<HTMLInputElement>) => {
+              state.customThemeColors = getDerivedColors(e.target.value);
+            })}
+            style={{ width: 40, height: 30, padding: 0, border: "none", cursor: "pointer" }}
+          />
+          {currentAccent ? (
+            <button
+              className="btn btn-link"
+              onClick={action(() => {
+                state.customThemeColors = {};
+              })}
+              type="button"
+            >
+              Reset
+            </button>
+          ) : null}
+        </div>
+      </div>
     </section>
   );
 });

--- a/packages/core/src/features/user-preferences/common/custom-theme-colors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/custom-theme-colors.injectable.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getInjectable } from "@ogre-tools/injectable";
+import { computed } from "mobx";
+import userPreferencesStateInjectable from "./state.injectable";
+
+export type CustomThemeColors = Partial<Record<string, string>>;
+
+const customThemeColorsInjectable = getInjectable({
+  id: "custom-theme-colors",
+  instantiate: (di) => {
+    const state = di.inject(userPreferencesStateInjectable);
+
+    return computed((): CustomThemeColors => state.customThemeColors ?? {});
+  },
+});
+
+export default customThemeColorsInjectable;

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -53,6 +53,10 @@ const userPreferenceDescriptorsInjectable = getInjectable({
         fromStore: (val) => val || defaultColorThemePreference,
         toStore: (val) => (!val || val === defaultColorThemePreference ? undefined : val),
       }),
+      customThemeColors: getPreferenceDescriptor<Partial<Record<string, string>>>({
+        fromStore: (val) => val ?? {},
+        toStore: (val) => (val && Object.keys(val).length > 0 ? val : undefined),
+      }),
       terminalTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || "",
         toStore: (val) => val || undefined,

--- a/packages/core/src/features/user-preferences/common/register-injectables.ts
+++ b/packages/core/src/features/user-preferences/common/register-injectables.ts
@@ -10,6 +10,7 @@ import {
   getClusterPageMenuOrderInjectable,
   resetClusterPageMenuOrderInjectable,
 } from "./cluster-page-menu-order.injectable";
+import customThemeColorsInjectable from "./custom-theme-colors.injectable";
 import httpsProxyConfigurationInjectable from "./https-proxy.injectable";
 import isTableColumnHiddenInjectable from "./is-table-column-hidden.injectable";
 import kubeconfigSyncsInjectable from "./kubeconfig-syncs.injectable";
@@ -44,6 +45,11 @@ export function registerInjectables(di: DiContainerForInjection): void {
   }
   try {
     di.register(kubeconfigSyncsInjectable);
+  } catch (e) {
+    /* Ignore duplicate registration */
+  }
+  try {
+    di.register(customThemeColorsInjectable);
   } catch (e) {
     /* Ignore duplicate registration */
   }

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -39,6 +39,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.allowErrorReporting = descriptors.allowErrorReporting.fromStore(preferences.allowErrorReporting);
         state.allowUntrustedCAs = descriptors.allowUntrustedCAs.fromStore(preferences.allowUntrustedCAs);
         state.colorTheme = descriptors.colorTheme.fromStore(preferences.colorTheme);
+        state.customThemeColors = descriptors.customThemeColors.fromStore(preferences.customThemeColors);
         state.downloadBinariesPath = descriptors.downloadBinariesPath.fromStore(preferences.downloadBinariesPath);
         state.downloadKubectlBinaries = descriptors.downloadKubectlBinaries.fromStore(
           preferences.downloadKubectlBinaries,
@@ -71,6 +72,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             allowErrorReporting: descriptors.allowErrorReporting.toStore(state.allowErrorReporting),
             allowUntrustedCAs: descriptors.allowUntrustedCAs.toStore(state.allowUntrustedCAs),
             colorTheme: descriptors.colorTheme.toStore(state.colorTheme),
+            customThemeColors: descriptors.customThemeColors.toStore(state.customThemeColors),
             downloadBinariesPath: descriptors.downloadBinariesPath.toStore(state.downloadBinariesPath),
             downloadKubectlBinaries: descriptors.downloadKubectlBinaries.toStore(state.downloadKubectlBinaries),
             downloadMirror: descriptors.downloadMirror.toStore(state.downloadMirror),

--- a/packages/core/src/renderer/themes/active.injectable.ts
+++ b/packages/core/src/renderer/themes/active.injectable.ts
@@ -7,6 +7,7 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import assert from "assert";
 import { computed } from "mobx";
+import customThemeColorsInjectable from "../../features/user-preferences/common/custom-theme-colors.injectable";
 import lensColorThemePreferenceInjectable from "../../features/user-preferences/common/lens-color-theme.injectable";
 import { lensThemeDeclarationInjectionToken } from "./declaration";
 import defaultLensThemeInjectable from "./default-theme.injectable";
@@ -28,9 +29,11 @@ const activeThemeInjectable: Injectable<IComputedValue<ReadonlyDeep<LensTheme>>>
     const lensColorThemePreference = di.inject(lensColorThemePreferenceInjectable);
     const systemThemeConfiguration = di.inject(systemThemeConfigurationInjectable);
     const defaultLensTheme = di.inject(defaultLensThemeInjectable);
+    const customThemeColors = di.inject(customThemeColorsInjectable);
 
     return computed(() => {
       const pref = lensColorThemePreference.get();
+      let baseTheme: ReadonlyDeep<LensTheme>;
 
       if (pref.useSystemTheme) {
         const systemThemeType = systemThemeConfiguration.get();
@@ -38,10 +41,25 @@ const activeThemeInjectable: Injectable<IComputedValue<ReadonlyDeep<LensTheme>>>
 
         assert(matchingTheme, `Missing theme declaration for system theme "${systemThemeType}"`);
 
-        return matchingTheme;
+        baseTheme = matchingTheme;
+      } else {
+        baseTheme = lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
       }
 
-      return lensThemes.get(pref.lensThemeId) ?? defaultLensTheme;
+      const customColors = customThemeColors.get();
+      const customKeys = Object.keys(customColors);
+
+      if (customKeys.length === 0) {
+        return baseTheme;
+      }
+
+      return {
+        ...baseTheme,
+        colors: {
+          ...baseTheme.colors,
+          ...customColors,
+        },
+      } as ReadonlyDeep<LensTheme>;
     });
   },
 });


### PR DESCRIPTION
## Summary

Adds a custom theme/accent color feature that allows users to override the primary accent color of any Freelens theme from the Appearance settings page.

## Changes

- **New `customThemeColors` user preference**: Stores color overrides as a key-value map of `LensColorName` → hex color string, persisted across sessions via the existing `lens-user-store`
- **New `custom-theme-colors.injectable.ts`**: Provides the custom colors as a MobX computed value from user preferences state
- **Modified `active.injectable.ts`**: Merges custom color overrides on top of the selected base theme before applying it; if no custom colors are set, the base theme is returned unchanged
- **Modified theme settings UI**: Added an HTML5 color picker and Reset button in the Appearance section, allowing users to pick an accent color that automatically applies to `primary`, `blue`, `buttonPrimaryBackground`, `menuActiveBackground`, and `helmStableRepo`
- **Updated storage layer**: Loads/saves `customThemeColors` alongside other preferences

## Implementation Details

- Follows the existing DI pattern using `@ogre-tools/injectable`
- Custom colors are merged on top of the base theme in the active theme computed, so they work with both dark and light themes, as well as with system theme sync
- The `apply-lens-theme.injectable.ts` already sets CSS custom properties for all color keys, so overrides take effect automatically
- When the user resets the accent color, an empty object is stored, which the active theme resolution treats as no custom overrides

## Why not the previous approach (PR #1368)?

The previous PR was closed without merging, likely because it tried to do too much at once. This implementation keeps the change minimal:
- Only adds what is necessary (custom color storage + merge + UI)
- Reuses the existing theme infrastructure instead of creating a parallel theme system
- Does not modify the LensTheme interface or require theme authors to support customization

## Testing
- Select a theme, set a custom accent color, observe the UI updates
- Restart the app, verify the accent color persists
- Click Reset, verify the original theme colors are restored