### PR TITLE
Use node: prefix for Node.js builtin module imports

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -91,6 +91,7 @@
             "strictCase": false
           }
         },
+        "useNodejsImportProtocol": "error",
         // should be error later
         "useTemplate": "off"
       },

--- a/freelens/build/prebuild.cjs
+++ b/freelens/build/prebuild.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 "use strict";
 
-const fs = require("fs");
+const fs = require("node:fs");
 
 // electron-builder requires a pnpm-lock.yaml file to detect the project as a pnpm workspace.
 // The real lockfile lives in the monorepo root, so we generate a dummy one here before building.

--- a/freelens/integration/helpers/kind.ts
+++ b/freelens/integration/helpers/kind.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { spawnSync } from "child_process";
+import { spawnSync } from "node:child_process";
 
 export function kindReady(kindClusterName: string, testNamespace: string): boolean {
   // determine if kind is running

--- a/freelens/integration/helpers/utils.ts
+++ b/freelens/integration/helpers/utils.ts
@@ -4,11 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { createHash } from "node:crypto";
+import * as os from "node:os";
+import * as path from "node:path";
 import { disposer } from "@freelensapp/utilities";
-import { createHash } from "crypto";
 import { mkdirp, remove } from "fs-extra";
-import * as os from "os";
-import * as path from "path";
 import { _electron as electron } from "playwright";
 import * as uuid from "uuid";
 

--- a/packages/core/src/common/app-paths/directory-for-user-data/directory-for-user-data.injectable.ts
+++ b/packages/core/src/common/app-paths/directory-for-user-data/directory-for-user-data.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import os from "node:os";
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import os from "os";
-import path from "path";
 import appNameInjectable from "../../../common/vars/app-name.injectable";
 import appPathsInjectable from "../app-paths.injectable";
 

--- a/packages/core/src/common/catalog/catalog-entity.ts
+++ b/packages/core/src/common/catalog/catalog-entity.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import EventEmitter from "node:events";
 import { iter } from "@freelensapp/utilities";
-import EventEmitter from "events";
 import { once } from "lodash";
 import { makeObservable, observable } from "mobx";
 

--- a/packages/core/src/common/certificate/ca-certificates.injectable.ts
+++ b/packages/core/src/common/certificate/ca-certificates.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import tls from "node:tls";
 import { getInjectable } from "@ogre-tools/injectable";
-import tls from "tls";
 
 const caCertificatesInjectable = getInjectable({
   id: "ca-certificates",

--- a/packages/core/src/common/fs/create-read-file-stream.injectable.ts
+++ b/packages/core/src/common/fs/create-read-file-stream.injectable.ts
@@ -6,7 +6,7 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import fsInjectable from "./fs.injectable";
-import type { ReadStream } from "fs";
+import type { ReadStream } from "node:fs";
 
 export interface CreateReadStreamOptions {
   mode?: number;

--- a/packages/core/src/common/fs/exec-file.injectable.ts
+++ b/packages/core/src/common/fs/exec-file.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { execFile } from "node:child_process";
 import { getInjectable } from "@ogre-tools/injectable";
-import { execFile } from "child_process";
-import type { ExecFileException, ExecFileOptions } from "child_process";
+import type { ExecFileException, ExecFileOptions } from "node:child_process";
 
 import type { AsyncResult } from "@freelensapp/utilities";
 

--- a/packages/core/src/common/fs/lstat.injectable.ts
+++ b/packages/core/src/common/fs/lstat.injectable.ts
@@ -6,7 +6,7 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import fsInjectable from "./fs.injectable";
-import type { Stats } from "fs";
+import type { Stats } from "node:fs";
 
 export type LStat = (path: string) => Promise<Stats>;
 

--- a/packages/core/src/common/fs/read-directory.injectable.ts
+++ b/packages/core/src/common/fs/read-directory.injectable.ts
@@ -6,7 +6,7 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import fsInjectable from "./fs.injectable";
-import type { Dirent } from "fs";
+import type { Dirent } from "node:fs";
 
 export interface ReadDirectory {
   (path: string, options: "buffer" | { encoding: "buffer"; withFileTypes?: false | undefined }): Promise<Buffer[]>;

--- a/packages/core/src/common/fs/stat.injectable.ts
+++ b/packages/core/src/common/fs/stat.injectable.ts
@@ -6,7 +6,7 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import fsInjectable from "./fs.injectable";
-import type { Stats } from "fs";
+import type { Stats } from "node:fs";
 
 export type Stat = (path: string) => Promise<Stats>;
 

--- a/packages/core/src/common/fs/watch/watch.injectable.ts
+++ b/packages/core/src/common/fs/watch/watch.injectable.ts
@@ -6,7 +6,7 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { watch } from "chokidar";
-import type { Stats } from "fs";
+import type { Stats } from "node:fs";
 
 import type { SingleOrMany } from "@freelensapp/utilities";
 

--- a/packages/core/src/common/get-configuration-file-model/get-configuration-file-model.global-override-for-injectable.ts
+++ b/packages/core/src/common/get-configuration-file-model/get-configuration-file-model.global-override-for-injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
+import path from "node:path";
 import { getGlobalOverride } from "@freelensapp/test-utils";
-import assert from "assert";
 import { get, has, set } from "lodash";
-import path from "path";
 import semver from "semver";
 import readJsonSyncInjectable from "../fs/read-json-sync.injectable";
 import writeJsonSyncInjectable from "../fs/write-json-sync.injectable";

--- a/packages/core/src/common/initializable-state/create.ts
+++ b/packages/core/src/common/initializable-state/create.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { getInjectable, getInjectionToken } from "@ogre-tools/injectable";
-import assert from "assert";
 
 import type { Runnable } from "@freelensapp/run-many";
 

--- a/packages/core/src/common/k8s-api/__tests__/api-manager.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/api-manager.test.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { KubeApi } from "@freelensapp/kube-api";
 import { maybeKubeApiInjectable } from "@freelensapp/kube-api-specifics";
 import { KubeObject } from "@freelensapp/kube-object";
@@ -15,7 +16,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { runInAction } from "mobx";
 import { KubeApi as ExternalKubeApi } from "../../../extensions/common-api/k8s-api";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../../renderer/cluster-frame-context/for-namespaced-resources.injectable";

--- a/packages/core/src/common/k8s-api/api-manager/auto-registration-emitter.injectable.ts
+++ b/packages/core/src/common/k8s-api/api-manager/auto-registration-emitter.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import EventEmitter from "node:events";
 import { getInjectable } from "@ogre-tools/injectable";
-import EventEmitter from "events";
 
 import type { KubeApi } from "@freelensapp/kube-api";
 

--- a/packages/core/src/common/k8s-api/create-json-api.injectable.ts
+++ b/packages/core/src/common/k8s-api/create-json-api.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Agent } from "node:https";
 import { JsonApi } from "@freelensapp/json-api";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import { Agent } from "https";
 import lensProxyCertificateInjectable from "../certificate/lens-proxy-certificate.injectable";
 import nodeFetchInjectable from "../fetch/node-fetch.injectable";
 

--- a/packages/core/src/common/k8s-api/create-kube-api-for-remote-cluster.injectable.ts
+++ b/packages/core/src/common/k8s-api/create-kube-api-for-remote-cluster.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Agent } from "node:https";
 import { KubeApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,10 +13,9 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import { Agent } from "https";
 import isDevelopmentInjectable from "../vars/is-development.injectable";
 import createKubeJsonApiInjectable from "./create-kube-json-api.injectable";
-import type { AgentOptions } from "https";
+import type { AgentOptions } from "node:https";
 
 import type { KubeApiOptions } from "@freelensapp/kube-api";
 import type { KubeJsonApiDataFor, KubeObject, KubeObjectConstructor } from "@freelensapp/kube-object";

--- a/packages/core/src/common/k8s-api/create-kube-json-api.injectable.ts
+++ b/packages/core/src/common/k8s-api/create-kube-json-api.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Agent } from "node:https";
 import { KubeJsonApi } from "@freelensapp/kube-api";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import { Agent } from "https";
 import packageJson from "../../../package.json";
 import lensProxyCertificateInjectable from "../certificate/lens-proxy-certificate.injectable";
 import nodeFetchInjectable, { type NodeFetchRequestInit } from "../fetch/node-fetch.injectable";

--- a/packages/core/src/common/k8s-api/kube-object.store.ts
+++ b/packages/core/src/common/k8s-api/kube-object.store.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { parseKubeApi } from "@freelensapp/kube-api";
 import { KubeStatus } from "@freelensapp/kube-object";
 import { includes, object, rejectPromiseBy, waitUntilDefined } from "@freelensapp/utilities";
-import assert from "assert";
 import autoBind from "auto-bind";
 import { action, computed, makeObservable, observable, reaction } from "mobx";
 import { ItemStore } from "../item.store";

--- a/packages/core/src/common/os/home-directory-path.injectable.ts
+++ b/packages/core/src/common/os/home-directory-path.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import os from "node:os";
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import os from "os";
-import path from "path";
 import appNameInjectable from "../vars/app-name.injectable";
 import userInfoInjectable from "../vars/user-info.injectable";
 

--- a/packages/core/src/common/os/kube-directory-path.injectable.ts
+++ b/packages/core/src/common/os/kube-directory-path.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 import userInfoInjectable from "../vars/user-info.injectable";
 
 const kubeDirectoryPathInjectable = getInjectable({

--- a/packages/core/src/common/os/temp-directory-path.injectable.ts
+++ b/packages/core/src/common/os/temp-directory-path.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { tmpdir } from "node:os";
 import { getInjectable } from "@ogre-tools/injectable";
-import { tmpdir } from "os";
 
 const tempDirectoryPathInjectable = getInjectable({
   id: "temp-directory-path",

--- a/packages/core/src/common/path/get-absolute-path.global-override-for-injectable.ts
+++ b/packages/core/src/common/path/get-absolute-path.global-override-for-injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getGlobalOverride } from "@freelensapp/test-utils";
-import path from "path";
 import getAbsolutePathInjectable from "./get-absolute-path.injectable";
 
 export default getGlobalOverride(getAbsolutePathInjectable, () => path.posix.resolve);

--- a/packages/core/src/common/path/get-absolute-path.injectable.ts
+++ b/packages/core/src/common/path/get-absolute-path.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 
 export type GetAbsolutePath = (...args: string[]) => string;
 

--- a/packages/core/src/common/path/get-basename.global-override-for-injectable.ts
+++ b/packages/core/src/common/path/get-basename.global-override-for-injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getGlobalOverride } from "@freelensapp/test-utils";
-import path from "path";
 import getBasenameOfPathInjectable from "./get-basename.injectable";
 
 export default getGlobalOverride(getBasenameOfPathInjectable, () => path.posix.basename);

--- a/packages/core/src/common/path/get-basename.injectable.ts
+++ b/packages/core/src/common/path/get-basename.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 
 export type GetBasenameOfPath = (path: string) => string;
 

--- a/packages/core/src/common/path/get-dirname.global-override-for-injectable.ts
+++ b/packages/core/src/common/path/get-dirname.global-override-for-injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getGlobalOverride } from "@freelensapp/test-utils";
-import path from "path";
 import getDirnameOfPathInjectable from "./get-dirname.injectable";
 
 export default getGlobalOverride(getDirnameOfPathInjectable, () => path.posix.dirname);

--- a/packages/core/src/common/path/get-dirname.injectable.ts
+++ b/packages/core/src/common/path/get-dirname.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 
 export type GetDirnameOfPath = (path: string) => string;
 

--- a/packages/core/src/common/path/get-relative-path.global-override-for-injectable.ts
+++ b/packages/core/src/common/path/get-relative-path.global-override-for-injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getGlobalOverride } from "@freelensapp/test-utils";
-import path from "path";
 import getRelativePathInjectable from "./get-relative-path.injectable";
 
 export default getGlobalOverride(getRelativePathInjectable, () => path.posix.relative);

--- a/packages/core/src/common/path/get-relative-path.injectable.ts
+++ b/packages/core/src/common/path/get-relative-path.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 
 export type GetRelativePath = (from: string, to: string) => string;
 

--- a/packages/core/src/common/path/join-paths.global-override-for-injectable.ts
+++ b/packages/core/src/common/path/join-paths.global-override-for-injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getGlobalOverride } from "@freelensapp/test-utils";
-import path from "path";
 import joinPathsInjectable from "./join-paths.injectable";
 
 export default getGlobalOverride(joinPathsInjectable, () => path.posix.join);

--- a/packages/core/src/common/path/join-paths.injectable.ts
+++ b/packages/core/src/common/path/join-paths.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 
 export type JoinPaths = (...args: string[]) => string;
 

--- a/packages/core/src/common/path/parse.global-override-for-injectable.ts
+++ b/packages/core/src/common/path/parse.global-override-for-injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getGlobalOverride } from "@freelensapp/test-utils";
-import path from "path";
 import parsePathInjectable from "./parse.injectable";
 
 export default getGlobalOverride(parsePathInjectable, () => path.posix.parse);

--- a/packages/core/src/common/path/parse.injectable.ts
+++ b/packages/core/src/common/path/parse.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 
 const parsePathInjectable = getInjectable({
   id: "parse-path",

--- a/packages/core/src/common/path/separator.global-override-for-injectable.ts
+++ b/packages/core/src/common/path/separator.global-override-for-injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getGlobalOverride } from "@freelensapp/test-utils";
-import path from "path";
 import fileSystemSeparatorInjectable from "./separator.injectable";
 
 export default getGlobalOverride(fileSystemSeparatorInjectable, () => path.posix.sep);

--- a/packages/core/src/common/path/separator.injectable.ts
+++ b/packages/core/src/common/path/separator.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 
 const fileSystemSeparatorInjectable = getInjectable({
   id: "file-system-separator",

--- a/packages/core/src/common/utils/__tests__/paths.test.ts
+++ b/packages/core/src/common/utils/__tests__/paths.test.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import path from "path";
+import path from "node:path";
 import { getDiForUnitTesting } from "../../../main/getDiForUnitTesting";
 import getAbsolutePathInjectable from "../../path/get-absolute-path.injectable";
 import getDirnameOfPathInjectable from "../../path/get-dirname.injectable";

--- a/packages/core/src/common/utils/generate-new-id-for.ts
+++ b/packages/core/src/common/utils/generate-new-id-for.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 
 export function generateNewIdFor(cluster: { kubeConfigPath: string; contextName: string }): string {
   return createHash("md5").update(`${cluster.kubeConfigPath}:${cluster.contextName}`).digest("hex");

--- a/packages/core/src/common/utils/random-bytes.injectable.ts
+++ b/packages/core/src/common/utils/random-bytes.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { randomBytes } from "node:crypto";
 import { getInjectable } from "@ogre-tools/injectable";
-import { randomBytes } from "crypto";
 
 export type RandomBytes = (size: number) => Buffer;
 

--- a/packages/core/src/common/utils/wait-for-path.ts
+++ b/packages/core/src/common/utils/wait-for-path.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { FSWatcher } from "chokidar";
-import path from "path";
 
 /**
  * Wait for `filePath` and all parent directories to exist.

--- a/packages/core/src/common/vars/user-info.injectable.ts
+++ b/packages/core/src/common/vars/user-info.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { userInfo } from "node:os";
 import { getInjectable } from "@ogre-tools/injectable";
-import { userInfo } from "os";
 
 const userInfoInjectable = getInjectable({
   id: "user-info",

--- a/packages/core/src/extensions/base-extension-store.ts
+++ b/packages/core/src/extensions/base-extension-store.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
+import * as path from "node:path";
 import { getOrInsertWith } from "@freelensapp/utilities";
-import assert from "assert";
-import * as path from "path";
 import directoryForUserDataInjectable from "../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import createPersistentStorageInjectable, {
   type PersistentStorage,

--- a/packages/core/src/extensions/extension-discovery/extension-discovery.ts
+++ b/packages/core/src/extensions/extension-discovery/extension-discovery.ts
@@ -4,16 +4,16 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { EventEmitter } from "node:events";
 import { isErrnoException } from "@freelensapp/utilities";
 import AwaitLock from "await-lock";
 import { ipcRenderer } from "electron";
-import { EventEmitter } from "events";
 import { makeObservable, observable, reaction, when } from "mobx";
 import { broadcastMessage, ipcMainHandle, ipcRendererOn } from "../../common/ipc";
 import { extensionDiscoveryStateChannel } from "../../common/ipc/extension-handling";
 import { toJS } from "../../common/utils";
 import { requestInitialExtensionDiscovery } from "../../renderer/ipc";
-import type { Stats } from "fs";
+import type { Stats } from "node:fs";
 
 import type {
   ExternalInstalledExtension,

--- a/packages/core/src/extensions/extension-loader/extension-loader.ts
+++ b/packages/core/src/extensions/extension-loader/extension-loader.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
+import { createRequire } from "node:module";
 import { EventEmitter } from "@freelensapp/event-emitter";
 import { isDefined, iter } from "@freelensapp/utilities";
-import assert from "assert";
 import { ipcMain, ipcRenderer } from "electron";
 import { isEqual } from "lodash";
 import { action, computed, observable, reaction, runInAction, toJS, when } from "mobx";
-import { createRequire } from "module";
 import { broadcastMessage, ipcMainHandle, ipcMainOn, ipcRendererOn } from "../../common/ipc";
 import {
   extensionLoaderFromMainChannel,

--- a/packages/core/src/extensions/install-extension/fork-pnpm.injectable.ts
+++ b/packages/core/src/extensions/install-extension/fork-pnpm.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { fork } from "node:child_process";
 import { prefixedLoggerInjectable } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import { fork } from "child_process";
 import directoryForUserDataInjectable from "../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import pathToPnpmCliInjectable from "../../common/app-paths/path-to-pnpm-cli.injectable";
 import joinPathsInjectable from "../../common/path/join-paths.injectable";

--- a/packages/core/src/extensions/ipc/ipc-registrar.ts
+++ b/packages/core/src/extensions/ipc/ipc-registrar.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 import { broadcastMessage } from "../../common/ipc";
 import { Singleton } from "../../common/utils/singleton";
 

--- a/packages/core/src/features/application-menu/application-menu.test.ts
+++ b/packages/core/src/features/application-menu/application-menu.test.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { inspect } from "util";
+import { inspect } from "node:util";
 import { getCompositePaths } from "../../common/utils/composite/get-composite-paths/get-composite-paths";
 import platformInjectable, { allPlatforms } from "../../common/vars/platform.injectable";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";

--- a/packages/core/src/features/cluster/connections/main/api-url.injectable.ts
+++ b/packages/core/src/features/cluster/connections/main/api-url.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { URL } from "node:url";
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
-import { URL } from "url";
 import statInjectable from "../../../../common/fs/stat.injectable";
 import loadValidatedClusterConfigInjectable from "../../../../common/kube-helpers/load-validated-config-from-file.injectable";
 

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/reactively-hide-kube-object-detail-item.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/reactively-hide-kube-object-detail-item.test.tsx
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { KubeObject } from "@freelensapp/kube-object";
-import assert from "assert";
 import { computed, observable, runInAction } from "mobx";
 import React from "react";
 import apiManagerInjectable from "../../../../common/k8s-api/api-manager/manager.injectable";

--- a/packages/core/src/features/cluster/sidebar-and-tab-navigation-for-extensions.test.tsx
+++ b/packages/core/src/features/cluster/sidebar-and-tab-navigation-for-extensions.test.tsx
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { flushPromises } from "@freelensapp/test-utils";
 import { fireEvent } from "@testing-library/react";
-import assert from "assert";
 import { matches } from "lodash/fp";
 import { computed, observable, runInAction } from "mobx";
 import React from "react";

--- a/packages/core/src/features/cluster/storage/cluster-storage.test.ts
+++ b/packages/core/src/features/cluster/storage/cluster-storage.test.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import assert from "assert";
+import assert from "node:assert";
 import directoryForTempInjectable from "../../../common/app-paths/directory-for-temp/directory-for-temp.injectable";
 import directoryForUserDataInjectable from "../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import getCustomKubeConfigFilePathInjectable from "../../../common/app-paths/get-custom-kube-config-directory/get-custom-kube-config-directory.injectable";

--- a/packages/core/src/features/hotbar/storage/common/remove.injectable.ts
+++ b/packages/core/src/features/hotbar/storage/common/remove.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { iter } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { action } from "mobx";
 import activeHotbarIdInjectable from "./active-id.injectable";
 import hotbarsStateInjectable from "./state.injectable";

--- a/packages/core/src/features/namespace-filtering/renderer/storage.injectable.ts
+++ b/packages/core/src/features/namespace-filtering/renderer/storage.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import hostedClusterInjectable from "../../../renderer/cluster-frame-context/hosted-cluster.injectable";
 import createStorageInjectable from "../../../renderer/utils/create-storage/create-storage.injectable";
 

--- a/packages/core/src/features/persistent-storage/common/create.injectable.ts
+++ b/packages/core/src/features/persistent-storage/common/create.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { nextTick } from "node:process";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { enlistMessageChannelListenerInjectionToken, sendMessageToChannelInjectionToken } from "@freelensapp/messaging";
 import { disposer, isPromiseLike } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import { isEqual, kebabCase } from "lodash";
 import { reaction } from "mobx";
-import { nextTick } from "process";
 import directoryForUserDataInjectable from "../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import getConfigurationFileModelInjectable from "../../../common/get-configuration-file-model/get-configuration-file-model.injectable";
 import getBasenameOfPathInjectable from "../../../common/path/get-basename.injectable";

--- a/packages/core/src/features/population-of-logs-to-a-file/renderer/ipc-transport.ts
+++ b/packages/core/src/features/population-of-logs-to-a-file/renderer/ipc-transport.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { setImmediate } from "timers";
+import { setImmediate } from "node:timers";
 import TransportStream from "winston-transport";
 
 import type { LogEntry } from "winston";

--- a/packages/core/src/features/shell-sync/main/compute-unix-shell-environment.test.ts
+++ b/packages/core/src/features/shell-sync/main/compute-unix-shell-environment.test.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import EventEmitter from "node:events";
 import { flushPromises } from "@freelensapp/test-utils";
-import EventEmitter from "events";
 import MemoryStream from "memorystream";
 import spawnInjectable from "../../../main/child-process/spawn.injectable";
 import randomUUIDInjectable from "../../../main/crypto/random-uuid.injectable";
@@ -13,7 +13,7 @@ import { getDiForUnitTesting } from "../../../main/getDiForUnitTesting";
 import computeUnixShellEnvironmentInjectable from "./compute-unix-shell-environment.injectable";
 import processEnvInjectable from "./env.injectable";
 import processExecPathInjectable from "./execPath.injectable";
-import type { ChildProcessWithoutNullStreams } from "child_process";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
 import type { DiContainer } from "@ogre-tools/injectable";
 import type { MockedFunction } from "vitest";

--- a/packages/core/src/features/shell-sync/main/env.injectable.ts
+++ b/packages/core/src/features/shell-sync/main/env.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import process from "node:process";
 import { getInjectable } from "@ogre-tools/injectable";
-import process from "process";
 
 const processEnvInjectable = getInjectable({
   id: "process-env",

--- a/packages/core/src/features/shell-sync/main/execPath.injectable.ts
+++ b/packages/core/src/features/shell-sync/main/execPath.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import process from "node:process";
 import { getInjectable } from "@ogre-tools/injectable";
-import process from "process";
 
 const processExecPathInjectable = getInjectable({
   id: "process-exec-path",

--- a/packages/core/src/main/__test__/kube-api-upgrade-request.test.ts
+++ b/packages/core/src/main/__test__/kube-api-upgrade-request.test.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-vi.mock("tls", () => {
+vi.mock("node:tls", () => {
   const connect = vi.fn();
 
   // Some modules in the graph import tls as a default import, so the mock has
@@ -12,8 +12,8 @@ vi.mock("tls", () => {
   return { connect, default: { connect } };
 });
 
-import { EventEmitter } from "events";
-import { connect } from "tls";
+import { EventEmitter } from "node:events";
+import { connect } from "node:tls";
 import { Cluster } from "../../common/cluster/cluster";
 import { apiKubePrefix } from "../../common/vars";
 import clusterApiUrlInjectable from "../../features/cluster/connections/main/api-url.injectable";

--- a/packages/core/src/main/__test__/kube-auth-proxy.test.ts
+++ b/packages/core/src/main/__test__/kube-auth-proxy.test.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { EventEmitter } from "stream";
+import { EventEmitter } from "node:stream";
 import { mock, mockDeep } from "vitest-mock-extended";
 import directoryForTempInjectable from "../../common/app-paths/directory-for-temp/directory-for-temp.injectable";
 import directoryForUserDataInjectable from "../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
@@ -21,8 +21,8 @@ import waitUntilPortIsUsedInjectable from "../kube-auth-proxy/wait-until-port-is
 import kubectlBinaryNameInjectable from "../kubectl/binary-name.injectable";
 import { Kubectl } from "../kubectl/kubectl";
 import kubectlDownloadingNormalizedArchInjectable from "../kubectl/normalized-arch.injectable";
-import type { ChildProcess } from "child_process";
-import type { Readable } from "stream";
+import type { ChildProcess } from "node:child_process";
+import type { Readable } from "node:stream";
 
 import type { Mock } from "vitest";
 import type { DeepMockProxy } from "vitest-mock-extended";

--- a/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
+++ b/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import EventEmitter from "node:events";
 import asyncFn from "@async-fn/vitest";
 import { iter, strictGet } from "@freelensapp/utilities";
-import EventEmitter from "events";
 import { ObservableMap, observable, runInAction } from "mobx";
 import directoryForTempInjectable from "../../../common/app-paths/directory-for-temp/directory-for-temp.injectable";
 import directoryForUserDataInjectable from "../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
@@ -26,7 +26,7 @@ import computeKubeconfigDiffInjectable from "../kubeconfig-sync/compute-diff.inj
 import configToModelsInjectable from "../kubeconfig-sync/config-to-models.injectable";
 import kubeconfigSyncLoggerInjectable from "../kubeconfig-sync/logger.injectable";
 import kubeconfigSyncManagerInjectable from "../kubeconfig-sync/manager.injectable";
-import type { ReadStream, Stats } from "fs";
+import type { ReadStream, Stats } from "node:fs";
 
 import type { Logger } from "@freelensapp/logger";
 

--- a/packages/core/src/main/catalog-sources/kubeconfig-sync/compute-diff.injectable.ts
+++ b/packages/core/src/main/catalog-sources/kubeconfig-sync/compute-diff.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
 import { getInjectable } from "@ogre-tools/injectable";
-import { createHash } from "crypto";
 import { action } from "mobx";
-import { homedir } from "os";
 import directoryForKubeConfigsInjectable from "../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import { Cluster } from "../../../common/cluster/cluster";
 import { loadConfigFromString } from "../../../common/kube-helpers";

--- a/packages/core/src/main/catalog-sources/kubeconfig-sync/diff-changed-kubeconfig.injectable.ts
+++ b/packages/core/src/main/catalog-sources/kubeconfig-sync/diff-changed-kubeconfig.injectable.ts
@@ -4,14 +4,14 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { constants } from "node:fs";
 import { bytesToUnits, noop } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
-import { constants } from "fs";
 import createReadFileStreamInjectable from "../../../common/fs/create-read-file-stream.injectable";
 import computeKubeconfigDiffInjectable from "./compute-diff.injectable";
 import kubeconfigSyncLoggerInjectable from "./logger.injectable";
-import type { Stats } from "fs";
-import type { Readable } from "stream";
+import type { Stats } from "node:fs";
+import type { Readable } from "node:stream";
 
 import type { Disposer } from "@freelensapp/utilities";
 

--- a/packages/core/src/main/catalog-sources/kubeconfig-sync/watch-file-changes.injectable.ts
+++ b/packages/core/src/main/catalog-sources/kubeconfig-sync/watch-file-changes.injectable.ts
@@ -4,12 +4,12 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
+import { inspect } from "node:util";
 import { getOrInsertWith, isErrnoException, iter } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import GlobToRegExp from "glob-to-regexp";
 import { computed, observable } from "mobx";
-import path from "path";
-import { inspect } from "util";
 import statInjectable from "../../../common/fs/stat.injectable";
 import watchInjectable from "../../../common/fs/watch/watch.injectable";
 import diffChangedKubeconfigInjectable from "./diff-changed-kubeconfig.injectable";

--- a/packages/core/src/main/child-process/spawn.injectable.ts
+++ b/packages/core/src/main/child-process/spawn.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { spawn } from "node:child_process";
 import { getInjectable } from "@ogre-tools/injectable";
-import { spawn } from "child_process";
 
 export type Spawn = typeof spawn;
 

--- a/packages/core/src/main/cluster-detectors/cluster-distribution-detector.injectable.ts
+++ b/packages/core/src/main/cluster-detectors/cluster-distribution-detector.injectable.ts
@@ -10,7 +10,7 @@ import clusterApiUrlInjectable from "../../features/cluster/connections/main/api
 import k8SRequestInjectable from "../k8s-request.injectable";
 import requestClusterVersionInjectable from "./request-cluster-version.injectable";
 import { clusterMetadataDetectorInjectionToken } from "./token";
-import type { URL } from "url";
+import type { URL } from "node:url";
 
 import type { Cluster } from "../../common/cluster/cluster";
 

--- a/packages/core/src/main/cluster-detectors/cluster-id-detector.injectable.ts
+++ b/packages/core/src/main/cluster-detectors/cluster-id-detector.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { createHash } from "node:crypto";
 import { getInjectable } from "@ogre-tools/injectable";
-import { createHash } from "crypto";
 import { ClusterMetadataKey } from "../../common/cluster-types";
 import clusterApiUrlInjectable from "../../features/cluster/connections/main/api-url.injectable";
 import k8SRequestInjectable from "../k8s-request.injectable";

--- a/packages/core/src/main/crypto/random-uuid.injectable.ts
+++ b/packages/core/src/main/crypto/random-uuid.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { randomUUID } from "node:crypto";
 import { getInjectable } from "@ogre-tools/injectable";
-import { randomUUID } from "crypto";
 
 const randomUUIDInjectable = getInjectable({
   id: "random-uuid",

--- a/packages/core/src/main/electron-app/electron-app.global-override-for-injectable.ts
+++ b/packages/core/src/main/electron-app/electron-app.global-override-for-injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import EventEmitter from "node:events";
 import { getGlobalOverride } from "@freelensapp/test-utils";
 import { getOrInsert } from "@freelensapp/utilities";
-import EventEmitter from "events";
 import { kebabCase } from "lodash";
 import electronAppInjectable from "./electron-app.injectable";
 

--- a/packages/core/src/main/electron-app/features/native-theme.global-override-for-injectable.ts
+++ b/packages/core/src/main/electron-app/features/native-theme.global-override-for-injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import EventEmitter from "node:events";
 import { getGlobalOverride } from "@freelensapp/test-utils";
-import EventEmitter from "events";
 import nativeThemeInjectable from "./native-theme.injectable";
 
 export default getGlobalOverride(nativeThemeInjectable, () =>

--- a/packages/core/src/main/fetch/https-agent.injectable.ts
+++ b/packages/core/src/main/fetch/https-agent.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import https from "node:https";
 import { getInjectable, type Injectable } from "@ogre-tools/injectable";
 import { HttpsProxyAgent } from "hpagent";
-import https from "https";
 import caCertificatesInjectable from "../../common/certificate/ca-certificates.injectable";
 import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
 

--- a/packages/core/src/main/fetch/lens-fetch.injectable.ts
+++ b/packages/core/src/main/fetch/lens-fetch.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Agent } from "node:https";
 import { getInjectable } from "@ogre-tools/injectable";
-import { Agent } from "https";
 import lensProxyCertificateInjectable from "../../common/certificate/lens-proxy-certificate.injectable";
 import nodeFetchInjectable, {
   type NodeFetchRequestInit,

--- a/packages/core/src/main/helm/exec-helm/exec-helm.injectable.ts
+++ b/packages/core/src/main/helm/exec-helm/exec-helm.injectable.ts
@@ -8,7 +8,7 @@ import { getInjectable } from "@ogre-tools/injectable";
 import execFileInjectable from "../../../common/fs/exec-file.injectable";
 import helmBinaryPathInjectable from "../helm-binary-path.injectable";
 import execHelmEnvInjectable from "./exec-env.injectable";
-import type { ExecFileException } from "child_process";
+import type { ExecFileException } from "node:child_process";
 
 import type { AsyncResult } from "@freelensapp/utilities";
 

--- a/packages/core/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable.ts
+++ b/packages/core/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable.ts
@@ -4,11 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { isNumber } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import nonPromiseExecFileInjectable from "./non-promise-exec-file.injectable";
-import type { ChildProcess } from "child_process";
+import type { ChildProcess } from "node:child_process";
 
 import type { AsyncResult } from "@freelensapp/utilities";
 

--- a/packages/core/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.test.ts
+++ b/packages/core/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.test.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import EventEmitter from "node:events";
 import { getPromiseStatus } from "@freelensapp/test-utils";
-import EventEmitter from "events";
 import { getDiForUnitTesting } from "../../../../../getDiForUnitTesting";
 import execFileWithInputInjectable from "./exec-file-with-input.injectable";
 import nonPromiseExecFileInjectable from "./non-promise-exec-file.injectable";

--- a/packages/core/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/non-promise-exec-file.injectable.ts
+++ b/packages/core/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/non-promise-exec-file.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { execFile } from "node:child_process";
 import { getInjectable } from "@ogre-tools/injectable";
-import { execFile } from "child_process";
 
 const nonPromiseExecFileInjectable = getInjectable({
   id: "non-promise-exec-file",

--- a/packages/core/src/main/helm/repositories/get-active-helm-repository.injectable.ts
+++ b/packages/core/src/main/helm/repositories/get-active-helm-repository.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import getActiveHelmRepositoriesInjectable from "./get-active-helm-repositories/get-active-helm-repositories.injectable";
 
 const getActiveHelmRepositoryInjectable = getInjectable({

--- a/packages/core/src/main/kube-auth-proxy/create-kube-auth-proxy.injectable.ts
+++ b/packages/core/src/main/kube-auth-proxy/create-kube-auth-proxy.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
-import assert from "assert";
 import { observable, when } from "mobx";
 import { TypedRegEx } from "typed-regex";
 import getDirnameOfPathInjectable from "../../common/path/get-dirname.injectable";
@@ -18,7 +18,7 @@ import getPortFromStreamInjectable from "../utils/get-port-from-stream.injectabl
 import freeLensK8sProxyPathInjectable from "./freelens-k8s-proxy-path.injectable";
 import kubeAuthProxyCertificateInjectable from "./kube-auth-proxy-certificate.injectable";
 import waitUntilPortIsUsedInjectable from "./wait-until-port-is-used/wait-until-port-is-used.injectable";
-import type { ChildProcess } from "child_process";
+import type { ChildProcess } from "node:child_process";
 
 import type { Cluster } from "../../common/cluster/cluster";
 

--- a/packages/core/src/main/kubectl/kubectl.ts
+++ b/packages/core/src/main/kubectl/kubectl.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import fs from "node:fs";
 import { hasTypedProperty, isObject, isString, json } from "@freelensapp/utilities";
-import fs from "fs";
 import { ensureDir, pathExists } from "fs-extra";
 import { noop } from "lodash/fp";
 import * as lockFile from "proper-lockfile";

--- a/packages/core/src/main/lens-proxy/lens-proxy.ts
+++ b/packages/core/src/main/lens-proxy/lens-proxy.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import assert from "assert";
-import https from "https";
-import net from "net";
+import assert from "node:assert";
+import https from "node:https";
+import net from "node:net";
 import stoppable from "stoppable";
 import { apiKubePrefix, apiPrefix } from "../../common/vars";
 import { getBoolean } from "../utils/parse-query";
-import type http from "http";
+import type http from "node:http";
 
 import type { Logger } from "@freelensapp/logger";
 

--- a/packages/core/src/main/lens-proxy/proxy-functions/kube-api-upgrade-request.injectable.ts
+++ b/packages/core/src/main/lens-proxy/proxy-functions/kube-api-upgrade-request.injectable.ts
@@ -4,15 +4,15 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { connect } from "node:tls";
+import url from "node:url";
 import { getInjectable } from "@ogre-tools/injectable";
 import { chunk } from "lodash";
-import { connect } from "tls";
-import url from "url";
 import { apiKubePrefix } from "../../../common/vars";
 import clusterApiUrlInjectable from "../../../features/cluster/connections/main/api-url.injectable";
 import kubeAuthProxyServerInjectable from "../../cluster/kube-auth-proxy-server.injectable";
 import kubeAuthProxyCertificateInjectable from "../../kube-auth-proxy/kube-auth-proxy-certificate.injectable";
-import type { ConnectionOptions } from "tls";
+import type { ConnectionOptions } from "node:tls";
 
 import type { LensProxyApiRequest } from "../lens-proxy";
 

--- a/packages/core/src/main/lens-proxy/proxy-functions/shell-request-authenticator/shell-request-authenticator.ts
+++ b/packages/core/src/main/lens-proxy/proxy-functions/shell-request-authenticator/shell-request-authenticator.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import crypto from "node:crypto";
+import { promisify } from "node:util";
 import { getOrInsertMap } from "@freelensapp/utilities";
-import crypto from "crypto";
-import { promisify } from "util";
 import { ipcMainHandle } from "../../../../common/ipc";
 
 import type { ClusterId } from "../../../../common/cluster-types";

--- a/packages/core/src/main/lens-proxy/proxy-functions/types.ts
+++ b/packages/core/src/main/lens-proxy/proxy-functions/types.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import type http from "http";
-import type net from "net";
+import type http from "node:http";
+import type net from "node:net";
 
 import type { SetRequired } from "type-fest";
 

--- a/packages/core/src/main/logger/console-format.ts
+++ b/packages/core/src/main/logger/console-format.ts
@@ -4,11 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { inspect } from "node:util";
 import chalk from "chalk";
 import { omit } from "lodash";
 import { LEVEL, MESSAGE, SPLAT } from "triple-beam";
-import { inspect } from "util";
-import type { InspectOptions } from "util";
+import type { InspectOptions } from "node:util";
 
 import type { Format, TransformableInfo } from "logform";
 

--- a/packages/core/src/main/router/create-handler-for-route.injectable.ts
+++ b/packages/core/src/main/router/create-handler-for-route.injectable.ts
@@ -8,7 +8,7 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { object } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import { contentTypes } from "./router-content-types";
-import type { ServerResponse } from "http";
+import type { ServerResponse } from "node:http";
 
 import type { LensApiRequest, Route } from "./route";
 

--- a/packages/core/src/main/router/route.ts
+++ b/packages/core/src/main/router/route.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import type http from "http";
-import type { URLSearchParams } from "url";
+import type http from "node:http";
+import type { URLSearchParams } from "node:url";
 
 import type httpProxy from "http-proxy-node16";
 import type Joi from "joi";

--- a/packages/core/src/main/router/router.ts
+++ b/packages/core/src/main/router/router.ts
@@ -5,7 +5,7 @@
  */
 
 import Call from "@hapi/call";
-import type http from "http";
+import type http from "node:http";
 
 import type { Cluster } from "../../common/cluster/cluster";
 import type { ServerIncomingMessage } from "../lens-proxy/lens-proxy";

--- a/packages/core/src/main/routes/files/development.injectable.ts
+++ b/packages/core/src/main/routes/files/development.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import httpProxy from "http-proxy-node16";
-import path from "path";
 
 import type { LensApiRequest, RouteResponse } from "../../router/route";
 

--- a/packages/core/src/main/routes/files/production.injectable.ts
+++ b/packages/core/src/main/routes/files/production.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { prefixedLoggerInjectable } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 import readFileBufferInjectable from "../../../common/fs/read-file-buffer.injectable";
 import joinPathsInjectable from "../../../common/path/join-paths.injectable";
 import staticFilesDirectoryInjectable from "../../../common/vars/static-files-directory.injectable";

--- a/packages/core/src/main/routes/port-forward/functionality/port-forward.ts
+++ b/packages/core/src/main/routes/port-forward/functionality/port-forward.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { spawn } from "child_process";
+import { spawn } from "node:child_process";
 import * as tcpPortUsed from "tcp-port-used";
 import { TypedRegEx } from "typed-regex";
-import type { ChildProcessWithoutNullStreams } from "child_process";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
 import type { Logger } from "@freelensapp/logger";
 

--- a/packages/core/src/main/shell-session/shell-session.ts
+++ b/packages/core/src/main/shell-session/shell-session.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import os from "node:os";
+import path from "node:path";
 import { getOrInsertWith } from "@freelensapp/utilities";
-import os from "os";
-import path from "path";
 import { TerminalChannels, type TerminalMessage } from "../../common/terminal/channels";
 import { clearKubeconfigEnvVars } from "../utils/clear-kube-env-vars";
 

--- a/packages/core/src/main/start-main-application/lens-window/application-window/session-certificate-verifier.injectable.ts
+++ b/packages/core/src/main/start-main-application/lens-window/application-window/session-certificate-verifier.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { timingSafeEqual, X509Certificate } from "node:crypto";
 import { getInjectable } from "@ogre-tools/injectable";
-import { timingSafeEqual, X509Certificate } from "crypto";
 import lensProxyCertificateInjectable from "../../../../common/certificate/lens-proxy-certificate.injectable";
 
 import type { Request } from "electron";

--- a/packages/core/src/main/start-main-application/lens-window/navigate-for-extension.injectable.ts
+++ b/packages/core/src/main/start-main-application/lens-window/navigate-for-extension.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { iter } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import clusterFramesInjectable from "../../../common/cluster-frames.injectable";
 import { navigateForExtensionChannel } from "../../../features/extensions/navigate/common/channel";
 import getCurrentApplicationWindowInjectable from "./application-window/get-current-application-window.injectable";

--- a/packages/core/src/main/start-main-application/lens-window/navigate.injectable.ts
+++ b/packages/core/src/main/start-main-application/lens-window/navigate.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { iter } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import clusterFramesInjectable from "../../../common/cluster-frames.injectable";
 import { IpcRendererNavigationEvents } from "../../../common/ipc/navigation-events";
 import getCurrentApplicationWindowInjectable from "./application-window/get-current-application-window.injectable";

--- a/packages/core/src/main/start-main-application/runnables/setup-lens-proxy.injectable.ts
+++ b/packages/core/src/main/start-main-application/runnables/setup-lens-proxy.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Agent } from "node:https";
 import { beforeApplicationIsLoadingInjectionToken } from "@freelensapp/application";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import { Agent } from "https";
 import lensProxyCertificateInjectable from "../../../common/certificate/lens-proxy-certificate.injectable";
 import nodeFetchInjectable from "../../../common/fetch/node-fetch.injectable";
 import isProductionInjectable from "../../../common/vars/is-production.injectable";

--- a/packages/core/src/main/utils/get-port-from-stream.injectable.ts
+++ b/packages/core/src/main/utils/get-port-from-stream.injectable.ts
@@ -7,7 +7,7 @@
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
 import URLParse from "url-parse";
-import type { Readable } from "stream";
+import type { Readable } from "node:stream";
 
 export interface GetPortFromStreamArgs {
   /**

--- a/packages/core/src/main/utils/http-responses.ts
+++ b/packages/core/src/main/utils/http-responses.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import type http from "http";
+import type http from "node:http";
 
 /**
  * Respond to a HTTP request with a body of JSON data

--- a/packages/core/src/renderer/api/create-terminal-api.injectable.ts
+++ b/packages/core/src/renderer/api/create-terminal-api.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import hostedClusterIdInjectable from "../cluster-frame-context/hosted-cluster-id.injectable";
 import defaultWebsocketApiParamsInjectable from "./default-websocket-api-params.injectable";
 import { TerminalApi } from "./terminal-api";

--- a/packages/core/src/renderer/api/terminal-api.ts
+++ b/packages/core/src/renderer/api/terminal-api.ts
@@ -4,11 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import url from "node:url";
 import { ipcRenderer } from "electron";
 import { once } from "lodash";
 import isEqual from "lodash/isEqual";
 import { makeObservable, observable } from "mobx";
-import url from "url";
 import { TerminalChannels, type TerminalMessage } from "../../common/terminal/channels";
 import { WebSocketApi } from "./websocket-api";
 

--- a/packages/core/src/renderer/api/websocket-api.ts
+++ b/packages/core/src/renderer/api/websocket-api.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import EventEmitter from "events";
+import EventEmitter from "node:events";
 import { makeObservable, observable } from "mobx";
 
 import type { Defaulted } from "@freelensapp/utilities";

--- a/packages/core/src/renderer/bootstrap.tsx
+++ b/packages/core/src/renderer/bootstrap.tsx
@@ -6,7 +6,7 @@
 
 import "./components/app.scss";
 
-import assert from "assert";
+import assert from "node:assert";
 import extensionDiscoveryInjectable from "../extensions/extension-discovery/extension-discovery.injectable";
 import extensionInstallationStateStoreInjectable from "../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
 import extensionLoaderInjectable from "../extensions/extension-loader/extension-loader.injectable";

--- a/packages/core/src/renderer/cluster-frame-context/for-namespaced-resources.injectable.ts
+++ b/packages/core/src/renderer/cluster-frame-context/for-namespaced-resources.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { computed } from "mobx";
 import selectedNamespacesStorageInjectable from "../../features/namespace-filtering/renderer/storage.injectable";
 import namespaceStoreInjectable from "../components/namespaces/store.injectable";

--- a/packages/core/src/renderer/components/catalog/catalog-add-button.tsx
+++ b/packages/core/src/renderer/components/catalog/catalog-add-button.tsx
@@ -5,11 +5,11 @@
  */
 
 import "./catalog-add-button.scss";
+import { EventEmitter } from "node:events";
 import { Icon } from "@freelensapp/icon";
 import { SpeedDial, SpeedDialAction } from "@mui/material";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import autoBindReact from "auto-bind/react";
-import { EventEmitter } from "events";
 import { action, makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";

--- a/packages/core/src/renderer/components/chart/bar-chart.tsx
+++ b/packages/core/src/renderer/components/chart/bar-chart.tsx
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { bytesToUnits, cssNames, isObject } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import assert from "assert";
 import Color from "color";
 import merge from "lodash/merge";
 import { observer } from "mobx-react";

--- a/packages/core/src/renderer/components/cluster-manager/cluster-frame-handler.ts
+++ b/packages/core/src/renderer/components/cluster-manager/cluster-frame-handler.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { onceDefined } from "@freelensapp/utilities";
-import assert from "assert";
 import { action, makeObservable, observable, when } from "mobx";
 import { getClusterFrameUrl } from "../../../common/utils";
 

--- a/packages/core/src/renderer/components/cluster-settings/__tests__/cluster-local-terminal-settings.test.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/__tests__/cluster-local-terminal-settings.test.tsx
@@ -14,7 +14,7 @@ import statInjectable from "../../../../common/fs/stat.injectable";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import { renderFor } from "../../test-utils/renderFor";
 import { ClusterLocalTerminalSetting } from "../local-terminal-settings";
-import type { Stats } from "fs";
+import type { Stats } from "node:fs";
 
 import type { UserEvent } from "@testing-library/user-event";
 import type { Mock } from "vitest";

--- a/packages/core/src/renderer/components/cluster/store.injectable.ts
+++ b/packages/core/src/renderer/components/cluster/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { clusterApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { ClusterStore } from "./store";

--- a/packages/core/src/renderer/components/config-horizontal-pod-autoscalers/store.injectable.ts
+++ b/packages/core/src/renderer/components/config-horizontal-pod-autoscalers/store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   horizontalPodAutoscalerApiInjectable,
   storesAndApisCanBeCreatedInjectionToken,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { HorizontalPodAutoscalerStore } from "./store";

--- a/packages/core/src/renderer/components/config-leases/store.injectable.ts
+++ b/packages/core/src/renderer/components/config-leases/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { leaseApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { LeaseStore } from "./store";

--- a/packages/core/src/renderer/components/config-limit-ranges/store.injectable.ts
+++ b/packages/core/src/renderer/components/config-limit-ranges/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { limitRangeApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { LimitRangeStore } from "./store";

--- a/packages/core/src/renderer/components/config-maps/store.injectable.ts
+++ b/packages/core/src/renderer/components/config-maps/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { configMapApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { ConfigMapStore } from "./store";

--- a/packages/core/src/renderer/components/config-mutating-webhook-configurations/mutating-webhook-configuration-store.injectable.ts
+++ b/packages/core/src/renderer/components/config-mutating-webhook-configurations/mutating-webhook-configuration-store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   mutatingWebhookConfigurationApiInjectable,
   storesAndApisCanBeCreatedInjectionToken,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { MutatingWebhookConfigurationStore } from "./mutating-webhook-configuration-store";

--- a/packages/core/src/renderer/components/config-pod-disruption-budgets/store.injectable.ts
+++ b/packages/core/src/renderer/components/config-pod-disruption-budgets/store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   podDisruptionBudgetApiInjectable,
   storesAndApisCanBeCreatedInjectionToken,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { PodDisruptionBudgetStore } from "./store";

--- a/packages/core/src/renderer/components/config-priority-classes/store.injectable.ts
+++ b/packages/core/src/renderer/components/config-priority-classes/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { priorityClassApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForClusterScopedResourcesInjectable from "../../cluster-frame-context/for-cluster-scoped-resources.injectable";
 import { PriorityClassStore } from "./store";

--- a/packages/core/src/renderer/components/config-resource-quotas/store.injectable.ts
+++ b/packages/core/src/renderer/components/config-resource-quotas/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { resourceQuotaApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { ResourceQuotaStore } from "./store";

--- a/packages/core/src/renderer/components/config-runtime-classes/store.injectable.ts
+++ b/packages/core/src/renderer/components/config-runtime-classes/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { runtimeClassApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForClusterScopedResourcesInjectable from "../../cluster-frame-context/for-cluster-scoped-resources.injectable";
 import { RuntimeClassStore } from "./store";

--- a/packages/core/src/renderer/components/config-secrets/store.injectable.ts
+++ b/packages/core/src/renderer/components/config-secrets/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { secretApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { SecretStore } from "./store";

--- a/packages/core/src/renderer/components/config-validating-admission-policies/validating-admission-policy-store.injectable.ts
+++ b/packages/core/src/renderer/components/config-validating-admission-policies/validating-admission-policy-store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   storesAndApisCanBeCreatedInjectionToken,
   validatingAdmissionPolicyApiInjectable,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { ValidatingAdmissionPolicyStore } from "./validating-admission-policy-store";

--- a/packages/core/src/renderer/components/config-validating-admission-policy-bindings/validating-admission-policy-binding-store.injectable.ts
+++ b/packages/core/src/renderer/components/config-validating-admission-policy-bindings/validating-admission-policy-binding-store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   storesAndApisCanBeCreatedInjectionToken,
   validatingAdmissionPolicyBindingApiInjectable,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { ValidatingAdmissionPolicyBindingStore } from "./validating-admission-policy-binding-store";

--- a/packages/core/src/renderer/components/config-validating-webhook-configurations/validating-webhook-configuration-store.injectable.ts
+++ b/packages/core/src/renderer/components/config-validating-webhook-configurations/validating-webhook-configuration-store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   storesAndApisCanBeCreatedInjectionToken,
   validatingWebhookConfigurationApiInjectable,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { ValidatingWebhookConfigurationStore } from "./validating-webhook-configuration-store";

--- a/packages/core/src/renderer/components/config-vertical-pod-autoscalers/store.injectable.ts
+++ b/packages/core/src/renderer/components/config-vertical-pod-autoscalers/store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   storesAndApisCanBeCreatedInjectionToken,
   verticalPodAutoscalerApiInjectable,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { VerticalPodAutoscalerStore } from "./store";

--- a/packages/core/src/renderer/components/custom-resource-definitions/store.injectable.ts
+++ b/packages/core/src/renderer/components/custom-resource-definitions/store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   customResourceDefinitionApiInjectable,
   storesAndApisCanBeCreatedInjectionToken,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForClusterScopedResourcesInjectable from "../../cluster-frame-context/for-cluster-scoped-resources.injectable";
 import { CustomResourceDefinitionStore } from "./store";

--- a/packages/core/src/renderer/components/dock/create-resource/user-templates.injectable.ts
+++ b/packages/core/src/renderer/components/dock/create-resource/user-templates.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { readFile } from "node:fs/promises";
 import { prefixedLoggerInjectable } from "@freelensapp/logger";
 import { delay, getOrInsert, isErrnoException } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
-import { readFile } from "fs/promises";
 import { computed, observable } from "mobx";
 import watchInjectable from "../../../../common/fs/watch/watch.injectable";
 import homeDirectoryPathInjectable from "../../../../common/os/home-directory-path.injectable";

--- a/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
@@ -4,11 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { createKubeApiURL, parseKubeApi } from "@freelensapp/kube-api";
 import { showErrorNotificationInjectable, showSuccessNotificationInjectable } from "@freelensapp/notifications";
 import { waitUntilDefined } from "@freelensapp/utilities";
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
-import assert from "assert";
 import * as yaml from "js-yaml";
 import { action, computed, observable, runInAction } from "mobx";
 import React from "react";

--- a/packages/core/src/renderer/components/dock/install-chart/install-chart-model.injectable.tsx
+++ b/packages/core/src/renderer/components/dock/install-chart/install-chart-model.injectable.tsx
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { waitUntilDefined } from "@freelensapp/utilities";
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
-import assert from "assert";
 import { action, computed, observable, runInAction } from "mobx";
 import React from "react";
 import navigateToHelmReleasesInjectable from "../../../../common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable";

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
@@ -8,8 +8,8 @@ import React from "react";
 
 import type { MockedFunction } from "vitest";
 import "@testing-library/jest-dom/vitest";
+import assert from "node:assert";
 import userEvent from "@testing-library/user-event";
-import assert from "assert";
 import * as selectEvent from "react-select-event";
 import directoryForUserDataInjectable from "../../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import fsInjectable from "../../../../../common/fs/fs.injectable";

--- a/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
+++ b/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { isDefined } from "@freelensapp/utilities";
-import assert from "assert";
 import { computed } from "mobx";
 import { defaultLogViewerPreferences } from "../../../../features/user-preferences/common/preferences-helpers";
 

--- a/packages/core/src/renderer/components/dock/terminal/terminal-spawning-pool.injectable.ts
+++ b/packages/core/src/renderer/components/dock/terminal/terminal-spawning-pool.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 
 const terminalSpawningPoolInjectable = getInjectable({
   id: "terminal-spawning-pool",

--- a/packages/core/src/renderer/components/dock/terminal/terminal.ts
+++ b/packages/core/src/renderer/components/dock/terminal/terminal.ts
@@ -4,11 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { disposer } from "@freelensapp/utilities";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Terminal as XTerm } from "@xterm/xterm";
-import assert from "assert";
 import { clipboard } from "electron";
 import { once } from "lodash";
 import debounce from "lodash/debounce";

--- a/packages/core/src/renderer/components/dock/terminal/view.tsx
+++ b/packages/core/src/renderer/components/dock/terminal/view.tsx
@@ -6,9 +6,9 @@
 
 import "./terminal-window.scss";
 
+import assert from "node:assert";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import assert from "assert";
 import { disposeOnUnmount, observer } from "mobx-react";
 import React from "react";
 import activeThemeInjectable from "../../../themes/active.injectable";

--- a/packages/core/src/renderer/components/events/store.injectable.ts
+++ b/packages/core/src/renderer/components/events/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { kubeEventApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import getPodByIdInjectable from "../workloads-pods/get-pod-by-id.injectable";

--- a/packages/core/src/renderer/components/extensions/__tests__/extensions.test.tsx
+++ b/packages/core/src/renderer/components/extensions/__tests__/extensions.test.tsx
@@ -7,8 +7,8 @@
 import type { MockedFunction } from "vitest";
 
 import "@testing-library/jest-dom/vitest";
+import assert from "node:assert";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
-import assert from "assert";
 import { observable, when } from "mobx";
 import React from "react";
 import directoryForDownloadsInjectable from "../../../../common/app-paths/directory-for-downloads/directory-for-downloads.injectable";

--- a/packages/core/src/renderer/components/extensions/attempt-install/get-extension-dest-folder.injectable.ts
+++ b/packages/core/src/renderer/components/extensions/attempt-install/get-extension-dest-folder.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 import extensionDiscoveryInjectable from "../../../../extensions/extension-discovery/extension-discovery.injectable";
 import { sanitizeExtensionName } from "../../../../extensions/lens-extension";
 

--- a/packages/core/src/renderer/components/extensions/attempt-install/unpack-extension.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/attempt-install/unpack-extension.injectable.tsx
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { showErrorNotificationInjectable, showInfoNotificationInjectable } from "@freelensapp/notifications";
 import { noop } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import fse from "fs-extra";
 import { when } from "mobx";
-import path from "path";
 import React from "react";
 import extractTarInjectable from "../../../../common/fs/extract-tar.injectable";
 import extensionInstallationStateStoreInjectable from "../../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";

--- a/packages/core/src/renderer/components/extensions/attempt-install/validate-package.tsx
+++ b/packages/core/src/renderer/components/extensions/attempt-install/validate-package.tsx
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { isObject, isString, listTarEntries, readFileFromTar } from "@freelensapp/utilities";
-import path from "path";
 import { manifestFilename } from "../../../../extensions/extension-discovery/extension-discovery";
 
 import type { LensExtensionManifest } from "@freelensapp/legacy-extensions";

--- a/packages/core/src/renderer/components/extensions/attempt-installs.injectable.ts
+++ b/packages/core/src/renderer/components/extensions/attempt-installs.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import path from "node:path";
 import { getInjectable } from "@ogre-tools/injectable";
-import path from "path";
 import attemptInstallInjectable from "./attempt-install/attempt-install.injectable";
 import readFileNotifyInjectable from "./read-file-notify/read-file-notify.injectable";
 

--- a/packages/core/src/renderer/components/file-picker/file-picker.tsx
+++ b/packages/core/src/renderer/components/file-picker/file-picker.tsx
@@ -6,13 +6,13 @@
 
 import "./file-picker.scss";
 
+import path from "node:path";
 import { Icon } from "@freelensapp/icon";
 import { Spinner } from "@freelensapp/spinner";
 import fse from "fs-extra";
 import _ from "lodash";
 import { makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
-import path from "path";
 import React from "react";
 
 import type { StrictReactNode } from "@freelensapp/utilities";

--- a/packages/core/src/renderer/components/helm-charts/helm-chart-details.tsx
+++ b/packages/core/src/renderer/components/helm-charts/helm-chart-details.tsx
@@ -6,12 +6,12 @@
 
 import "./helm-chart-details.scss";
 
+import assert from "node:assert";
 import { Button } from "@freelensapp/button";
 import { Spinner } from "@freelensapp/spinner";
 import { stopPropagation } from "@freelensapp/utilities";
 import { styled, Tooltip } from "@mui/material";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import assert from "assert";
 import autoBindReact from "auto-bind/react";
 import { observer } from "mobx-react";
 import React, { Component } from "react";

--- a/packages/core/src/renderer/components/helm-releases/release-details/release-details-model/release-details-model.injectable.tsx
+++ b/packages/core/src/renderer/components/helm-releases/release-details/release-details-model/release-details-model.injectable.tsx
@@ -4,11 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { showCheckedErrorNotificationInjectable, showSuccessNotificationInjectable } from "@freelensapp/notifications";
 import { waitUntilDefined } from "@freelensapp/utilities";
 import { pipeline } from "@ogre-tools/fp";
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
-import assert from "assert";
 import { groupBy, map } from "lodash/fp";
 import { action, computed, observable, runInAction } from "mobx";
 import React from "react";

--- a/packages/core/src/renderer/components/helm-releases/releases.injectable.ts
+++ b/packages/core/src/renderer/components/helm-releases/releases.injectable.ts
@@ -4,11 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { prefixedLoggerInjectable } from "@freelensapp/logger";
 import { iter } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import { asyncComputed } from "@ogre-tools/injectable-react";
-import assert from "assert";
 import requestListHelmReleasesInjectable from "../../../features/helm-releases/renderer/request-list-helm-releases.injectable";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import hostedClusterIdInjectable from "../../cluster-frame-context/hosted-cluster-id.injectable";

--- a/packages/core/src/renderer/components/namespaces/store.injectable.ts
+++ b/packages/core/src/renderer/components/namespaces/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { namespaceApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import selectedNamespacesStorageInjectable from "../../../features/namespace-filtering/renderer/storage.injectable";
 import clusterConfiguredAccessibleNamespacesInjectable from "../../cluster/accessible-namespaces.injectable";

--- a/packages/core/src/renderer/components/network-endpoint-slices/store.injectable.ts
+++ b/packages/core/src/renderer/components/network-endpoint-slices/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { endpointSliceApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { EndpointSliceStore } from "./store";

--- a/packages/core/src/renderer/components/network-endpoints/store.injectable.ts
+++ b/packages/core/src/renderer/components/network-endpoints/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { endpointsApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { EndpointsStore } from "./store";

--- a/packages/core/src/renderer/components/network-ingresses/ingress-class-store.injectable.ts
+++ b/packages/core/src/renderer/components/network-ingresses/ingress-class-store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ingressClassApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForClusterScopedResourcesInjectable from "../../cluster-frame-context/for-cluster-scoped-resources.injectable";
 import { IngressClassStore } from "./ingress-class-store";

--- a/packages/core/src/renderer/components/network-ingresses/ingress-store.injectable.ts
+++ b/packages/core/src/renderer/components/network-ingresses/ingress-store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ingressApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { IngressStore } from "./ingress-store";

--- a/packages/core/src/renderer/components/network-policies/store.injectable.ts
+++ b/packages/core/src/renderer/components/network-policies/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { networkPolicyApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { NetworkPolicyStore } from "./store";

--- a/packages/core/src/renderer/components/network-services/store.injectable.ts
+++ b/packages/core/src/renderer/components/network-services/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { serviceApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { ServiceStore } from "./store";

--- a/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-attach-menu.test.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-attach-menu.test.tsx
@@ -1,4 +1,4 @@
-import os from "os";
+import os from "node:os";
 import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import createTerminalTabInjectable from "../../dock/terminal/create-terminal-tab.injectable";

--- a/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-shell-menu.test.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-shell-menu.test.tsx
@@ -1,4 +1,4 @@
-import os from "os";
+import os from "node:os";
 import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import createTerminalTabInjectable from "../../dock/terminal/create-terminal-tab.injectable";

--- a/packages/core/src/renderer/components/node-pod-menu/pod-attach-menu.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/pod-attach-menu.tsx
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import os from "node:os";
 import { Pod } from "@freelensapp/kube-object";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import os from "os";
 import React from "react";
 import { v4 as uuidv4 } from "uuid";
 import { App } from "../../../extensions/common-api";

--- a/packages/core/src/renderer/components/node-pod-menu/pod-shell-menu.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/pod-shell-menu.tsx
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import os from "node:os";
 import { Pod } from "@freelensapp/kube-object";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import os from "os";
 import React from "react";
 import { v4 as uuidv4 } from "uuid";
 import { App } from "../../../extensions/common-api";

--- a/packages/core/src/renderer/components/nodes/store.injectable.ts
+++ b/packages/core/src/renderer/components/nodes/store.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   nodeApiInjectable,
   nodeMetricsApiInjectable,
@@ -11,7 +12,6 @@ import {
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForClusterScopedResourcesInjectable from "../../cluster-frame-context/for-cluster-scoped-resources.injectable";
 import { NodeStore } from "./store";

--- a/packages/core/src/renderer/components/pod-security-policies/store.injectable.ts
+++ b/packages/core/src/renderer/components/pod-security-policies/store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   podSecurityPolicyApiInjectable,
   storesAndApisCanBeCreatedInjectionToken,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForClusterScopedResourcesInjectable from "../../cluster-frame-context/for-cluster-scoped-resources.injectable";
 import { PodSecurityPolicyStore } from "./store";

--- a/packages/core/src/renderer/components/slider/slider.tsx
+++ b/packages/core/src/renderer/components/slider/slider.tsx
@@ -8,9 +8,9 @@
 // API docs: https://material-ui.com/lab/api/slider/
 import "./slider.scss";
 
+import assert from "node:assert";
 import { cssNames } from "@freelensapp/utilities";
 import MaterialSlider from "@mui/material/Slider";
-import assert from "assert";
 import React, { Component } from "react";
 
 import type { SliderProps as MaterialSliderProps, SliderClassKey } from "@mui/material/Slider";

--- a/packages/core/src/renderer/components/storage-classes/store.injectable.ts
+++ b/packages/core/src/renderer/components/storage-classes/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { storageClassApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForClusterScopedResourcesInjectable from "../../cluster-frame-context/for-cluster-scoped-resources.injectable";
 import getPersistentVolumesByStorageClassInjectable from "../storage-volumes/get-persistent-volumes-by-storage-class.injectable";

--- a/packages/core/src/renderer/components/storage-volume-claims/store.injectable.ts
+++ b/packages/core/src/renderer/components/storage-volume-claims/store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   persistentVolumeClaimApiInjectable,
   storesAndApisCanBeCreatedInjectionToken,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { PersistentVolumeClaimStore } from "./store";

--- a/packages/core/src/renderer/components/storage-volumes/store.injectable.ts
+++ b/packages/core/src/renderer/components/storage-volumes/store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   persistentVolumeApiInjectable,
   storesAndApisCanBeCreatedInjectionToken,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForClusterScopedResourcesInjectable from "../../cluster-frame-context/for-cluster-scoped-resources.injectable";
 import { PersistentVolumeStore } from "./store";

--- a/packages/core/src/renderer/components/table/table.tsx
+++ b/packages/core/src/renderer/components/table/table.tsx
@@ -6,9 +6,9 @@
 
 import "./table.scss";
 
+import assert from "node:assert";
 import { cssNames, isDefined } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import assert from "assert";
 import autoBindReact from "auto-bind/react";
 import { computed, makeObservable } from "mobx";
 import { observer } from "mobx-react";

--- a/packages/core/src/renderer/components/test-utils/get-application-builder.tsx
+++ b/packages/core/src/renderer/components/test-utils/get-application-builder.tsx
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { applicationFeature, startApplicationInjectionToken } from "@freelensapp/application";
 import {
   applicationFeatureForElectronMain,
@@ -21,7 +22,6 @@ import { pipeline } from "@ogre-tools/fp";
 import { getInjectable } from "@ogre-tools/injectable";
 import { fireEvent, queryByText } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import assert from "assert";
 import { filter, first, join, last, map, matches } from "lodash/fp";
 import { action, computed, observable, runInAction } from "mobx";
 import React from "react";

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/store.injectable.ts
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/store.injectable.ts
@@ -4,13 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   clusterRoleBindingApiInjectable,
   storesAndApisCanBeCreatedInjectionToken,
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForClusterScopedResourcesInjectable from "../../../cluster-frame-context/for-cluster-scoped-resources.injectable";
 import { ClusterRoleBindingStore } from "./store";

--- a/packages/core/src/renderer/components/user-management/cluster-roles/store.injectable.ts
+++ b/packages/core/src/renderer/components/user-management/cluster-roles/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { clusterRoleApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForClusterScopedResourcesInjectable from "../../../cluster-frame-context/for-cluster-scoped-resources.injectable";
 import { ClusterRoleStore } from "./store";

--- a/packages/core/src/renderer/components/user-management/role-bindings/store.injectable.ts
+++ b/packages/core/src/renderer/components/user-management/role-bindings/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { roleBindingApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../../cluster-frame-context/for-namespaced-resources.injectable";
 import { RoleBindingStore } from "./store";

--- a/packages/core/src/renderer/components/user-management/roles/store.injectable.ts
+++ b/packages/core/src/renderer/components/user-management/roles/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { roleApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../../cluster-frame-context/for-namespaced-resources.injectable";
 import { RoleStore } from "./store";

--- a/packages/core/src/renderer/components/user-management/service-accounts/store.injectable.ts
+++ b/packages/core/src/renderer/components/user-management/service-accounts/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { serviceAccountApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../../cluster-frame-context/for-namespaced-resources.injectable";
 import { ServiceAccountStore } from "./store";

--- a/packages/core/src/renderer/components/workloads-cronjobs/store.injectable.ts
+++ b/packages/core/src/renderer/components/workloads-cronjobs/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { cronJobApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import getJobsByOwnerInjectable from "../workloads-jobs/get-jobs-by-owner.injectable";

--- a/packages/core/src/renderer/components/workloads-daemonsets/store.injectable.ts
+++ b/packages/core/src/renderer/components/workloads-daemonsets/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { daemonSetApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import getPodsByOwnerIdInjectable from "../workloads-pods/get-pods-by-owner-id.injectable";

--- a/packages/core/src/renderer/components/workloads-deployments/store.injectable.ts
+++ b/packages/core/src/renderer/components/workloads-deployments/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { deploymentApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import podStoreInjectable from "../workloads-pods/store.injectable";

--- a/packages/core/src/renderer/components/workloads-jobs/store.injectable.ts
+++ b/packages/core/src/renderer/components/workloads-jobs/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { jobApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import getPodsByOwnerIdInjectable from "../workloads-pods/get-pods-by-owner-id.injectable";

--- a/packages/core/src/renderer/components/workloads-pods/store.injectable.ts
+++ b/packages/core/src/renderer/components/workloads-pods/store.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import {
   podApiInjectable,
   podMetricsApiInjectable,
@@ -11,7 +12,6 @@ import {
 } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { PodStore } from "./store";

--- a/packages/core/src/renderer/components/workloads-replicasets/store.injectable.ts
+++ b/packages/core/src/renderer/components/workloads-replicasets/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { replicaSetApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import getPodsByOwnerIdInjectable from "../workloads-pods/get-pods-by-owner-id.injectable";

--- a/packages/core/src/renderer/components/workloads-statefulsets/store.injectable.ts
+++ b/packages/core/src/renderer/components/workloads-statefulsets/store.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { statefulSetApiInjectable, storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { kubeObjectStoreInjectionToken } from "../../../common/k8s-api/api-manager/kube-object-store-token";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import getPodsByOwnerIdInjectable from "../workloads-pods/get-pods-by-owner-id.injectable";

--- a/packages/core/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.injectable.ts
+++ b/packages/core/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.injectable.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import emitAppEventInjectable from "../../../../common/app-event-bus/emit-event.injectable";
 import catalogEntityRegistryInjectable from "../../../api/catalog/entity/registry.injectable";
 import hostedClusterInjectable from "../../../cluster-frame-context/hosted-cluster.injectable";

--- a/packages/core/src/renderer/k8s/api-kube.injectable.ts
+++ b/packages/core/src/renderer/k8s/api-kube.injectable.ts
@@ -4,11 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { apiKubeInjectionToken } from "@freelensapp/kube-api";
 import { storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
 import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { apiBaseServerAddressInjectionToken } from "../../common/k8s-api/api-base-configs";
 import createKubeJsonApiInjectable from "../../common/k8s-api/create-kube-json-api.injectable";
 import windowLocationInjectable from "../../common/k8s-api/window-location.injectable";

--- a/packages/core/src/renderer/protocol-handler/bind-protocol-add-route-handlers/bind-protocol-add-route-handlers.tsx
+++ b/packages/core/src/renderer/protocol-handler/bind-protocol-add-route-handlers/bind-protocol-add-route-handlers.tsx
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import assert from "assert";
+import assert from "node:assert";
 import React from "react";
 import { EXTENSION_NAME_MATCH, EXTENSION_PUBLISHER_MATCH, LensProtocolRouter } from "../../../common/protocol-handler";
 

--- a/packages/core/src/renderer/themes/active.injectable.ts
+++ b/packages/core/src/renderer/themes/active.injectable.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { computed } from "mobx";
 import lensColorThemePreferenceInjectable from "../../features/user-preferences/common/lens-color-theme.injectable";
 import { lensThemeDeclarationInjectionToken } from "./declaration";

--- a/packages/core/src/renderer/utils/storage-helper.ts
+++ b/packages/core/src/renderer/utils/storage-helper.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import assert from "assert";
+import assert from "node:assert";
 import { isDraft, produce } from "immer";
 import { isEqual, isPlainObject } from "lodash";
 // Helper for working with storages (e.g. window.localStorage, NodeJS/file-system, etc.)

--- a/packages/core/src/renderer/utils/sync-box/provide-initial-values-for-sync-boxes.injectable.ts
+++ b/packages/core/src/renderer/utils/sync-box/provide-initial-values-for-sync-boxes.injectable.ts
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { requestFromChannelInjectionToken } from "@freelensapp/messaging";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { runInAction } from "mobx";
 import { syncBoxInitialValueChannel } from "../../../common/utils/sync-box/channels";
 import { syncBoxInjectionToken } from "../../../common/utils/sync-box/sync-box-injection-token";

--- a/packages/core/src/test-utils/mock-responses.ts
+++ b/packages/core/src/test-utils/mock-responses.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { PassThrough } from "stream";
+import { PassThrough } from "node:stream";
 
 import type { Headers as NodeFetchHeaders, Response } from "node-fetch";
 import type { Mocked } from "vitest";

--- a/packages/core/src/vitest.setup.tsx
+++ b/packages/core/src/vitest.setup.tsx
@@ -4,11 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { TextDecoder as TextDecoderNode, TextEncoder } from "node:util";
 import { enableMapSet, setAutoFreeze } from "immer";
 import { configure } from "mobx";
 import freelensFetch from "node-fetch";
 import React from "react";
-import { TextDecoder as TextDecoderNode, TextEncoder } from "util";
 
 import type * as K8slensTooltip from "@freelensapp/tooltip";
 

--- a/packages/ensure-binaries/src/index.ts
+++ b/packages/ensure-binaries/src/index.ts
@@ -6,17 +6,17 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { constants, type WriteStream } from "node:fs";
+import { type FileHandle, mkdir, open, readFile, unlink } from "node:fs/promises";
+import path from "node:path";
+import { arch } from "node:process";
+import { pipeline as _pipeline, Transform, Writable } from "node:stream";
+import { promisify } from "node:util";
 import arg from "arg";
 import { MultiBar } from "cli-progress";
-import { constants, type WriteStream } from "fs";
-import { type FileHandle, mkdir, open, readFile, unlink } from "fs/promises";
 import gunzip from "gunzip-maybe";
 import fetch from "node-fetch";
-import path from "path";
-import { arch } from "process";
-import { pipeline as _pipeline, Transform, Writable } from "stream";
 import { extract } from "tar-stream";
-import { promisify } from "util";
 import z from "zod";
 
 import type { SingleBar } from "cli-progress";

--- a/packages/generate-license/src/index.ts
+++ b/packages/generate-license/src/index.ts
@@ -6,9 +6,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import fs from "node:fs/promises";
+import path from "node:path";
 import { getDependencies, getLicenseText } from "@quantco/pnpm-licenses/dist/api.mjs";
-import fs from "fs/promises";
-import path from "path";
 import spdxLicenseList from "spdx-license-list/full.js";
 
 type Dependency = Awaited<ReturnType<typeof getDependencies>>[number];

--- a/packages/generate-tray-icons/src/index.ts
+++ b/packages/generate-tray-icons/src/index.ts
@@ -6,12 +6,12 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { platform } from "node:process";
 import arg from "arg";
-import assert from "assert";
-import { mkdir, readFile } from "fs/promises";
 import { JSDOM } from "jsdom";
-import path from "path";
-import { platform } from "process";
 import sharp from "sharp";
 
 const options = arg({

--- a/packages/kube-object/src/specifics/pod.test.ts
+++ b/packages/kube-object/src/specifics/pod.test.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import assert from "assert";
+import assert from "node:assert";
 import { Pod, type PodContainerStatus } from "./pod";
 
 import type { Container } from "../types/container";

--- a/packages/ui-components/tooltip/src/tooltip.test.tsx
+++ b/packages/ui-components/tooltip/src/tooltip.test.tsx
@@ -4,9 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { render } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
-import assert from "assert";
 import React from "react";
 import { computeNextPosition, RectangleDimensions } from "./helpers";
 import { Tooltip, TooltipPosition } from "./tooltip";

--- a/packages/utility-features/json-api/src/json-api.ts
+++ b/packages/utility-features/json-api/src/json-api.ts
@@ -4,12 +4,12 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { Agent as HttpAgent } from "node:http";
+import { Agent as HttpsAgent } from "node:https";
+import { stringify } from "node:querystring";
 import { EventEmitter } from "@freelensapp/event-emitter";
 import { isObject, isString, json } from "@freelensapp/utilities";
-import { Agent as HttpAgent } from "http";
-import { Agent as HttpsAgent } from "https";
 import { merge } from "lodash";
-import { stringify } from "querystring";
 
 import type { Logger } from "@freelensapp/logger";
 import type { Defaulted } from "@freelensapp/utilities";

--- a/packages/utility-features/kube-api-specifics/src/specifics/cluster-role-binding.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/cluster-role-binding.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ClusterRoleBindingApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/cluster-role.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/cluster-role.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ClusterRoleApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/cluster.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/cluster.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ClusterApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/component-status.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/component-status.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ComponentStatusApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/config-map.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/config-map.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ConfigMapApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/cron-job.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/cron-job.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { CronJobApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/custom-resource-definition.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/custom-resource-definition.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { CustomResourceDefinitionApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/daemon-set.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/daemon-set.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { DaemonSetApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/deployment.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/deployment.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { DeploymentApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/endpoint-slice.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/endpoint-slice.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { EndpointSliceApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/endpoint.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/endpoint.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { EndpointsApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/event.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/event.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { KubeEventApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/horizontal-pod-autoscaler.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/horizontal-pod-autoscaler.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { HorizontalPodAutoscalerApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/ingress-class.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/ingress-class.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { IngressClassApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/ingress.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/ingress.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { IngressApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/job.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/job.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { JobApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/lease.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/lease.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { LeaseApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/limit-range.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/limit-range.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { LimitRangeApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/mutating-webhook-configuration-api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/mutating-webhook-configuration-api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { MutatingWebhookConfigurationApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/namespace.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/namespace.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { NamespaceApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/network-policy.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/network-policy.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { NetworkPolicyApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/node-metrics.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/node-metrics.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { NodeMetricsApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/node.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/node.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { NodeApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/persistent-volume-claim.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/persistent-volume-claim.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { PersistentVolumeClaimApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/persistent-volume.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/persistent-volume.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { PersistentVolumeApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/pod-disruption-budget.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/pod-disruption-budget.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { PodDisruptionBudgetApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/pod-metrics.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/pod-metrics.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { PodMetricsApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/pod-security-policy.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/pod-security-policy.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { PodSecurityPolicyApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/pod.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/pod.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { PodApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/priority-class.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/priority-class.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { PriorityClassApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/replica-set.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/replica-set.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ReplicaSetApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/replication-controller.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/replication-controller.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ReplicationControllerApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/resource-quota.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/resource-quota.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ResourceQuotaApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/role-binding.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/role-binding.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { RoleBindingApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/role.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/role.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { RoleApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/runtime-class.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/runtime-class.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { RuntimeClassApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/secret.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/secret.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { SecretApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/self-subject-rules-reviews.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/self-subject-rules-reviews.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { SelfSubjectRulesReviewApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/service-account.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/service-account.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ServiceAccountApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/service.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/service.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ServiceApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/stateful-set.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/stateful-set.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { StatefulSetApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/storage-class.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/storage-class.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { StorageClassApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/validating-admission-policy-api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/validating-admission-policy-api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ValidatingAdmissionPolicyApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/validating-admission-policy-binding-api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/validating-admission-policy-binding-api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ValidatingAdmissionPolicyBindingApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/validating-webhook-configuration-api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/validating-webhook-configuration-api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { ValidatingWebhookConfigurationApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api-specifics/src/specifics/vertical-pod-autoscaler.api.injectable.ts
+++ b/packages/utility-features/kube-api-specifics/src/specifics/vertical-pod-autoscaler.api.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { VerticalPodAutoscalerApi } from "@freelensapp/kube-api";
 import {
   logDebugInjectionToken,
@@ -12,7 +13,6 @@ import {
   logWarningInjectionToken,
 } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import assert from "assert";
 import { storesAndApisCanBeCreatedInjectionToken } from "./can-be-created-token";
 import { maybeKubeApiInjectable } from "./maybe-kube-api.injectable";
 import { kubeApiInjectionToken } from "./token";

--- a/packages/utility-features/kube-api/src/kube-api.test.ts
+++ b/packages/utility-features/kube-api/src/kube-api.test.ts
@@ -4,10 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { PassThrough } from "node:stream";
 import asyncFn from "@async-fn/vitest";
 import { Deployment, Pod } from "@freelensapp/kube-object";
 import { flushPromises } from "@freelensapp/test-utils";
-import { PassThrough } from "stream";
 import { DeploymentApi, NamespaceApi, PodApi } from "./endpoints";
 import { KubeJsonApi } from "./kube-json-api";
 import { createMockResponseFromStream, createMockResponseFromString } from "./mock-responses";

--- a/packages/utility-features/kube-api/src/kube-api.ts
+++ b/packages/utility-features/kube-api/src/kube-api.ts
@@ -6,6 +6,8 @@
 
 // Base class for building all kubernetes apis
 
+import assert from "node:assert";
+import { stringify } from "node:querystring";
 import {
   isJsonApiData,
   isJsonApiDataList,
@@ -14,12 +16,10 @@ import {
   KubeStatus,
 } from "@freelensapp/kube-object";
 import { isDefined, noop, WrappedAbortController } from "@freelensapp/utilities";
-import assert from "assert";
 import byline from "byline";
 import { merge } from "lodash";
 import { matches } from "lodash/fp";
 import { makeObservable, observable } from "mobx";
-import { stringify } from "querystring";
 import { createKubeApiURL, parseKubeApi } from "./kube-api-parse";
 
 import type {

--- a/packages/utility-features/kube-api/src/mock-responses.ts
+++ b/packages/utility-features/kube-api/src/mock-responses.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { PassThrough } from "node:stream";
 import { Headers as NodeFetchHeaders, Response } from "node-fetch";
-import { PassThrough } from "stream";
 import { type Mocked, vi } from "vitest";
 
 export const createMockResponseFromString = (url: string, data: string, statusCode = 200) => {

--- a/packages/utility-features/run-many/src/helpers.ts
+++ b/packages/utility-features/run-many/src/helpers.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import assert from "node:assert";
 import { getOrInsertSetFor, isDefined } from "@freelensapp/utilities";
-import assert from "assert";
 import * as uuid from "uuid";
 
 import type { DiContainerForInjection, InjectionInstanceWithMeta } from "@ogre-tools/injectable";

--- a/packages/utility-features/run-many/src/run-many-for.ts
+++ b/packages/utility-features/run-many/src/run-many-for.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import EventEmitter from "node:events";
 import { getOrInsert } from "@freelensapp/utilities";
-import EventEmitter from "events";
 import { convertToWithIdWith, verifyRunnablesAreDAG } from "./helpers";
 
 import type { DiContainerForInjection, InjectionToken } from "@ogre-tools/injectable";

--- a/packages/utility-features/run-many/src/run-many-sync-for.ts
+++ b/packages/utility-features/run-many/src/run-many-sync-for.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import EventEmitter from "events";
+import EventEmitter from "node:events";
 import { convertToWithIdWith, verifyRunnablesAreDAG } from "./helpers";
 
 import type { Disposer } from "@freelensapp/utilities";

--- a/packages/utility-features/test-utils/src/flush-promises.ts
+++ b/packages/utility-features/test-utils/src/flush-promises.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { setImmediate, setTimeout } from "timers/promises";
+import { setImmediate, setTimeout } from "node:timers/promises";
 
 export const flushPromises = async () => {
   await setImmediate();

--- a/packages/utility-features/utilities/src/collection-functions.ts
+++ b/packages/utility-features/utilities/src/collection-functions.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { inspect } from "node:util";
 import { runInAction } from "mobx";
-import { inspect } from "util";
 import { isDefined } from "./type-narrowing";
 
 /**

--- a/packages/utility-features/utilities/src/convertMemory.ts
+++ b/packages/utility-features/utilities/src/convertMemory.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import assert from "assert";
+import assert from "node:assert";
 import { iter } from "./iter";
 
 // Helper to convert memory from units Ki, Mi, Gi, Ti, Pi, Ei to bytes and vise versa

--- a/packages/utility-features/utilities/src/tar.ts
+++ b/packages/utility-features/utilities/src/tar.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import path from "path";
+import path from "node:path";
 // Helper for working with tarball files (.tar, .tgz)
 // Docs: https://github.com/npm/node-tar
 import { list } from "tar";

--- a/packages/utility-features/utilities/src/type-narrowing.ts
+++ b/packages/utility-features/utilities/src/type-narrowing.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import type { ExecException, ExecFileException } from "child_process";
-import type { IncomingMessage } from "http";
+import type { ExecException, ExecFileException } from "node:child_process";
+import type { IncomingMessage } from "node:http";
 
 /**
  * Narrows `val` to include the property `key` (if true is returned)

--- a/packages/utility-features/utilities/src/union-env-path.test.ts
+++ b/packages/utility-features/utilities/src/union-env-path.test.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import path from "path";
+import path from "node:path";
 import { unionPATHs } from "./union-env-path";
 
 describe("unionPATHs", () => {

--- a/packages/utility-features/utilities/src/union-env-path.ts
+++ b/packages/utility-features/utilities/src/union-env-path.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import path from "path";
+import path from "node:path";
 import { iter } from "./iter";
 
 /**


### PR DESCRIPTION
Enable the Biome `useNodejsImportProtocol` rule and migrate all bare Node.js builtin imports/requires to the `node:` protocol prefix. The rule is set to `error` so future bare builtin imports fail CI.

Also updates the Vitest mock in `kube-api-upgrade-request.test.ts` from `vi.mock("tls")` to `vi.mock("node:tls")` so it keeps matching the migrated `node:tls` import.

Closes #2156

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`