### PR TITLE
Fix dev-mode renderer decorators and main-process watch

### DIFF
--- a/freelens/electron.vite.config.ts
+++ b/freelens/electron.vite.config.ts
@@ -347,7 +347,15 @@ export default defineConfig({
   },
   renderer: {
     root: resolve(root, "src/renderer"),
-    plugins: [react(), runtimeRequireExternalsPlugin(), rendererBuildBasePlugin("/build/")],
+    plugins: [
+      // The dev-only react-refresh Babel pass parses raw TSX and rejects the
+      // legacy @observer/@injectable decorators used across the codebase
+      // without this parser plugin; esbuild still performs the actual
+      // decorator transform per tsconfig experimentalDecorators.
+      react({ babel: { parserOpts: { plugins: ["decorators-legacy"] } } }),
+      runtimeRequireExternalsPlugin(),
+      rendererBuildBasePlugin("/build/"),
+    ],
     server: {
       // Same serving architecture as the webpack dev server it replaces: the
       // app window always loads through the lens proxy, which forwards to

--- a/freelens/package.json
+++ b/freelens/package.json
@@ -34,7 +34,7 @@
     "build:resources:tray": "generate-tray-icons --output static/build/tray --input @freelensapp/icon/icons/logo-lens.svg --notice-icon @freelensapp/icon/icons/notice.svg --spinner-icon @freelensapp/icon/icons/arrow-spinner.svg --none-color fbfbfb",
     "clean": "pnpm dlx rimraf@6.1.3 binaries dist static/build",
     "clean:node_modules": "pnpm dlx rimraf@6.1.3 node_modules",
-    "dev": "NODE_ENV=development electron-vite dev --inspect --remoteDebuggingPort 9223",
+    "dev": "NODE_ENV=development electron-vite dev --watch --inspect --remoteDebuggingPort 9223",
     "start": "pnpm dlx run-script-os@1.1.6 --",
     "start:darwin": "pnpm start:darwin:${npm_config_arch:-$(uname -m)}",
     "start:darwin:arm64": "./dist/mac-arm64/Freelens.app/Contents/MacOS/Freelens",


### PR DESCRIPTION
Fixes #2158.

### Summary

Native `electron-vite dev` was broken for the renderer in dev mode: every renderer module using a legacy decorator (`@observer`/`@injectable`) failed to transform because `@vitejs/plugin-react`'s dev-only react-refresh Babel pass does not enable decorator syntax, returning HTTP 500.

### Changes

1. **Enable legacy-decorator parsing in the dev-mode renderer** (`freelens/electron.vite.config.ts`) — add the `decorators-legacy` Babel parser plugin so decorated modules transform; esbuild still performs the actual decorator transform per tsconfig `experimentalDecorators`.
2. **Rebuild and restart the main process on change** (`freelens/package.json`) — add electron-vite's `--watch` flag to the `dev` script.

Each fix is a separate commit.

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`