### PR TITLE
Fix native dev mode stuck on splash screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ icon.iconset/
 .pnpm/
 .turbo/
 
+# Runtime artifacts (screenshots, SQLite metadata, encryption key) written by
+# the optional Electron DevTools MCP server, see DEVELOPMENT.md
+logs/
+
 .npmrc
 
 .DS_Store

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -166,6 +166,10 @@ Then:
 3. Ask the agent to inspect the app; it should target the renderer window
    (`https://renderer.freelens.app:<port>/…`), not the `splash.html` target.
 
+The server writes runtime artifacts (screenshots, a SQLite metadata database
+and a generated `.security-key`) under `logs/` in the project root; that
+directory is git-ignored, so the key is never committed.
+
 See [laststance/electron-mcp-server](https://github.com/laststance/electron-mcp-server)
 for the full tool list. Remove it any time with
 `claude mcp remove electron-devtools --scope local`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -139,6 +139,37 @@ The renderer is served by the Vite dev server (port 9191, overridable with
 rebuilt on change. If dev mode misbehaves, the packaged-app workflow
 `pnpm build && pnpm build:app:dir && pnpm start` always works.
 
+### Inspecting the running dev app from an AI agent (optional)
+
+The `pnpm dev` script launches Electron with `--remoteDebuggingPort 9223`, so
+the running app exposes a Chrome DevTools Protocol (CDP) endpoint. An AI coding
+agent (Claude Code, Cursor, …) can attach to it to inspect the renderer — read
+the DOM, evaluate JavaScript, capture screenshots, and stream console/main-process
+logs — which is useful for debugging renderer-side startup issues that never
+reach the terminal.
+
+This is a per-developer, opt-in tool and is intentionally **not** committed to
+`.mcp.json` (that would prompt every contributor). Install it in your own local
+Claude Code config instead:
+
+```sh
+# Local scope: stored in .claude/settings.local.json (git-ignored), not shared
+claude mcp add electron-devtools --scope local -- npx -y @laststance/electron-mcp-server@latest
+```
+
+Then:
+
+1. Start the app first with `pnpm dev` (the MCP server auto-scans ports
+   9222–9225 and detects the app on 9223).
+2. In Claude Code, run `/mcp` to confirm the `electron-devtools` server is
+   connected.
+3. Ask the agent to inspect the app; it should target the renderer window
+   (`https://renderer.freelens.app:<port>/…`), not the `splash.html` target.
+
+See [laststance/electron-mcp-server](https://github.com/laststance/electron-mcp-server)
+for the full tool list. Remove it any time with
+`claude mcp remove electron-devtools --scope local`.
+
 ### Running tests
 
 ```sh

--- a/freelens/package.json
+++ b/freelens/package.json
@@ -34,7 +34,7 @@
     "build:resources:tray": "generate-tray-icons --output static/build/tray --input @freelensapp/icon/icons/logo-lens.svg --notice-icon @freelensapp/icon/icons/notice.svg --spinner-icon @freelensapp/icon/icons/arrow-spinner.svg --none-color fbfbfb",
     "clean": "pnpm dlx rimraf@6.1.3 binaries dist static/build",
     "clean:node_modules": "pnpm dlx rimraf@6.1.3 node_modules",
-    "dev": "NODE_ENV=development electron-vite dev --watch --inspect --remoteDebuggingPort 9223",
+    "dev": "ELECTRON_RUN_AS_NODE= NODE_ENV=development electron-vite dev --watch --inspect --remoteDebuggingPort 9223",
     "start": "pnpm dlx run-script-os@1.1.6 --",
     "start:darwin": "pnpm start:darwin:${npm_config_arch:-$(uname -m)}",
     "start:darwin:arm64": "./dist/mac-arm64/Freelens.app/Contents/MacOS/Freelens",

--- a/packages/core/src/common/vars/content-security-policy.injectable.ts
+++ b/packages/core/src/common/vars/content-security-policy.injectable.ts
@@ -6,10 +6,31 @@
 
 import { applicationInformationToken } from "@freelensapp/application";
 import { getInjectable } from "@ogre-tools/injectable";
+import isDevelopmentInjectable from "./is-development.injectable";
+
+// In dev mode the renderer is served by the Vite dev server, whose
+// @vitejs/plugin-react injects an inline `<script type="module">` react-refresh
+// preamble into the HTML. The production CSP (`script-src 'unsafe-eval' 'self'`)
+// blocks that inline script, so the preamble never runs and every decorated
+// React module throws "@vitejs/plugin-react can't detect preamble", leaving the
+// app stuck on the splash screen. Allow 'unsafe-inline' scripts in development
+// only so the HMR preamble executes; the packaged build keeps the strict CSP.
+const withUnsafeInlineScripts = (csp: string): string =>
+  csp
+    .split(";")
+    .map((directive) => {
+      const trimmed = directive.trim();
+      return /^script-src\b/.test(trimmed) ? `${trimmed} 'unsafe-inline'` : directive;
+    })
+    .join(";");
 
 const contentSecurityPolicyInjectable = getInjectable({
   id: "content-security-policy",
-  instantiate: (di) => di.inject(applicationInformationToken).contentSecurityPolicy,
+  instantiate: (di) => {
+    const contentSecurityPolicy = di.inject(applicationInformationToken).contentSecurityPolicy;
+
+    return di.inject(isDevelopmentInjectable) ? withUnsafeInlineScripts(contentSecurityPolicy) : contentSecurityPolicy;
+  },
 });
 
 export default contentSecurityPolicyInjectable;


### PR DESCRIPTION
Closes #2136.

### Summary

After #2165 fixed the decorator HTTP 500, native `electron-vite dev` still did not work: the app booted but stayed **stuck on the splash screen**, the main window never mounting. The renderer threw at startup:

```
Error: @vitejs/plugin-react can't detect preamble. Something is wrong.
Executing inline script violates the following Content Security Policy directive
'script-src 'unsafe-eval' 'self''. The action has been blocked.
```

### Root cause

`@vitejs/plugin-react` injects an inline `<script type="module">` react-refresh preamble into the renderer HTML in dev mode. The renderer's Content-Security-Policy (`script-src 'unsafe-eval' 'self'`, set by the lens proxy) blocks that inline script, so the preamble never runs. Every decorated React module then throws "can't detect preamble" and React never mounts — the splash window is never replaced.

### Changes

1. **Allow inline scripts in the dev CSP** (`packages/core/src/common/vars/content-security-policy.injectable.ts`) — append `'unsafe-inline'` to the `script-src` directive when `isDevelopment`. The packaged build keeps the strict CSP unchanged. *(the actual fix)*
2. **Unset `ELECTRON_RUN_AS_NODE` in the `dev` script** (`freelens/package.json`) — when the script is run from an environment that exports `ELECTRON_RUN_AS_NODE=1` (e.g. a shell spawned by an Electron-based editor), electron-vite launches Electron as plain Node, the electron `app` object is `undefined`, and startup crashes early (`app.setPath` on `undefined`). Forcing the variable empty makes Electron always boot as a GUI process, matching the existing inline-env style already used for `NODE_ENV`.
3. **Document optional AI-agent inspection of the dev app** (`DEVELOPMENT.md`) — the `dev` script already exposes a CDP endpoint on port 9223. Because each cluster renders in a cross-origin `<clusterId>.renderer.freelens.app` iframe, a top-document-only tool cannot reach the cluster views, so the docs recommend a frame-aware CDP MCP (Playwright / chrome-devtools-mcp), kept opt-in and out of a committed `.mcp.json`.
4. **Keep session/tool artifacts out of git** (`AGENTS.md`, `.gitignore`) — add an AGENTS.md rule that scratch files and AI-agent / MCP runtime artifacts belong in a system temp dir, never the working tree; git-ignore the concrete in-repo exceptions (`.playwright-mcp/`, `logs/`).

### Verification

Ran `electron-vite dev` locally (Electron 41, Node 24) and inspected the renderer over the remote-debugging port (9223):

- Before: renderer `#app` had 0 children, `Runtime.exceptionThrown` reported the preamble error, and the CSP block was logged.
- After fix #1: renderer navigates to `/welcome`, `#app` mounts, the Welcome UI renders, stores and extensions initialize, no preamble/CSP errors; connecting a cluster and browsing to Workloads → Pods works (verified via a frame-aware CDP client reaching the cluster iframe).
- Fix #2 verified by launching with `ELECTRON_RUN_AS_NODE=1` inherited: without the change the main process crashes at `app.setPath`; with the empty override it boots the GUI and loads the window.

_Note: a pre-existing, unrelated UI regression found while validating (detail-drawer toolbar icons lost their spacing after the flexbox.scss removal in #2162) is tracked separately in #2181, not fixed here._