### PR TITLE
Restore detail drawer toolbar icon spacing

### DIFF
--- a/packages/core/src/features/catalog/__snapshots__/opening-entity-details.test.tsx.snap
+++ b/packages/core/src/features/catalog/__snapshots__/opening-entity-details.test.tsx.snap
@@ -4295,7 +4295,7 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
           </div>
         </div>
         <ul
-          class="Menu MenuActions flex CatalogEntityDrawerMenu toolbar gaps right bottom"
+          class="Menu MenuActions flex CatalogEntityDrawerMenu toolbar right bottom"
           id="menu-actions-for-catalog-entity-drawer-menu-some-entity-id"
         >
           <li

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`disable kube object detail items when cluster is not relevant > given e
             </div>
           </div>
           <ul
-            class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+            class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
             data-testid="menu-actions-for-kube-object-menu-for-some-uid"
             id="menu-actions-for-kube-object-menu-for-some-uid"
           />
@@ -788,7 +788,7 @@ exports[`disable kube object detail items when cluster is not relevant > given e
             </div>
           </div>
           <ul
-            class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+            class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
             data-testid="menu-actions-for-kube-object-menu-for-some-uid"
             id="menu-actions-for-kube-object-menu-for-some-uid"
           />
@@ -1534,7 +1534,7 @@ exports[`disable kube object detail items when cluster is not relevant > given n
             </div>
           </div>
           <ul
-            class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+            class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
             data-testid="menu-actions-for-kube-object-menu-for-some-uid"
             id="menu-actions-for-kube-object-menu-for-some-uid"
           />

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/reactively-hide-kube-object-detail-item.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/reactively-hide-kube-object-detail-item.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`reactively hide kube object detail item > renders 1`] = `
             </div>
           </div>
           <ul
-            class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+            class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
             data-testid="menu-actions-for-kube-object-menu-for-some-uid"
             id="menu-actions-for-kube-object-menu-for-some-uid"
           />
@@ -783,7 +783,7 @@ exports[`reactively hide kube object detail item > when the item is shown > rend
             </div>
           </div>
           <ul
-            class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+            class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
             data-testid="menu-actions-for-kube-object-menu-for-some-uid"
             id="menu-actions-for-kube-object-menu-for-some-uid"
           />

--- a/packages/core/src/features/cluster/kube-object-menu/extension-api/__snapshots__/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-menu/extension-api/__snapshots__/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -411,7 +411,7 @@ exports[`disable kube object menu items when cluster is not relevant > given ext
         style="position: relative;"
       >
         <ul
-          class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+          class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
           data-testid="menu-actions-for-kube-object-menu-for-some-uid"
           id="menu-actions-for-kube-object-menu-for-some-uid"
         >
@@ -966,7 +966,7 @@ exports[`disable kube object menu items when cluster is not relevant > given ext
         style="position: relative;"
       >
         <ul
-          class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+          class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
           data-testid="menu-actions-for-kube-object-menu-for-some-uid"
           id="menu-actions-for-kube-object-menu-for-some-uid"
         />
@@ -1515,7 +1515,7 @@ exports[`disable kube object menu items when cluster is not relevant > given not
         style="position: relative;"
       >
         <ul
-          class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+          class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
           data-testid="menu-actions-for-kube-object-menu-for-some-uid"
           id="menu-actions-for-kube-object-menu-for-some-uid"
         />

--- a/packages/core/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
+++ b/packages/core/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
@@ -5968,7 +5968,7 @@ exports[`showing details for helm release > given application is started > when 
           </div>
         </div>
         <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          class="Menu MenuActions flex HelmReleaseMenu toolbar right bottom"
           id="menu-actions-for-release-menu-for-some-namespace/some-name"
         >
           <li
@@ -7493,7 +7493,7 @@ exports[`showing details for helm release > given application is started > when 
           </div>
         </div>
         <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          class="Menu MenuActions flex HelmReleaseMenu toolbar right bottom"
           id="menu-actions-for-release-menu-for-some-namespace/some-name"
         >
           <li
@@ -9018,7 +9018,7 @@ exports[`showing details for helm release > given application is started > when 
           </div>
         </div>
         <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          class="Menu MenuActions flex HelmReleaseMenu toolbar right bottom"
           id="menu-actions-for-release-menu-for-some-namespace/some-name"
         >
           <li
@@ -10270,7 +10270,7 @@ exports[`showing details for helm release > given application is started > when 
           </div>
         </div>
         <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          class="Menu MenuActions flex HelmReleaseMenu toolbar right bottom"
           id="menu-actions-for-release-menu-for-some-namespace/some-name"
         >
           <li
@@ -11522,7 +11522,7 @@ exports[`showing details for helm release > given application is started > when 
           </div>
         </div>
         <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          class="Menu MenuActions flex HelmReleaseMenu toolbar right bottom"
           id="menu-actions-for-release-menu-for-some-namespace/some-name"
         >
           <li
@@ -13049,7 +13049,7 @@ exports[`showing details for helm release > given application is started > when 
           </div>
         </div>
         <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          class="Menu MenuActions flex HelmReleaseMenu toolbar right bottom"
           id="menu-actions-for-release-menu-for-some-namespace/some-name"
         >
           <li

--- a/packages/core/src/renderer/components/kube-object-menu/__snapshots__/kube-object-menu.test.tsx.snap
+++ b/packages/core/src/renderer/components/kube-object-menu/__snapshots__/kube-object-menu.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`kube-object-menu > given kube object > renders 1`] = `
       style="position: relative;"
     >
       <ul
-        class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+        class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
         data-testid="menu-actions-for-kube-object-menu-for-some-uid"
         id="menu-actions-for-kube-object-menu-for-some-uid"
       >
@@ -52,7 +52,7 @@ exports[`kube-object-menu > given kube object > when removing kube object > rend
       style="position: relative;"
     >
       <ul
-        class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+        class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
         data-testid="menu-actions-for-kube-object-menu-for-some-uid"
         id="menu-actions-for-kube-object-menu-for-some-uid"
       >
@@ -150,7 +150,7 @@ exports[`kube-object-menu > given kube object > when rerendered with different k
       style="position: relative;"
     >
       <ul
-        class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+        class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
         data-testid="menu-actions-for-kube-object-menu-for-some-other-uid"
         id="menu-actions-for-kube-object-menu-for-some-other-uid"
       >
@@ -192,7 +192,7 @@ exports[`kube-object-menu > given kube object > when rerendered with different k
       style="position: relative;"
     >
       <ul
-        class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+        class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
         data-testid="menu-actions-for-kube-object-menu-for-some-other-uid"
         id="menu-actions-for-kube-object-menu-for-some-other-uid"
       >
@@ -287,7 +287,7 @@ exports[`kube-object-menu > given kube object with namespace > when removing kub
       style="position: relative;"
     >
       <ul
-        class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+        class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
         data-testid="menu-actions-for-kube-object-menu-for-some-uid"
         id="menu-actions-for-kube-object-menu-for-some-uid"
       >
@@ -385,7 +385,7 @@ exports[`kube-object-menu > given kube object without namespace > when removing 
       style="position: relative;"
     >
       <ul
-        class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+        class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
         data-testid="menu-actions-for-kube-object-menu-for-some-uid"
         id="menu-actions-for-kube-object-menu-for-some-uid"
       >
@@ -482,7 +482,7 @@ exports[`kube-object-menu > given no kube object, renders 1`] = `
     style="position: relative;"
   >
     <ul
-      class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+      class="Menu MenuActions flex KubeObjectMenu toolbar right bottom"
       data-testid="menu-actions-for-kube-object-menu-for-undefined"
       id="menu-actions-for-kube-object-menu-for-undefined"
     />

--- a/packages/core/src/renderer/components/menu/menu-actions.scss
+++ b/packages/core/src/renderer/components/menu/menu-actions.scss
@@ -15,6 +15,7 @@
     background: none;
     border: none;
     flex-direction: row;
+    gap: var(--flex-gap);
     margin-right: var(--flex-gap) !important;
 
     .Icon {

--- a/packages/core/src/renderer/components/menu/menu-actions.tsx
+++ b/packages/core/src/renderer/components/menu/menu-actions.tsx
@@ -194,7 +194,6 @@ class NonInjectedMenuActions extends React.Component<MenuActionsProps & Dependen
           close={this.close}
           className={cssNames("MenuActions flex", className, {
             toolbar,
-            gaps: toolbar, // add spacing for .flex
           })}
           animated={!toolbar}
           usePortal={autoClose}


### PR DESCRIPTION
Restores the 8 px spacing between the kube-object detail drawer toolbar action icons, lost when the legacy flexbox.scss utility layer was removed in #2162.

Uses a modern `gap` on the toolbar container and drops the now-dead `gaps` class.

Fixes #2181

Generated with [Claude Code](https://claude.ai/code)