### PR TITLE
Replace eval("require") in path-to-pnpm-cli with a runtime require

### DIFF
--- a/packages/core/src/common/app-paths/path-to-pnpm-cli.injectable.ts
+++ b/packages/core/src/common/app-paths/path-to-pnpm-cli.injectable.ts
@@ -4,14 +4,21 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { createRequire } from "node:module";
 import { getInjectable } from "@ogre-tools/injectable";
 
 const pathToPnpmCliInjectable = getInjectable({
   id: "path-to-pnpm-cli",
   instantiate: () => {
-    // Ugly trick to get the path in renderer process
-    const req = eval("require");
-    const pnpmPackageJson = req.resolve("pnpm");
+    // The bundles are ESM: the main process has no `require` global, while the
+    // node-integrated renderer keeps it. Derive a runtime `require` that
+    // resolves against node_modules from either process, instead of the
+    // `eval("require")` trick that Rollup flags as a security risk. Resolved
+    // lazily here (this injectable is only ever instantiated in the main
+    // process, via fork-pnpm) so it never runs the `createRequire` fallback
+    // against the renderer's non-file `import.meta.url`.
+    const runtimeRequire = globalThis.require ?? createRequire(import.meta.url);
+    const pnpmPackageJson = runtimeRequire.resolve("pnpm");
 
     return `${pnpmPackageJson.substring(0, pnpmPackageJson.indexOf("package.json"))}bin/pnpm.cjs`;
   },


### PR DESCRIPTION
Rollup flags the `eval("require")` in `path-to-pnpm-cli.injectable.ts` as a security risk that may also break minification:

```
../packages/core/src/common/app-paths/path-to-pnpm-cli.injectable.ts (13:16):
Use of eval in "..." is strongly discouraged as it poses security risks and may cause issues with minification.
```

## Change

Resolve the pnpm CLI path via `globalThis.require ?? createRequire(import.meta.url)` instead — the same runtime-require idiom the extension loader already uses (`packages/core/src/extensions/extension-loader/extension-loader.ts`).

- The **renderer** (`nodeIntegration: true`, `contextIsolation: false`) exposes `require` as a global, so `globalThis.require` is used there and the `createRequire` fallback (which would otherwise see a non-`file:` `import.meta.url`) never runs.
- The **main process**, whose ESM bundle has no `require` global, falls back to `createRequire` against its `file://` `import.meta.url`.
- The lookup is kept inside `instantiate()`, which only runs in the main process (via `fork-pnpm`), so it never executes in the renderer at all.

## Verification

- `pnpm build` (Node 24) completes with exit 0 and **no** `eval` / `path-to-pnpm-cli` warnings.
- The built `freelens/static/build/main.js` contains the expected `instantiate()` body with `globalThis.require ?? createRequire(import.meta.url)` and a preserved `import.meta.url`.

| Model: `claude-opus-4-8`