### PR TITLE
Reject malformed base64 input

### DIFF
--- a/packages/utility-features/utilities/src/base64.test.ts
+++ b/packages/utility-features/utilities/src/base64.test.ts
@@ -30,4 +30,14 @@ describe("base64", () => {
     // Callers (e.g. secret-key.tsx) rely on this to fall back to the raw value.
     expect(() => base64.decode("some-data-for-some-key")).toThrow();
   });
+
+  it("throws when decoding input that Buffer.from would otherwise ignore", () => {
+    expect(() => base64.decode("!!!!")).toThrow();
+    expect(() => base64.decode("Zm9v$")).toThrow();
+    expect(() => base64.decode("Zm9v=")).toThrow();
+  });
+
+  it("decodes valid unpadded base64", () => {
+    expect(base64.decode("Zg")).toBe("f");
+  });
 });

--- a/packages/utility-features/utilities/src/base64.ts
+++ b/packages/utility-features/utilities/src/base64.ts
@@ -7,6 +7,16 @@
 // Encode/decode utf-8 base64 string
 import { Buffer } from "node:buffer";
 
+const base64Regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2,3})?$/;
+
+function assertBase64(data: string): string {
+  if (!base64Regex.test(data)) {
+    throw new Error("Input is not valid base64");
+  }
+
+  return data.padEnd(data.length + ((4 - (data.length % 4)) % 4), "=");
+}
+
 /**
  * Computes utf-8 from base64
  * @param data A Base64 encoded string
@@ -16,10 +26,7 @@ import { Buffer } from "node:buffer";
  *   callers rely on to detect non-base64 input
  */
 function decode(data: string): string {
-  // `Buffer.from(..., "base64")` is lenient and never throws, but
-  // `TextDecoder` with `fatal: true` throws on malformed utf-8, preserving the
-  // throw-on-invalid contract callers depend on.
-  return new TextDecoder("utf-8", { fatal: true }).decode(Buffer.from(data, "base64"));
+  return new TextDecoder("utf-8", { fatal: true }).decode(Buffer.from(assertBase64(data), "base64"));
 }
 
 /**


### PR DESCRIPTION
## Summary

- reject malformed base64 input before decoding with Node Buffer
- keep valid unpadded base64 input working by normalizing padding before decode
- add regression coverage for inputs that Node would otherwise decode leniently

## Why

Buffer.from(value, "base64") accepts some malformed input by ignoring invalid characters. Callers such as secret rendering rely on decode failures to fall back to the raw secret value, so silent decoding can show incorrect data.

## Tests

- pnpm --filter @freelensapp/utilities test:unit
- pnpm biome check packages/utility-features/utilities/src/base64.ts packages/utility-features/utilities/src/base64.test.ts
- pnpm exec vitest run -c vitest.config.ts --project @freelensapp/core packages/core/src/renderer/components/workloads-pods/secret-key.test.tsx --reporter=verbose
- pnpm exec vitest run -c vitest.config.ts --project @freelensapp/core packages/core/src/renderer/components/config-secrets/__tests__/secret-details.test.tsx --reporter=verbose
- pnpm type-check
