### PR TITLE
Remove stepSize:1 from byte-valued chart Y axes

### DIFF
--- a/packages/core/src/renderer/components/chart/bar-chart.tsx
+++ b/packages/core/src/renderer/components/chart/bar-chart.tsx
@@ -337,7 +337,6 @@ export const memoryOptions: ChartOptions = {
 
           return bytesToUnits(value);
         },
-        stepSize: 1,
       },
     },
   },

--- a/packages/core/src/renderer/components/chart/options.ts
+++ b/packages/core/src/renderer/components/chart/options.ts
@@ -27,7 +27,6 @@ const memoryLikeOptions: ChartOptions = {
 
           return bytesToUnits(value);
         },
-        stepSize: 1,
       },
     },
   },


### PR DESCRIPTION
Follow-up to #2177 (Chart.js v2 -> v4 upgrade), surfaced by the post-merge Playwright regression checklist.

The memory/disk/network/filesystem metric charts set `ticks.stepSize: 1` on a Y axis measured in bytes (`memoryOptions` in `bar-chart.tsx`, `memoryLikeOptions` in `options.ts`). Under Chart.js v4 this makes the tick generator attempt billions of ticks before capping at 1000, logging on every render:

```
scales.y.ticks.stepSize: 1 would result generating up to 16820461569 ticks. Limiting to 1000.
```

The option was carried over verbatim from the v2 config (`yAxes[].ticks.stepSize`) during the migration; v2 did not warn. Removing it lets Chart.js pick sensible byte-scale tick steps and eliminates the console noise. The chart already rendered correctly (ticks were capped), so this is purely cleanup. The integer `Pods` axis has no `stepSize` and is unaffected.

## Validation

- `pnpm biome check` (changed files) - clean
- `pnpm type-check` - 0 errors
- `pnpm test:unit` chart suites (bar-chart, node-charts, pod-charts, container-charts, ingress-charts, volume-claim-disk-chart, cluster-pie-charts, cluster-metrics, pie-chart) - 6 files / 11 tests pass
- Verified live in the dev app against a Prometheus-enabled cluster: memory/disk/network charts render as before, warning no longer logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| Model: `claude-opus-4-8[1m]`