### PR TITLE
Upgrade Electron to v42

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ download the right package for your system.
 
 ### macOS
 
-macOS 12 or later is required.
+macOS 13 or later is required.
 
 Download either the PKG (installer) or DMG (image) package from the
 [releases](https://github.com/freelensapp/freelens/releases) page. Both arm64
 (M1 chip or newer) and amd64 (Intel) variants are available.
 
-All binary packages are built on macOS 14 and should be compatible with newer
+All binary packages are built on macOS 15 and should be compatible with newer
 systems.
 
 #### Homebrew

--- a/freelens/electron-builder.yml
+++ b/freelens/electron-builder.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/electron-userland/electron-builder/refs/heads/master/packages/app-builder-lib/scheme.json
 
-electronVersion: 41.10.0 # datasource=npm depName=electron
+electronVersion: 42.7.0 # datasource=npm depName=electron
 
 ## node-pty is our only native module and it is a N-API (node-addon-api)
 ## addon, so its bundled prebuilt binaries are ABI-stable and load as-is on

--- a/freelens/package.json
+++ b/freelens/package.json
@@ -139,7 +139,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "~24.12.4",
     "@vitejs/plugin-react": "5.2.0",
-    "electron": "^41.10.0",
+    "electron": "^42.7.0",
     "electron-builder": "26.11.1",
     "electron-builder-squirrel-windows": "26.11.1",
     "electron-vite": "5.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -201,7 +201,7 @@
     "@types/triple-beam": "^1.3.5",
     "@types/uuid": "^11.0.0",
     "@types/ws": "^8.18.1",
-    "electron": "^41.10.0",
+    "electron": "^42.7.0",
     "jsdom": "^29.1.1",
     "logform": "^2.7.0",
     "memfs": "^4.17.1",

--- a/packages/core/src/main/electron-app/electron-app.global-override-for-injectable.ts
+++ b/packages/core/src/main/electron-app/electron-app.global-override-for-injectable.ts
@@ -103,6 +103,9 @@ export default getGlobalOverride(electronAppInjectable, () => {
     isAccessibilitySupportEnabled(): boolean {
       throw new Error("Method not implemented.");
     }
+    isActive(): boolean {
+      throw new Error("Method not implemented.");
+    }
     isDefaultProtocolClient(protocol: string, path?: string | undefined, args?: string[] | undefined): boolean {
       void protocol;
       void path;

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -70,7 +70,7 @@
     "typescript-plugin-css-modules": "^5.2.0"
   },
   "peerDependencies": {
-    "electron": ">=41.0.0"
+    "electron": ">=42.0.0"
   },
   "peerDependenciesMeta": {
     "electron": {

--- a/packages/technical-features/application/application-for-electron-main/package.json
+++ b/packages/technical-features/application/application-for-electron-main/package.json
@@ -29,7 +29,7 @@
     "@freelensapp/feature-core": "workspace:^",
     "@freelensapp/run-many": "workspace:^",
     "@ogre-tools/injectable": "^17.11.1",
-    "electron": "^41.10.0"
+    "electron": "^42.7.0"
   },
   "devDependencies": {
     "@async-fn/vitest": "^1.8.0",

--- a/packages/technical-features/messaging/messaging-for-main/package.json
+++ b/packages/technical-features/messaging/messaging-for-main/package.json
@@ -28,7 +28,7 @@
     "@freelensapp/feature-core": "workspace:^",
     "@freelensapp/messaging": "workspace:^",
     "@ogre-tools/injectable": "^17.11.1",
-    "electron": "^41.10.0"
+    "electron": "^42.7.0"
   },
   "devDependencies": {
     "@async-fn/vitest": "^1.8.0",

--- a/packages/technical-features/messaging/messaging-for-renderer/package.json
+++ b/packages/technical-features/messaging/messaging-for-renderer/package.json
@@ -29,7 +29,7 @@
     "@freelensapp/feature-core": "workspace:^",
     "@freelensapp/messaging": "workspace:^",
     "@ogre-tools/injectable": "^17.11.1",
-    "electron": "^41.10.0"
+    "electron": "^42.7.0"
   },
   "devDependencies": {
     "@async-fn/vitest": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,8 +285,8 @@ importers:
         specifier: 5.2.0
         version: 5.2.0(vite@7.3.6(@types/node@24.12.4)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.62.0)(terser@5.39.0))
       electron:
-        specifier: ^41.10.0
-        version: 41.10.0
+        specifier: ^42.7.0
+        version: 42.7.0
       electron-builder:
         specifier: 26.11.1
         version: 26.11.1(electron-builder-squirrel-windows@26.11.1)
@@ -832,8 +832,8 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1
       electron:
-        specifier: ^41.10.0
-        version: 41.10.0
+        specifier: ^42.7.0
+        version: 42.7.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -959,8 +959,8 @@ importers:
         specifier: ^10.2.0
         version: 10.2.0
       electron:
-        specifier: '>=41.0.0'
-        version: 41.10.0
+        specifier: '>=42.0.0'
+        version: 42.7.0
       history:
         specifier: ^4.10.1
         version: 4.10.1
@@ -1305,8 +1305,8 @@ importers:
         specifier: ^17.11.1
         version: 17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(lodash@4.18.1)
       electron:
-        specifier: ^41.10.0
-        version: 41.10.0
+        specifier: ^42.7.0
+        version: 42.7.0
     devDependencies:
       '@async-fn/vitest':
         specifier: ^1.8.0
@@ -1496,8 +1496,8 @@ importers:
         specifier: ^17.11.1
         version: 17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(lodash@4.18.1)
       electron:
-        specifier: ^41.10.0
-        version: 41.10.0
+        specifier: ^42.7.0
+        version: 42.7.0
     devDependencies:
       '@async-fn/vitest':
         specifier: ^1.8.0
@@ -1530,8 +1530,8 @@ importers:
         specifier: ^17.11.1
         version: 17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(lodash@4.18.1)
       electron:
-        specifier: ^41.10.0
-        version: 41.10.0
+        specifier: ^42.7.0
+        version: 42.7.0
     devDependencies:
       '@async-fn/vitest':
         specifier: ^1.8.0
@@ -4721,8 +4721,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.10.0:
-    resolution: {integrity: sha512-KuPcYnZXtmUv89YbNyZoU+Hud8s/X724zrhUZ4RjUg1b0pE0ax0FzTCiM1Lo4Nmxf2vX25u8w055to8IxVWxsQ==}
+  electron@42.7.0:
+    resolution: {integrity: sha512-Uu5p03M5o7aqulT8QxFYYg3eJVDfuNEUuasBU1qFl05ghVRRH7UHL7na8S3GhxVScZQ2D7j9DCMsc+qT5FuxtQ==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -9722,7 +9722,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.10.0:
+  electron@42.7.0:
     dependencies:
       '@electron-internal/extract-zip': 1.0.3
       '@electron/get': 5.0.0


### PR DESCRIPTION
Bumps Electron from `^41.10.0` to `^42.7.0` across the app and workspace packages, the extensions peer dependency range, and the electron-builder version pin.

Electron 42.7.0 bundles Node.js 24.18.0, which already matches the version pinned in .nvmrc, mise.toml and .trunk/trunk.yaml - no Node bump was required.

Fixes #2192

Generated with [Claude Code](https://claude.ai/code)