### PR TITLE
Append current timestamp to downloaded log filenames

### DIFF
--- a/packages/core/src/features/pod-logs/download-logs.test.tsx
+++ b/packages/core/src/features/pod-logs/download-logs.test.tsx
@@ -177,7 +177,11 @@ describe("download logs options in logs dock tab", () => {
           });
 
           it("shows save dialog with proper attributes", () => {
-            expect(openSaveFileDialogMock).toHaveBeenCalledWith("dockerExporter.log", "some-logs", "text/plain");
+            expect(openSaveFileDialogMock).toHaveBeenCalledWith(
+              expect.stringMatching(/^dockerExporter-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.log$/),
+              "some-logs",
+              "text/plain",
+            );
           });
         });
 
@@ -203,7 +207,11 @@ describe("download logs options in logs dock tab", () => {
             });
 
             it("shows save dialog with proper attributes", () => {
-              expect(openSaveFileDialogMock).toHaveBeenCalledWith("docker-exporter.log", "all-logs", "text/plain");
+              expect(openSaveFileDialogMock).toHaveBeenCalledWith(
+                expect.stringMatching(/^docker-exporter-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.log$/),
+                "all-logs",
+                "text/plain",
+              );
             });
 
             it("doesn't block download dropdown for interaction after click", () => {

--- a/packages/core/src/renderer/components/dock/logs/__test__/get-timestamped-log-filename.test.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/get-timestamped-log-filename.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getTimestampedLogFilename } from "../get-timestamped-log-filename";
+
+describe("getTimestampedLogFilename", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-21T09:55:41.123Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("appends a filesystem-safe ISO timestamp and .log extension", () => {
+    expect(getTimestampedLogFilename("docker-exporter")).toBe("docker-exporter-2026-05-21T09-55-41-123Z.log");
+  });
+});

--- a/packages/core/src/renderer/components/dock/logs/download-all-logs.injectable.ts
+++ b/packages/core/src/renderer/components/dock/logs/download-all-logs.injectable.ts
@@ -9,6 +9,7 @@ import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
 import openSaveFileDialogInjectable from "../../../utils/save-file.injectable";
 import callForLogsInjectable from "./call-for-logs.injectable";
+import { getTimestampedLogFilename } from "./get-timestamped-log-filename";
 
 import type { ResourceDescriptor } from "@freelensapp/kube-api";
 import type { PodLogsQuery } from "@freelensapp/kube-object";
@@ -28,7 +29,7 @@ const downloadAllLogsInjectable = getInjectable({
       });
 
       if (logs) {
-        openSaveFileDialog(`${query.container}.log`, logs, "text/plain");
+        openSaveFileDialog(getTimestampedLogFilename(query.container ?? params.name), logs, "text/plain");
       } else {
         showErrorNotification("No logs to download");
       }

--- a/packages/core/src/renderer/components/dock/logs/get-timestamped-log-filename.ts
+++ b/packages/core/src/renderer/components/dock/logs/get-timestamped-log-filename.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+function getFilenameSafeTimestamp() {
+  return new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-");
+}
+
+export function getTimestampedLogFilename(prefix: string) {
+  return `${prefix}-${getFilenameSafeTimestamp()}.log`;
+}

--- a/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
+++ b/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
@@ -8,6 +8,7 @@ import assert from "node:assert";
 import { isDefined } from "@freelensapp/utilities";
 import { computed } from "mobx";
 import { defaultLogViewerPreferences } from "../../../../features/user-preferences/common/preferences-helpers";
+import { getTimestampedLogFilename } from "./get-timestamped-log-filename";
 
 import type { ResourceDescriptor } from "@freelensapp/kube-api";
 import type { Pod, PodLogsQuery } from "@freelensapp/kube-object";
@@ -118,7 +119,7 @@ export class LogTabViewModel {
       const fileName = pod.getName();
       const logsToDownload: string[] = tabData.showTimestamps ? this.logs.get() : this.logsWithoutTimestamps.get();
 
-      this.dependencies.downloadLogs(`${fileName}.log`, logsToDownload);
+      this.dependencies.downloadLogs(getTimestampedLogFilename(fileName), logsToDownload);
     }
   };
 


### PR DESCRIPTION
## Problem

Downloaded pod log files use a fixed name (`<pod>.log` for visible logs, `<container>.log` for all logs). Downloading logs twice for the same pod or container silently overwrites the previous file, which loses data when comparing logs over time.

## Change

- New helper `getTimestampedLogFilename(prefix)` builds `<prefix>-<ISO timestamp>.log`, with colons and dots replaced by dashes so the name is safe on all filesystems, e.g. `docker-exporter-2026-05-21T09-55-41-123Z.log`.
- `LogTabViewModel.downloadLogs` and the download-all-logs injectable use the helper instead of the fixed names.
- Unit test for the helper (fake timers) plus updated assertions in `download-logs.test.tsx`.

## Validation

- `pnpm biome check` on the changed files: clean.
- `vitest run` over `packages/core/src/renderer/components/dock/logs/`: 8 files, 29 tests passed.
- Repo `type-check` (generated tsconfig + `tsc`): no errors.