### PR TITLE
Inline await-lock source and add its copyright to the license manifest

### DIFF
--- a/freelens/electron.vite.config.ts
+++ b/freelens/electron.vite.config.ts
@@ -68,20 +68,9 @@ const workspacePackages = Object.keys(packageJson.dependencies).filter((name) =>
 // - @ogre-tools/*: webpack-bundled CJS whose exports are defined via
 //   Object.defineProperty getters; cjs-module-lexer cannot detect them, so
 //   named imports fail at ESM link time ("Named export ... not found").
-// - await-lock: a CJS module that exports its class as `exports.default`.
-//   Under a bundler TypeScript's esModuleInterop binds `import AwaitLock from
-//   "await-lock"` to `module.exports.default` (the class), but Node's native
-//   ESM interop binds the default import to the whole `module.exports` object
-//   (`{ __esModule: true, default: [class] }`), so `new AwaitLock()` throws
-//   "AwaitLock is not a constructor".
 // Bundling lets Vite resolve the named exports and default interop at build
 // time, sidestepping runtime ESM resolution.
-const bundledCjsPackages = [
-  "await-lock",
-  "@ogre-tools/injectable",
-  "@ogre-tools/fp",
-  "@ogre-tools/injectable-extension-for-mobx",
-];
+const bundledCjsPackages = ["@ogre-tools/injectable", "@ogre-tools/fp", "@ogre-tools/injectable-extension-for-mobx"];
 
 // Rewrite the packaged main bundle's single merged `electron` import from a
 // named import into a default import + destructure.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -108,7 +108,6 @@
     "@xterm/xterm": "^6.0.0",
     "ansi_up": "^6.0.6",
     "auto-bind": "^4.0.0",
-    "await-lock": "^2.2.2",
     "chalk": "^4.1.2",
     "chart.js": "^4.5.1",
     "chartjs-adapter-moment": "^1.0.1",

--- a/packages/core/src/common/utils/await-lock.ts
+++ b/packages/core/src/common/utils/await-lock.ts
@@ -4,26 +4,106 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-// `await-lock` is a CommonJS module that exports its class via `exports.default`
-// (`{ __esModule: true, default: AwaitLock }`). Bundlers disagree on what a
-// default import of such a module binds to:
-//
-// - With TypeScript's `esModuleInterop` / a classic bundler, `import AwaitLock
-//   from "await-lock"` binds directly to the class.
-// - Under Node-mode ESM interop — which rolldown/esbuild use for the Electron
-//   main (Node) target, and which electron-vite v6 + Vite 8 now also emit for
-//   the renderer — the default import binds to the whole `module.exports`
-//   object, leaving the class one `.default` deeper (`__toESM(require(...), 1)`).
-//   `new AwaitLock()` then throws "import_AwaitLock.default is not a
-//   constructor" because the binding is `{ __esModule, default: class }`.
-//
-// Normalize both shapes to the constructor here so call sites can just do
-// `new AwaitLock()` regardless of how the module is bundled.
-import AwaitLockImport from "await-lock";
+/**
+ * Vendored from `await-lock` v2.2.2 (https://github.com/ide/await-lock).
+ *
+ * Copyright (c) 2015-present James Ide. Licensed under the MIT License.
+ *
+ * Inlined as TypeScript so it is bundled directly as ESM, avoiding the CommonJS
+ * `exports.default` interop mismatch between bundlers and Node's native ESM
+ * (which required both a runtime wrapper here and a `bundledCjsPackages` entry
+ * in `electron.vite.config.ts`).
+ */
 
-type AwaitLockConstructor = typeof AwaitLockImport;
+/**
+ * A mutex lock for coordination across async functions
+ */
+export default class AwaitLock {
+  #acquired = false;
+  #waitingResolvers: Set<() => void> = new Set();
 
-const AwaitLock = ((AwaitLockImport as unknown as { default?: AwaitLockConstructor }).default ??
-  AwaitLockImport) as AwaitLockConstructor;
+  /**
+   * Whether the lock is currently acquired or not. Accessing this property does not affect the
+   * status of the lock.
+   */
+  get acquired(): boolean {
+    return this.#acquired;
+  }
 
-export default AwaitLock;
+  /**
+   * Acquires the lock, waiting if necessary for it to become free if it is already locked. The
+   * returned promise is fulfilled once the lock is acquired.
+   *
+   * A timeout (in milliseconds) may be optionally provided. If the lock cannot be acquired before
+   * the timeout elapses, the returned promise is rejected with an error. The behavior of invalid
+   * timeout values depends on how `setTimeout` handles those values.
+   *
+   * After acquiring the lock, you **must** call `release` when you are done with it.
+   */
+  acquireAsync({ timeout }: { timeout?: number } = {}): Promise<void> {
+    if (!this.#acquired) {
+      this.#acquired = true;
+      return Promise.resolve();
+    }
+
+    if (timeout == null) {
+      return new Promise((resolve) => {
+        this.#waitingResolvers.add(resolve);
+      });
+    }
+
+    let resolver: () => void;
+    let timer: ReturnType<typeof setTimeout>;
+
+    return Promise.race<void>([
+      new Promise((resolve) => {
+        resolver = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+        this.#waitingResolvers.add(resolver);
+      }),
+      new Promise<void>((_, reject) => {
+        timer = setTimeout(() => {
+          this.#waitingResolvers.delete(resolver);
+          reject(new Error(`Timed out waiting for lock`));
+        }, timeout);
+      }),
+    ]);
+  }
+
+  /**
+   * Acquires the lock if it is free and otherwise returns immediately without waiting. Returns
+   * `true` if the lock was free and is now acquired, and `false` otherwise.
+   *
+   * This method differs from calling `acquireAsync` with a zero-millisecond timeout in that it runs
+   * synchronously without waiting for the JavaScript task queue.
+   */
+  tryAcquire(): boolean {
+    if (!this.#acquired) {
+      this.#acquired = true;
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Releases the lock and gives it to the next waiting acquirer, if there is one. Each acquirer
+   * must release the lock exactly once.
+   */
+  release(): void {
+    if (!this.#acquired) {
+      throw new Error(`Cannot release an unacquired lock`);
+    }
+
+    if (this.#waitingResolvers.size > 0) {
+      // Sets preserve insertion order like a queue
+      const [resolve] = this.#waitingResolvers;
+      this.#waitingResolvers.delete(resolve);
+      resolve();
+    } else {
+      this.#acquired = false;
+    }
+  }
+}

--- a/packages/generate-license/src/index.ts
+++ b/packages/generate-license/src/index.ts
@@ -127,6 +127,15 @@ async function main() {
       author: "The Helm Authors",
       licenseText: spdxLicenseList["Apache-2.0"].licenseText,
     },
+    // `await-lock` is vendored as TypeScript into
+    // `packages/core/src/common/utils/await-lock.ts` (see #2209), so it is no
+    // longer an npm dependency and must be listed here to keep its copyright in
+    // the generated license manifest.
+    "await-lock:MIT": {
+      name: "await-lock",
+      author: "James Ide",
+      licenseText: spdxLicenseList.MIT.licenseText,
+    },
   };
 
   const npmDependencies = await getDependenciesFromPnpmApi(prod);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,9 +557,6 @@ importers:
       auto-bind:
         specifier: ^4.0.0
         version: 4.0.0
-      await-lock:
-        specifier: ^2.2.2
-        version: 2.2.2
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -4276,9 +4273,6 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
-
-  await-lock@2.2.2:
-    resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
 
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
@@ -9110,8 +9104,6 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
-
-  await-lock@2.2.2: {}
 
   aws4@1.13.2: {}
 


### PR DESCRIPTION
Vendors the original await-lock v2.2.2 TypeScript source into `common/utils/await-lock.ts` (removing the CJS interop wrapper, the `bundledCjsPackages` entry, and the `await-lock` dependency), and adds a static `await-lock:MIT` entry to `generate-license` so James Ide's copyright stays in the manifest generated by `pnpm build:resources:license`.

Fixes #2209.

Generated with [Claude Code](https://claude.ai/code)