### PR TITLE
Fix React DevTools error on pnpm dev

### DIFF
--- a/packages/core/src/main/electron-app/runnables/setup-developer-tools-in-development-environment.injectable.ts
+++ b/packages/core/src/main/electron-app/runnables/setup-developer-tools-in-development-environment.injectable.ts
@@ -25,9 +25,9 @@ const setupDeveloperToolsInDevelopmentEnvironmentInjectable = getInjectable({
 
       void (async () => {
         try {
-          const { default: devToolsInstaller, REACT_DEVELOPER_TOOLS } = await import("electron-devtools-installer");
+          const { installExtension, REACT_DEVELOPER_TOOLS } = await import("electron-devtools-installer");
 
-          const name = await devToolsInstaller([REACT_DEVELOPER_TOOLS]);
+          const name = await installExtension([REACT_DEVELOPER_TOOLS]);
 
           logger.info(`[DEVTOOLS-INSTALLER]: installed ${name}`);
         } catch (error) {


### PR DESCRIPTION
Fixes #2214.

`electron-devtools-installer@4` is a CommonJS module. Under electron-vite's Node-ESM interop (after Webpack removal in #2118), the default import resolves to the whole `module.exports` object rather than the install function, so calling it threw `devToolsInstaller is not a function`. This switches to the named `installExtension` export, which cjs-module-lexer resolves the same way `REACT_DEVELOPER_TOOLS` already did.

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`