### PR TITLE
Speed up the integration tests workflow across all platforms

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -263,7 +263,6 @@ jobs:
         working-directory: freelens
         run: node "$ELECTRON_BUILDER_PATH" --publish never --${{ matrix.os }} dir --${{ matrix.arch }}
         env:
-          DEBUG: electron-builder,electron-builder:*
           npm_config_user_agent: pnpm
 
       - name: Restore dev node_modules

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -55,7 +55,6 @@ jobs:
       DO_NOT_TRACK: "1"
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
-      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/playwright
       TURBOREPO_CACHE: ${{ github.workspace }}/.turbo
 
     steps:
@@ -128,10 +127,6 @@ jobs:
         shell: bash
         run: echo "electron_builder_version=$(yq -r .importers.freelens.devDependencies.electron-builder.version pnpm-lock.yaml | sed 's/(.*)//')" >> $GITHUB_ENV
 
-      - name: Get Playwright version
-        shell: bash
-        run: echo "playwright_version=$(yq -r .importers.freelens.devDependencies.playwright.version pnpm-lock.yaml | sed 's/(.*)//')" >> $GITHUB_ENV
-
       - name: Use Electron cache
         uses: actions/cache@v6
         with:
@@ -147,24 +142,6 @@ jobs:
           key: ${{ matrix.runs-on }}-${{ matrix.arch }}-electron-builder-${{ env.electron_builder_version }}
           restore-keys: |
             ${{ matrix.runs-on }}-${{ matrix.arch }}-electron-builder-
-
-      # The integration tests drive the packaged Electron app through
-      # Playwright's `_electron` API, which uses Electron's own bundled Chromium
-      # and never touches Playwright's downloaded browsers. So the browser
-      # download/cache and `install-deps` are only relevant on Linux, where
-      # `install-deps` (an apt, Ubuntu/Debian-only operation) pulls the shared
-      # libraries Chromium needs. On macOS this step is a ~2s no-op, but on the
-      # Windows runners the `pnpx` (dlx) fetch of Playwright makes it cost ~3 min
-      # for no benefit, so the whole thing is gated to Linux.
-      - name: Use Playwright cache
-        id: playwright-cache
-        if: runner.os == 'Linux'
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-playwright-${{ env.playwright_version }}
-          restore-keys: |
-            ${{ matrix.runs-on }}-${{ matrix.arch }}-playwright-
 
       - name: Use Turborepo cache
         uses: actions/cache@v6
@@ -206,12 +183,13 @@ jobs:
         if: runner.os == 'windows'
         run: echo "HOME=$HOME" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Install Playwright with dependencies
-        if: runner.os == 'Linux' && steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpx playwright install --with-deps
-
-      - name: Install Playwright's dependencies
-        if: runner.os == 'Linux' && steps.playwright-cache.outputs.cache-hit == 'true'
+      # The integration tests drive the packaged Electron app via Playwright's
+      # `_electron` API, which uses Electron's own bundled Chromium, so
+      # Playwright's browsers are never downloaded. `install-deps` is still
+      # needed on Linux: it apt-installs the shared libraries that Chromium (and
+      # thus the Electron app) needs to launch under xvfb.
+      - name: Install Playwright's OS dependencies (Linux)
+        if: runner.os == 'Linux'
         run: pnpx playwright install-deps
 
       - name: Build packages

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -151,6 +151,19 @@ jobs:
           restore-keys: |
             ${{ matrix.runs-on }}-${{ matrix.arch }}-turborepo-
 
+      # Cache the .deb archives and package lists that `playwright install-deps`
+      # downloads through apt, so re-runs reuse them instead of re-downloading.
+      # apt is pointed at this project-local directory via a global config file
+      # written in the install step below.
+      - name: Use APT cache (Linux)
+        if: runner.os == 'Linux'
+        uses: actions/cache@v6
+        with:
+          path: .apt
+          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-apt-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ matrix.runs-on }}-${{ matrix.arch }}-apt-
+
       - name: Start KinD cluster (Linux)
         if: runner.os == 'Linux'
         uses: helm/kind-action@v1
@@ -192,7 +205,23 @@ jobs:
       # Firefox/WebKit dependency set that the Electron app never uses.
       - name: Install Playwright's OS dependencies (Linux)
         if: runner.os == 'Linux'
-        run: pnpx playwright install-deps chromium
+        shell: bash
+        run: |
+          set -eo pipefail
+          # `playwright install-deps` runs its own `apt-get update`/`install`, so
+          # the archive/list redirect has to be a global apt config file it picks
+          # up rather than per-invocation `-o` flags. Point apt at the cached
+          # project-local dirs (see the APT cache step above); dpkg's status stays
+          # at the system default, so packages still install into the runner.
+          mkdir -p .apt/cache/archives/partial .apt/state/lists/partial
+          sudo tee /etc/apt/apt.conf.d/00freelens-cache >/dev/null <<EOF
+          Dir::Cache::archives "$PWD/.apt/cache/archives";
+          Dir::State::lists "$PWD/.apt/state/lists";
+          EOF
+          pnpx playwright install-deps chromium
+          # apt ran as root, so hand the cache dir back to the runner user for the
+          # cache-save post step to read.
+          sudo chown -R "$(id -u):$(id -g)" .apt
 
       - name: Build packages
         if: runner.os != 'Windows'

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -187,10 +187,12 @@ jobs:
       # `_electron` API, which uses Electron's own bundled Chromium, so
       # Playwright's browsers are never downloaded. `install-deps` is still
       # needed on Linux: it apt-installs the shared libraries that Chromium (and
-      # thus the Electron app) needs to launch under xvfb.
+      # thus the Electron app) needs to launch under xvfb. Scope it to `chromium`
+      # so only Chromium's libraries are installed, skipping the heavier
+      # Firefox/WebKit dependency set that the Electron app never uses.
       - name: Install Playwright's OS dependencies (Linux)
         if: runner.os == 'Linux'
-        run: pnpx playwright install-deps
+        run: pnpx playwright install-deps chromium
 
       - name: Build packages
         if: runner.os != 'Windows'

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -148,8 +148,17 @@ jobs:
           restore-keys: |
             ${{ matrix.runs-on }}-${{ matrix.arch }}-electron-builder-
 
+      # The integration tests drive the packaged Electron app through
+      # Playwright's `_electron` API, which uses Electron's own bundled Chromium
+      # and never touches Playwright's downloaded browsers. So the browser
+      # download/cache and `install-deps` are only relevant on Linux, where
+      # `install-deps` (an apt, Ubuntu/Debian-only operation) pulls the shared
+      # libraries Chromium needs. On macOS this step is a ~2s no-op, but on the
+      # Windows runners the `pnpx` (dlx) fetch of Playwright makes it cost ~3 min
+      # for no benefit, so the whole thing is gated to Linux.
       - name: Use Playwright cache
         id: playwright-cache
+        if: runner.os == 'Linux'
         uses: actions/cache@v6
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
@@ -198,11 +207,11 @@ jobs:
         run: echo "HOME=$HOME" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install Playwright with dependencies
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: runner.os == 'Linux' && steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpx playwright install --with-deps
 
       - name: Install Playwright's dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        if: runner.os == 'Linux' && steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpx playwright install-deps
 
       - name: Build packages


### PR DESCRIPTION
## Problem

The integration-tests job was noticeably slow, worst on Windows (~7 min vs ~2m40s on macOS). Profiling a run showed the tests themselves take only ~20s — the time went into setup and the packaged-app build, not the tests. Several of those setup steps did work that these tests never use.

The integration tests drive the **packaged Electron app** through Playwright's `_electron` API (`freelens/integration/helpers/utils.ts`), which uses Electron's own bundled Chromium. They never launch Playwright's downloaded browsers.

## Changes

**All platforms**
- Stop downloading and caching Playwright browsers (Chromium/Firefox/WebKit). They are never used, so the browser cache, the install step, the version lookup that fed the cache key, and the `PLAYWRIGHT_BROWSERS_PATH` env are all removed.

**Windows**
- The `Install Playwright's dependencies` step (`playwright install-deps`) cost ~3m02s per run via the `pnpx`/dlx fetch, for an apt-only, Ubuntu/Debian operation that is a no-op on Windows. Gated to Linux → 0s on Windows.
- Removed `DEBUG: electron-builder,electron-builder:*` from the `Build Electron app` step. It shares a single debug namespace that cannot be narrowed and floods the log with a per-file line for every packed file (e.g. "path is outside of explicit safe paths, defaulting to safe"); on Windows that console output measurably slowed the build (~84s → ~67s).

**Linux**
- Scope `playwright install-deps` to `chromium` so only Chromium's shared libraries are apt-installed, skipping the heavier Firefox/WebKit dependency set the Electron app never uses (~59s → ~25s).
- Cache the apt `.deb` archives and package lists across runs (ported from the GitLab `.apt` caching pattern). Since `playwright install-deps` runs its own `apt-get`, the redirect to the project-local cache dir is a global `/etc/apt/apt.conf.d` config file (`Dir::Cache::archives` / `Dir::State::lists`) that Playwright's apt calls pick up; dpkg's status stays at the system default so packages still install into the runner. On a warm cache `install-deps` drops further to ~15s.

## Measured impact (CI)

| | baseline `main` | after |
|---|---|---|
| Windows job | ~7m05s | ~3m20s |
| Windows `Build Electron app` | ~1m28s | ~1m07s |
| Windows Playwright `install-deps` | ~3m02s | 0s (skipped) |
| Linux Playwright `install-deps` | ~59s | ~25s scoped to chromium, ~15s on a warm apt cache |

Runner-to-runner variance on the Windows images is significant, so treat the numbers as indicative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)