### PR TITLE
Replace grapheme-splitter with native Intl.Segmenter

### DIFF
--- a/freelens/package.json
+++ b/freelens/package.json
@@ -83,7 +83,6 @@
     "electron-window-state": "^5.0.3",
     "fs-extra": "^11.3.6",
     "glob-to-regexp": "^0.4.1",
-    "grapheme-splitter": "^1.0.4",
     "handlebars": "^4.7.9",
     "hpagent": "^1.2.0",
     "http-proxy-node16": "^1.0.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -123,7 +123,6 @@
     "es-toolkit": "^1.49.0",
     "fs-extra": "^11.3.6",
     "glob-to-regexp": "^0.4.1",
-    "grapheme-splitter": "^1.0.4",
     "handlebars": "^4.7.9",
     "history": "^4.10.1",
     "hpagent": "^1.2.0",

--- a/packages/core/src/common/catalog/helpers.ts
+++ b/packages/core/src/common/catalog/helpers.ts
@@ -5,9 +5,16 @@
  */
 
 import { hasOwnProperty, hasTypedProperty, isObject, isString, iter } from "@freelensapp/utilities";
-import GraphemeSplitter from "grapheme-splitter";
 
 import type { CatalogEntity } from "./catalog-entity";
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function* iterateGraphemes(src: string): IterableIterator<string> {
+  for (const { segment } of graphemeSegmenter.segment(src)) {
+    yield segment;
+  }
+}
 
 function getNameParts(name: string): string[] {
   const byWhitespace = name.split(/\s+/);
@@ -26,9 +33,7 @@ function getNameParts(name: string): string[] {
 }
 
 export function limitGraphemeLengthOf(src: string, count: number): string {
-  const splitter = new GraphemeSplitter();
-
-  return iter.chain(splitter.iterateGraphemes(src)).take(count).join("");
+  return iter.chain(iterateGraphemes(src)).take(count).join("");
 }
 
 export function computeDefaultShortName(name: string) {
@@ -37,10 +42,9 @@ export function computeDefaultShortName(name: string) {
   }
 
   const [rawFirst, rawSecond, rawThird] = getNameParts(name);
-  const splitter = new GraphemeSplitter();
-  const first = splitter.iterateGraphemes(rawFirst);
-  const second = rawSecond ? splitter.iterateGraphemes(rawSecond) : first;
-  const third = rawThird ? splitter.iterateGraphemes(rawThird) : iter.newEmpty<string>();
+  const first = iterateGraphemes(rawFirst);
+  const second = rawSecond ? iterateGraphemes(rawSecond) : first;
+  const third = rawThird ? iterateGraphemes(rawThird) : iter.newEmpty<string>();
 
   return iter.chain(iter.take(first, 1)).concat(iter.take(second, 1)).concat(iter.take(third, 1)).join("");
 }

--- a/packages/core/src/common/catalog/helpers.ts
+++ b/packages/core/src/common/catalog/helpers.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { hasOwnProperty, hasTypedProperty, isObject, isString, iter } from "@freelensapp/utilities";
+import { hasOwnProperty, hasTypedProperty, isObject, isString } from "@freelensapp/utilities";
 
 import type { CatalogEntity } from "./catalog-entity";
 
@@ -33,7 +33,7 @@ function getNameParts(name: string): string[] {
 }
 
 export function limitGraphemeLengthOf(src: string, count: number): string {
-  return iter.chain(iterateGraphemes(src)).take(count).join("");
+  return [...iterateGraphemes(src)].slice(0, count).join("");
 }
 
 export function computeDefaultShortName(name: string) {
@@ -42,11 +42,11 @@ export function computeDefaultShortName(name: string) {
   }
 
   const [rawFirst, rawSecond, rawThird] = getNameParts(name);
-  const first = iterateGraphemes(rawFirst);
-  const second = rawSecond ? iterateGraphemes(rawSecond) : first;
-  const third = rawThird ? iterateGraphemes(rawThird) : iter.newEmpty<string>();
+  const first = [...iterateGraphemes(rawFirst)];
+  const second = rawSecond ? [...iterateGraphemes(rawSecond)] : first.slice(1);
+  const third = rawThird ? [...iterateGraphemes(rawThird)] : [];
 
-  return iter.chain(iter.take(first, 1)).concat(iter.take(second, 1)).concat(iter.take(third, 1)).join("");
+  return [first[0], second[0], third[0]].filter(Boolean).join("");
 }
 
 export function getShortName(entity: CatalogEntity): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,9 +121,6 @@ importers:
       glob-to-regexp:
         specifier: ^0.4.1
         version: 0.4.1
-      grapheme-splitter:
-        specifier: ^1.0.4
-        version: 1.0.4
       handlebars:
         specifier: ^4.7.9
         version: 4.7.9
@@ -602,9 +599,6 @@ importers:
       glob-to-regexp:
         specifier: ^0.4.1
         version: 0.4.1
-      grapheme-splitter:
-        specifier: ^1.0.4
-        version: 1.0.4
       handlebars:
         specifier: ^4.7.9
         version: 4.7.9
@@ -4956,9 +4950,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  grapheme-splitter@1.0.4:
-    resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
 
   gunzip-maybe@1.4.2:
     resolution: {integrity: sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==}
@@ -9814,8 +9805,6 @@ snapshots:
       responselike: 2.0.1
 
   graceful-fs@4.2.11: {}
-
-  grapheme-splitter@1.0.4: {}
 
   gunzip-maybe@1.4.2:
     dependencies:


### PR DESCRIPTION
Replaces the deprecated `grapheme-splitter` package with the native `Intl.Segmenter` API in `packages/core/src/common/catalog/helpers.ts`, and removes the dependency from both packages and the lockfile.

Fixes #2170

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`