### PR TITLE
Fix React DevTools not downloading on pnpm dev due to proxy misconfiguration

### DIFF
--- a/packages/core/src/main/electron-app/runnables/setup-developer-tools-in-development-environment.injectable.ts
+++ b/packages/core/src/main/electron-app/runnables/setup-developer-tools-in-development-environment.injectable.ts
@@ -27,9 +27,11 @@ const setupDeveloperToolsInDevelopmentEnvironmentInjectable = getInjectable({
         try {
           const { installExtension, REACT_DEVELOPER_TOOLS } = await import("electron-devtools-installer");
 
-          const name = await installExtension([REACT_DEVELOPER_TOOLS]);
+          const extensions = await installExtension([REACT_DEVELOPER_TOOLS]);
 
-          logger.info(`[DEVTOOLS-INSTALLER]: installed ${name}`);
+          const names = extensions.map((extension) => extension.name).join(", ");
+
+          logger.info(`[DEVTOOLS-INSTALLER]: installed ${names}`);
         } catch (error) {
           logger.error(`[DEVTOOLS-INSTALLER]: failed`, { error });
         }

--- a/packages/core/src/main/start-main-application/runnables/setup-session-proxy-bypass.injectable.ts
+++ b/packages/core/src/main/start-main-application/runnables/setup-session-proxy-bypass.injectable.ts
@@ -18,17 +18,47 @@ const setupSessionProxyBypassInjectable = getInjectable({
       try {
         logger.info("[PROXY-BYPASS] Configuring session proxy bypass for localhost connections");
 
-        const systemProxyRules = await session.defaultSession.resolveProxy("https://example.com");
+        // `resolveProxy` returns a PAC-format string (e.g. "DIRECT" or "PROXY host:port; DIRECT").
+        // It cannot be fed directly into `setProxy` with `mode: "fixed_servers"`, whose `proxyRules`
+        // expects server specs like "host:port" or "https=host:port". Passing "DIRECT" there makes
+        // Chromium route all non-local traffic through a phantom proxy named "DIRECT", which breaks
+        // every external request with ERR_PROXY_CONNECTION_FAILED.
+        const pacResult = await session.defaultSession.resolveProxy("https://example.com");
 
-        await session.defaultSession.setProxy({
-          mode: "fixed_servers",
-          proxyRules: systemProxyRules,
-          proxyBypassRules: ["<local>", "renderer.freelens.app", ".renderer.freelens.app", "127.0.0.1/8", "[::1]"].join(
-            ",",
-          ),
-        });
+        const proxyRules = pacResult
+          .split(";")
+          .map((entry) => entry.trim())
+          .filter((entry) => entry && entry.toUpperCase() !== "DIRECT")
+          .map((entry) =>
+            entry
+              .replace(/^PROXY\s+/i, "")
+              .replace(/^HTTPS\s+/i, "https://")
+              .replace(/^SOCKS5\s+/i, "socks5://")
+              .replace(/^SOCKS4\s+/i, "socks4://")
+              .replace(/^SOCKS\s+/i, "socks://"),
+          )
+          .join(",");
 
-        logger.info("[PROXY-BYPASS] Proxy bypass configured for local addresses while preserving system proxy");
+        if (proxyRules === "") {
+          // No system proxy — connect directly so external requests are not routed through a proxy.
+          await session.defaultSession.setProxy({ mode: "direct" });
+
+          logger.info("[PROXY-BYPASS] No system proxy detected; using direct connection");
+        } else {
+          await session.defaultSession.setProxy({
+            mode: "fixed_servers",
+            proxyRules,
+            proxyBypassRules: [
+              "<local>",
+              "renderer.freelens.app",
+              ".renderer.freelens.app",
+              "127.0.0.1/8",
+              "[::1]",
+            ].join(","),
+          });
+
+          logger.info("[PROXY-BYPASS] Proxy bypass configured for local addresses while preserving system proxy");
+        }
       } catch (error) {
         logger.error("[PROXY-BYPASS] Failed to configure session proxy bypass", { error });
       }


### PR DESCRIPTION
Fixes #2214.

Issue #2214 was closed after fixing the `devToolsInstaller is not a function` error, but React DevTools still failed to download — the real blocker was a proxy misconfiguration, so the installer kept failing with `net::ERR_PROXY_CONNECTION_FAILED`.

## Root cause

`electron-devtools-installer` downloads via `electron.net`, which uses `session.defaultSession` and therefore obeys that session's proxy configuration.

`setup-session-proxy-bypass.injectable.ts` fed the result of `session.resolveProxy()` straight into `setProxy({ mode: "fixed_servers", proxyRules })`. But `resolveProxy` returns a **PAC-format** string, while `fixed_servers` `proxyRules` expects server specs (`host:port`). When there is no system proxy, `resolveProxy` returns `"DIRECT"`, and passing `"DIRECT"` to `fixed_servers` makes Chromium route every non-local request through a phantom proxy server literally named `DIRECT` → `ERR_PROXY_CONNECTION_FAILED`.

This broke all external requests on the default session (including the DevTools download), while localhost kept working because of the bypass rules — which is why the app otherwise ran fine.

## Changes

1. **Fix the proxy bypass** — parse the PAC result: use `mode: "direct"` when there is no system proxy, and convert real PAC entries (`PROXY`/`HTTPS`/`SOCKS`) into the `fixed_servers` `proxyRules` format otherwise. This is what actually unblocks the download.
2. **Log fix** — `installExtension([...])` returns an `Extension[]` in v4, so the log printed `installed [object Object]`; now it maps to the extension names.

## Validation

- `pnpm dev` now logs `[PROXY-BYPASS] No system proxy detected; using direct connection` and `[DEVTOOLS-INSTALLER]: installed React Developer Tools` instead of `failed`.
- `biome check` passes on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)