### PR TITLE
Cache Electron v42 binary in unit tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -53,8 +53,8 @@ jobs:
 
     env:
       DO_NOT_TRACK: "1"
-      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
+      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       TURBOREPO_CACHE: ${{ github.workspace }}/.turbo
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,8 +83,8 @@ jobs:
 
     env:
       DO_NOT_TRACK: "1"
-      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
+      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
 
     steps:
       - name: Checkout

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -29,6 +29,7 @@ jobs:
 
     env:
       DO_NOT_TRACK: "1"
+      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       TURBOREPO_CACHE: ${{ github.workspace }}/.turbo
 
     steps:
@@ -64,6 +65,16 @@ jobs:
           restore-keys: |
             ubuntu-24.04-arm-arm64-turborepo-
 
+      - name: Get Electron version
+        shell: bash
+        run: echo "electron_version=$(yq -r .importers.freelens.devDependencies.electron.version pnpm-lock.yaml | sed 's/(.*)//')" >> ${GITHUB_ENV}
+
+      - name: Use Electron cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.ELECTRON_CACHE }}
+          key: ubuntu-24.04-arm-arm64-electron-${{ env.electron_version }}
+
       - name: Install pnpm dependencies
         id: install-pnpm
         run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
@@ -72,6 +83,17 @@ jobs:
       - name: Install pnpm dependencies (retry)
         if: steps.install-pnpm.outcome == 'failure'
         run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+
+      # Electron 42 downloads its runtime binary lazily on the first require(),
+      # not during install. Without this step the parallel Vitest workers each
+      # trigger the download and extraction at test time and clobber each other,
+      # failing with "Electron failed to install correctly". Download and
+      # extract it once, serially, here; the archive is served from the
+      # GitHub-cached ELECTRON_CACHE restored above.
+      - name: Install Electron binary
+        working-directory: freelens
+        run: |
+          node "$(node -p "require.resolve('electron/install.js')")"
 
       - name: Build packages
         run: pnpm --color=always --stream build

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -88,10 +88,13 @@ jobs:
       # not during install. Without this step the parallel Vitest workers each
       # trigger the download and extraction at test time and clobber each other,
       # failing with "Electron failed to install correctly". Download and
-      # extract it once, serially, here; the archive is served from the
+      # extract it once, serially, here. electron/install.js reads its download
+      # cache directory from electron_config_cache, so point it at the
       # GitHub-cached ELECTRON_CACHE restored above.
       - name: Install Electron binary
         working-directory: freelens
+        env:
+          electron_config_cache: ${{ env.ELECTRON_CACHE }}
         run: |
           node "$(node -p "require.resolve('electron/install.js')")"
 


### PR DESCRIPTION
## Summary

Electron 42 no longer downloads its runtime binary during install; it fetches it lazily on the first `require()`. In the unit-tests workflow the parallel Vitest workers each triggered that download and extraction at test time and clobbered each other, failing with `Electron failed to install correctly`.

This is independent of the pnpm v11 migration (#2047) — the same lazy download already happens on `main` and usually survives the race, but it is fragile.

## Changes

- **`unit-tests.yaml`**: download and extract the Electron binary once, serially, before the tests run, and cache it via GitHub Actions:
  - new `ELECTRON_CACHE` env var
  - `Get Electron version` step (reads the version from `pnpm-lock.yaml`)
  - `Use Electron cache` step (`actions/cache@v6`, keyed on the Electron version)
  - `Install Electron binary` step (`node "$(node -p "require.resolve('electron/install.js')")"`)

  This mirrors the established pattern in the integration-tests and release workflows. Once `dist/` is populated up front, the Vitest workers only ever read a complete binary, so the race is gone.
- **`integration-tests.yaml`** / **`release.yaml`**: sort the `env` keys alphabetically (`ELECTRON_BUILDER_CACHE` before `ELECTRON_CACHE`).

Integration tests intentionally do not get the explicit download step: there Electron is fetched by electron-builder during packaging and Playwright drives the packaged app, so there is no lazy `require('electron')` race across parallel workers.

`.cache/` is already git-ignored, so the `Check untracked files` step is unaffected.

| Model: `claude-opus-4-8[1m]`