### PR TITLE
Use React automatic JSX runtime

### DIFF
--- a/.github/workflows/claude-task.yaml
+++ b/.github/workflows/claude-task.yaml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.TURBOREPO_CACHE }}
-          key: ${{ env.RUNS_ON }}-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json') }}
+          key: ${{ env.RUNS_ON }}-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json','tsconfig*.json','packages/infrastructure/typescript/config/*.json') }}
           restore-keys: |
             ${{ env.RUNS_ON }}-turborepo-
 

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.TURBOREPO_CACHE }}
-          key: ${{ runner.os }}-${{ runner.arch }}-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json','tsconfig*.json','packages/infrastructure/typescript/config/*.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-turborepo-
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -147,7 +147,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.TURBOREPO_CACHE }}
-          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json') }}
+          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json','tsconfig*.json','packages/infrastructure/typescript/config/*.json') }}
           restore-keys: |
             ${{ matrix.runs-on }}-${{ matrix.arch }}-turborepo-
 

--- a/.github/workflows/knip.yaml
+++ b/.github/workflows/knip.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.TURBOREPO_CACHE }}
-          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json') }}
+          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json','tsconfig*.json','packages/infrastructure/typescript/config/*.json') }}
           restore-keys: |
             ${{ matrix.runs-on }}-${{ matrix.arch }}-turborepo-
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.TURBOREPO_CACHE }}
-          key: ubuntu-24.04-arm-arm64-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json') }}
+          key: ubuntu-24.04-arm-arm64-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json','tsconfig*.json','packages/infrastructure/typescript/config/*.json') }}
           restore-keys: |
             ubuntu-24.04-arm-arm64-turborepo-
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -163,6 +163,14 @@
     "packages/resource-templates": {
       "entry": [],
       "project": []
+    },
+
+    "packages/ui-components/button": {
+      // JSX compiles to react/jsx-runtime under the automatic runtime, which
+      // knip's --production --strict pass does not attribute to `react`. The
+      // only explicit react import here is type-only (ButtonHTMLAttributes),
+      // so react looks unused even though it is a real runtime dependency.
+      "ignoreDependencies": ["react"]
     }
   },
 

--- a/packages/business-features/keyboard-shortcuts/src/keyboard-shortcut-listener.tsx
+++ b/packages/business-features/keyboard-shortcuts/src/keyboard-shortcut-listener.tsx
@@ -1,5 +1,5 @@
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import invokeShortcutInjectable, { InvokeShortcut } from "./invoke-shortcut.injectable";
 
 import type { StrictReactNode } from "@freelensapp/utilities";

--- a/packages/business-features/keyboard-shortcuts/src/keyboard-shortcut-scope.tsx
+++ b/packages/business-features/keyboard-shortcuts/src/keyboard-shortcut-scope.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import type { StrictReactNode } from "@freelensapp/utilities";
 
 export interface KeyboardShortcutScopeProps {

--- a/packages/business-features/keyboard-shortcuts/src/keyboard-shortcuts.test.tsx
+++ b/packages/business-features/keyboard-shortcuts/src/keyboard-shortcuts.test.tsx
@@ -8,7 +8,6 @@ import { registerInjectableReact } from "@ogre-tools/injectable-react";
 import { render } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 import { computed, runInAction } from "mobx";
-import React from "react";
 import { keyboardShortcutsFeature } from "./feature";
 import { keyboardShortcutInjectionToken } from "./keyboard-shortcut-injection-token";
 import { KeyboardShortcutScope } from "./keyboard-shortcut-scope";

--- a/packages/core/src/common/__tests__/catalog-entity.test.tsx
+++ b/packages/core/src/common/__tests__/catalog-entity.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { CatalogCategory } from "../catalog";
 
 import type { CatalogCategorySpec } from "../catalog";

--- a/packages/core/src/common/utils/reactive-now/reactive-now.test.tsx
+++ b/packages/core/src/common/utils/reactive-now/reactive-now.test.tsx
@@ -7,7 +7,6 @@
 import { render } from "@testing-library/react";
 import { computed, observe } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
 import { advanceFakeTime, testUsingFakeTime } from "../../../test-utils/use-fake-time";
 import { reactiveNow } from "./reactive-now";
 

--- a/packages/core/src/features/cluster/extension-api/disable-cluster-pages-when-cluster-is-not-relevant.test.tsx
+++ b/packages/core/src/features/cluster/extension-api/disable-cluster-pages-when-cluster-is-not-relevant.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import asyncFn from "@async-fn/vitest";
-import React from "react";
 import { getApplicationBuilder } from "../../../renderer/components/test-utils/get-application-builder";
 
 import type { AsyncFnMock } from "@async-fn/vitest";

--- a/packages/core/src/features/cluster/extension-api/disable-sidebar-items-when-cluster-is-not-relevant.test.tsx
+++ b/packages/core/src/features/cluster/extension-api/disable-sidebar-items-when-cluster-is-not-relevant.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import asyncFn from "@async-fn/vitest";
-import React from "react";
 import { act } from "react-dom/test-utils";
 import { getApplicationBuilder } from "../../../renderer/components/test-utils/get-application-builder";
 

--- a/packages/core/src/features/cluster/extension-api/reactively-disable-cluster-pages.test.tsx
+++ b/packages/core/src/features/cluster/extension-api/reactively-disable-cluster-pages.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { computed, observable, runInAction } from "mobx";
-import React from "react";
 import { getApplicationBuilder } from "../../../renderer/components/test-utils/get-application-builder";
 
 import type { RenderResult } from "@testing-library/react";

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx
@@ -6,7 +6,6 @@
 
 import { KubeObject } from "@freelensapp/kube-object";
 import { observable } from "mobx";
-import React from "react";
 import apiManagerInjectable from "../../../../common/k8s-api/api-manager/manager.injectable";
 import showDetailsInjectable from "../../../../renderer/components/kube-detail-params/show-details.injectable";
 import { getApplicationBuilder } from "../../../../renderer/components/test-utils/get-application-builder";

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/reactively-hide-kube-object-detail-item.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/reactively-hide-kube-object-detail-item.test.tsx
@@ -7,7 +7,6 @@
 import assert from "node:assert";
 import { KubeObject } from "@freelensapp/kube-object";
 import { computed, observable, runInAction } from "mobx";
-import React from "react";
 import apiManagerInjectable from "../../../../common/k8s-api/api-manager/manager.injectable";
 import showDetailsInjectable from "../../../../renderer/components/kube-detail-params/show-details.injectable";
 import { getApplicationBuilder } from "../../../../renderer/components/test-utils/get-application-builder";

--- a/packages/core/src/features/cluster/kube-object-menu/extension-api/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-menu/extension-api/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx
@@ -8,7 +8,6 @@ import asyncFn from "@async-fn/vitest";
 import { KubeObject } from "@freelensapp/kube-object";
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed, runInAction } from "mobx";
-import React from "react";
 import { frontEndRouteInjectionToken } from "../../../../common/front-end-routing/front-end-route-injection-token";
 import { navigateToRouteInjectionToken } from "../../../../common/front-end-routing/navigate-to-route-injection-token";
 import { KubeObjectMenu } from "../../../../renderer/components/kube-object-menu";

--- a/packages/core/src/features/cluster/kube-object-menu/extension-api/reactively-hide-kube-object-menu-item.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-menu/extension-api/reactively-hide-kube-object-menu-item.test.tsx
@@ -7,7 +7,6 @@
 import { KubeObject } from "@freelensapp/kube-object";
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed, observable, runInAction } from "mobx";
-import React from "react";
 import { frontEndRouteInjectionToken } from "../../../../common/front-end-routing/front-end-route-injection-token";
 import { navigateToRouteInjectionToken } from "../../../../common/front-end-routing/navigate-to-route-injection-token";
 import { KubeObjectMenu } from "../../../../renderer/components/kube-object-menu";

--- a/packages/core/src/features/cluster/legacy-extension-adding-cluster-frame-components.test.tsx
+++ b/packages/core/src/features/cluster/legacy-extension-adding-cluster-frame-components.test.tsx
@@ -6,7 +6,6 @@
 
 import { act } from "@testing-library/react";
 import { computed, observable, runInAction } from "mobx";
-import React from "react";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
 import type { RenderResult } from "@testing-library/react";

--- a/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
+++ b/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
@@ -9,7 +9,6 @@ import { JsonApiErrorParsed } from "@freelensapp/json-api";
 import { Namespace } from "@freelensapp/kube-object";
 import { showErrorNotificationInjectable, showSuccessNotificationInjectable } from "@freelensapp/notifications";
 import { fireEvent } from "@testing-library/react";
-import React from "react";
 import directoryForLensLocalStorageInjectable from "../../../common/directory-for-lens-local-storage/directory-for-lens-local-storage.injectable";
 import navigateToNamespacesInjectable from "../../../common/front-end-routing/routes/cluster/namespaces/navigate-to-namespaces.injectable";
 import readJsonFileInjectable from "../../../common/fs/read-json-file.injectable";

--- a/packages/core/src/features/cluster/sidebar-and-tab-navigation-for-core.test.tsx
+++ b/packages/core/src/features/cluster/sidebar-and-tab-navigation-for-core.test.tsx
@@ -10,7 +10,6 @@ import { getInjectable } from "@ogre-tools/injectable";
 import { fireEvent } from "@testing-library/react";
 import { noop } from "es-toolkit";
 import { computed, runInAction } from "mobx";
-import React from "react";
 import { frontEndRouteInjectionToken } from "../../common/front-end-routing/front-end-route-injection-token";
 import { navigateToRouteInjectionToken } from "../../common/front-end-routing/navigate-to-route-injection-token";
 import pathExistsInjectable from "../../common/fs/path-exists.injectable";

--- a/packages/core/src/features/cluster/sidebar-and-tab-navigation-for-extensions.test.tsx
+++ b/packages/core/src/features/cluster/sidebar-and-tab-navigation-for-extensions.test.tsx
@@ -8,7 +8,6 @@ import assert from "node:assert";
 import { flushPromises } from "@freelensapp/test-utils";
 import { fireEvent } from "@testing-library/react";
 import { computed, observable, runInAction } from "mobx";
-import React from "react";
 import directoryForLensLocalStorageInjectable from "../../common/directory-for-lens-local-storage/directory-for-lens-local-storage.injectable";
 import { navigateToRouteInjectionToken } from "../../common/front-end-routing/navigate-to-route-injection-token";
 import pathExistsInjectable from "../../common/fs/path-exists.injectable";

--- a/packages/core/src/features/cluster/visibility-of-sidebar-items.test.tsx
+++ b/packages/core/src/features/cluster/visibility-of-sidebar-items.test.tsx
@@ -7,7 +7,6 @@
 import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { getInjectable } from "@ogre-tools/injectable";
 import { runInAction } from "mobx";
-import React from "react";
 import { frontEndRouteInjectionToken } from "../../common/front-end-routing/front-end-route-injection-token";
 import { navigateToRouteInjectionToken } from "../../common/front-end-routing/navigate-to-route-injection-token";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";

--- a/packages/core/src/features/cluster/workloads/overview/extension-api/disable-workloads-overview-details-when-cluster-is-not-relevant.test.tsx
+++ b/packages/core/src/features/cluster/workloads/overview/extension-api/disable-workloads-overview-details-when-cluster-is-not-relevant.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import asyncFn from "@async-fn/vitest";
-import React from "react";
 import navigateToWorkloadsOverviewInjectable from "../../../../../common/front-end-routing/routes/cluster/workloads/overview/navigate-to-workloads-overview.injectable";
 import { getApplicationBuilder } from "../../../../../renderer/components/test-utils/get-application-builder";
 

--- a/packages/core/src/features/cluster/workloads/overview/extension-api/order-of-workload-overview-details.test.tsx
+++ b/packages/core/src/features/cluster/workloads/overview/extension-api/order-of-workload-overview-details.test.tsx
@@ -7,7 +7,6 @@
 import { getRandomIdInjectionToken } from "@freelensapp/random";
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed, runInAction } from "mobx";
-import React from "react";
 import { getApplicationBuilder } from "../../../../../renderer/components/test-utils/get-application-builder";
 import { workloadOverviewDetailInjectionToken } from "../../../../../renderer/components/workloads-overview/workload-overview-details/workload-overview-detail-injection-token";
 

--- a/packages/core/src/features/cluster/workloads/overview/extension-api/reactively-hide-workloads-overview-details-item.test.tsx
+++ b/packages/core/src/features/cluster/workloads/overview/extension-api/reactively-hide-workloads-overview-details-item.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { computed, observable, runInAction } from "mobx";
-import React from "react";
 import navigateToWorkloadsOverviewInjectable from "../../../../../common/front-end-routing/routes/cluster/workloads/overview/navigate-to-workloads-overview.injectable";
 import { getApplicationBuilder } from "../../../../../renderer/components/test-utils/get-application-builder";
 

--- a/packages/core/src/features/extension-special-characters-in-page-registrations.test.tsx
+++ b/packages/core/src/features/extension-special-characters-in-page-registrations.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { getApplicationBuilder } from "../renderer/components/test-utils/get-application-builder";
 import currentPathInjectable from "../renderer/routes/current-path.injectable";
 

--- a/packages/core/src/features/helm-charts/child-features/preferences/renderer/adding-of-custom-helm-repository/adding-of-custom-helm-repository-dialog-content.tsx
+++ b/packages/core/src/features/helm-charts/child-features/preferences/renderer/adding-of-custom-helm-repository/adding-of-custom-helm-repository-dialog-content.tsx
@@ -11,7 +11,6 @@ import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { action } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
 import { toJS } from "../../../../../../common/utils";
 import { Checkbox } from "../../../../../../renderer/components/checkbox";
 import { Input } from "../../../../../../renderer/components/input";

--- a/packages/core/src/features/helm-charts/child-features/preferences/renderer/adding-of-custom-helm-repository/adding-of-custom-helm-repository-dialog.tsx
+++ b/packages/core/src/features/helm-charts/child-features/preferences/renderer/adding-of-custom-helm-repository/adding-of-custom-helm-repository-dialog.tsx
@@ -8,7 +8,6 @@ import "./add-helm-repo-dialog.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Dialog } from "../../../../../../renderer/components/dialog";
 import { AddingOfCustomHelmRepositoryDialogContent } from "./adding-of-custom-helm-repository-dialog-content";
 import addingOfCustomHelmRepositoryDialogIsVisibleInjectable from "./dialog-visibility/adding-of-custom-helm-repository-dialog-is-visible.injectable";

--- a/packages/core/src/features/helm-charts/child-features/preferences/renderer/adding-of-custom-helm-repository/adding-of-custom-helm-repository-open-button.tsx
+++ b/packages/core/src/features/helm-charts/child-features/preferences/renderer/adding-of-custom-helm-repository/adding-of-custom-helm-repository-open-button.tsx
@@ -6,7 +6,6 @@
 
 import { Button } from "@freelensapp/button";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import showDialogForAddingCustomHelmRepositoryInjectable from "./dialog-visibility/show-dialog-for-adding-custom-helm-repository.injectable";
 
 interface Dependencies {

--- a/packages/core/src/features/helm-charts/child-features/preferences/renderer/adding-of-custom-helm-repository/helm-file-input/helm-file-input.tsx
+++ b/packages/core/src/features/helm-charts/child-features/preferences/renderer/adding-of-custom-helm-repository/helm-file-input/helm-file-input.tsx
@@ -6,7 +6,6 @@
 
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { Input } from "../../../../../../../renderer/components/input";
 import isPathInjectable from "../../../../../../../renderer/components/input/validators/is-path.injectable";
 import requestFilePathsInjectable from "./get-file-paths.injectable";

--- a/packages/core/src/features/helm-charts/child-features/preferences/renderer/adding-of-public-helm-repository/adding-of-public-helm-repository.tsx
+++ b/packages/core/src/features/helm-charts/child-features/preferences/renderer/adding-of-public-helm-repository/adding-of-public-helm-repository.tsx
@@ -7,7 +7,6 @@
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Select } from "../../../../../../renderer/components/select";
 import activeHelmRepositoriesInjectable from "../active-helm-repositories.injectable";
 import publicHelmRepositoriesInjectable from "./public-helm-repositories/public-helm-repositories.injectable";

--- a/packages/core/src/features/helm-charts/child-features/preferences/renderer/helm-charts.tsx
+++ b/packages/core/src/features/helm-charts/child-features/preferences/renderer/helm-charts.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Notice } from "../../../../../renderer/components/extensions/notice";
 import { AddingOfCustomHelmRepositoryDialog } from "./adding-of-custom-helm-repository/adding-of-custom-helm-repository-dialog";
 import { AddingOfCustomHelmRepositoryOpenButton } from "./adding-of-custom-helm-repository/adding-of-custom-helm-repository-open-button";

--- a/packages/core/src/features/helm-charts/child-features/preferences/renderer/helm-repositories.tsx
+++ b/packages/core/src/features/helm-charts/child-features/preferences/renderer/helm-repositories.tsx
@@ -12,7 +12,6 @@
 import { Spinner } from "@freelensapp/spinner";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { RemovableItem } from "../../../../preferences/renderer/removable-item/removable-item";
 import activeHelmRepositoriesInjectable from "./active-helm-repositories.injectable";
 import styles from "./helm-charts.module.scss";

--- a/packages/core/src/features/licenses/renderer/licenses.tsx
+++ b/packages/core/src/features/licenses/renderer/licenses.tsx
@@ -8,7 +8,6 @@ import "./licenses.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { SettingLayout } from "../../../renderer/components/layout/setting-layout";
 import closeLicensesInjectable from "./close-licenses.injectable";
 import licenseContentInjectable from "./license-content.injectable";

--- a/packages/core/src/features/navigate-to-extension-page.test.tsx
+++ b/packages/core/src/features/navigate-to-extension-page.test.tsx
@@ -6,7 +6,6 @@
 
 import { fireEvent } from "@testing-library/react";
 import { isEmpty } from "es-toolkit/compat";
-import React from "react";
 import { getApplicationBuilder } from "../renderer/components/test-utils/get-application-builder";
 import currentPathInjectable from "../renderer/routes/current-path.injectable";
 import queryParametersInjectable from "../renderer/routes/query-parameters.injectable";

--- a/packages/core/src/features/navigating-between-routes.test.tsx
+++ b/packages/core/src/features/navigating-between-routes.test.tsx
@@ -7,7 +7,6 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed, runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
 import { frontEndRouteInjectionToken } from "../common/front-end-routing/front-end-route-injection-token";
 import { navigateToRouteInjectionToken } from "../common/front-end-routing/navigate-to-route-injection-token";
 import { getApplicationBuilder } from "../renderer/components/test-utils/get-application-builder";

--- a/packages/core/src/features/preferences/closing-preferences.test.tsx
+++ b/packages/core/src/features/preferences/closing-preferences.test.tsx
@@ -9,7 +9,6 @@ import { getInjectable } from "@ogre-tools/injectable";
 import { createMemoryHistory } from "history";
 import { computed, runInAction } from "mobx";
 import { createObservableHistory } from "mobx-observable-history";
-import React from "react";
 import { frontEndRouteInjectionToken } from "../../common/front-end-routing/front-end-route-injection-token";
 import navigateToFrontPageInjectable from "../../common/front-end-routing/navigate-to-front-page.injectable";
 import { navigateToRouteInjectionToken } from "../../common/front-end-routing/navigate-to-route-injection-token";

--- a/packages/core/src/features/preferences/extension-adding-preference-tabs.test.tsx
+++ b/packages/core/src/features/preferences/extension-adding-preference-tabs.test.tsx
@@ -6,7 +6,6 @@
 
 import { discoverFor } from "@freelensapp/react-testing-library-discovery";
 import { computed, observable, runInAction } from "mobx";
-import React from "react";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
 import type { Discover } from "@freelensapp/react-testing-library-discovery";

--- a/packages/core/src/features/preferences/hiding-of-empty-branches.test.tsx
+++ b/packages/core/src/features/preferences/hiding-of-empty-branches.test.tsx
@@ -7,7 +7,6 @@
 import { discoverFor } from "@freelensapp/react-testing-library-discovery";
 import { getInjectable } from "@ogre-tools/injectable";
 import { runInAction } from "mobx";
-import React from "react";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import { preferenceItemInjectionToken } from "./renderer/preference-items/preference-item-injection-token";
 

--- a/packages/core/src/features/preferences/navigation-to-application-preferences.test.tsx
+++ b/packages/core/src/features/preferences/navigation-to-application-preferences.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { discoverFor } from "@freelensapp/react-testing-library-discovery";
-import React from "react";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import navigateToProxyPreferencesInjectable from "./common/navigate-to-proxy-preferences.injectable";
 

--- a/packages/core/src/features/preferences/navigation-to-extension-preferences-using-extension-api.test.tsx
+++ b/packages/core/src/features/preferences/navigation-to-extension-preferences-using-extension-api.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { discoverFor } from "@freelensapp/react-testing-library-discovery";
-import React from "react";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import currentPathInjectable from "../../renderer/routes/current-path.injectable";
 

--- a/packages/core/src/features/preferences/navigation-to-extension-specific-preferences.test.tsx
+++ b/packages/core/src/features/preferences/navigation-to-extension-specific-preferences.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
 import type { RenderResult } from "@testing-library/react";

--- a/packages/core/src/features/preferences/renderer/preference-items/application/application-preference-page.injectable.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/application-preference-page.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { HorizontalLine } from "../../../../../renderer/components/horizontal-line/horizontal-line";
 import { PreferencePageComponent } from "../../preference-page-component";
 import { preferenceItemInjectionToken } from "../preference-item-injection-token";

--- a/packages/core/src/features/preferences/renderer/preference-items/application/hotbar-auto-hide/hotbar-auto-hide.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/hotbar-auto-hide/hotbar-auto-hide.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Switch } from "../../../../../../renderer/components/switch";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/application/menu-bar/menu-bar.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/menu-bar/menu-bar.tsx
@@ -7,7 +7,6 @@
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { ipcRenderer } from "electron";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Switch } from "../../../../../../renderer/components/switch";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/application/sidebar-menu/sidebar-menu.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/sidebar-menu/sidebar-menu.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@freelensapp/button";
 import { ShowNotification, showSuccessNotificationInjectable } from "@freelensapp/notifications";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React, { useState } from "react";
+import { useState } from "react";
 import { SubTitle } from "../../../../../../extensions/renderer-api/components";
 import { resetClusterPageMenuOrderInjectable } from "../../../../../user-preferences/common/cluster-page-menu-order.injectable";
 import styles from "./sidebar-menu.module.scss";

--- a/packages/core/src/features/preferences/renderer/preference-items/application/start-up/start-up.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/start-up/start-up.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Switch } from "../../../../../../renderer/components/switch";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { defaultColorThemePreference } from "../../../../../../common/vars";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";

--- a/packages/core/src/features/preferences/renderer/preference-items/application/timezone/timezone.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/timezone/timezone.tsx
@@ -7,7 +7,6 @@
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import moment from "moment-timezone";
-import React from "react";
 import currentTimezoneInjectable from "../../../../../../common/vars/current-timezone.injectable";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";

--- a/packages/core/src/features/preferences/renderer/preference-items/editor/editor-font-family/editor-font-family.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/editor/editor-font-family/editor-font-family.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Input } from "../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/editor/editor-font-size/editor-font-size.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/editor/editor-font-size/editor-font-size.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Input, InputValidators } from "../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/editor/editor-preference-page.injectable.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/editor/editor-preference-page.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { PreferencePageComponent } from "../../preference-page-component";
 import { preferenceItemInjectionToken } from "../preference-item-injection-token";
 

--- a/packages/core/src/features/preferences/renderer/preference-items/editor/line-numbers/line-numbers.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/editor/line-numbers/line-numbers.tsx
@@ -7,7 +7,6 @@
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { capitalize } from "es-toolkit";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
 import { defaultEditorConfig } from "../../../../../user-preferences/common/preferences-helpers";

--- a/packages/core/src/features/preferences/renderer/preference-items/editor/minimap/minimap.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/editor/minimap/minimap.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubHeader } from "../../../../../../renderer/components/layout/sub-header";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";

--- a/packages/core/src/features/preferences/renderer/preference-items/editor/tab-size/tab-size.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/editor/tab-size/tab-size.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Input, InputValidators } from "../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/kubernetes/helm/helm-path-to-binary/helm-path-to-binary.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/kubernetes/helm/helm-path-to-binary/helm-path-to-binary.tsx
@@ -6,7 +6,7 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useState } from "react";
+import { useState } from "react";
 import bundledBinaryPathInjectable from "../../../../../../../common/utils/bundled-binary-path.injectable";
 import { Input, InputValidators } from "../../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../../renderer/components/layout/sub-title";

--- a/packages/core/src/features/preferences/renderer/preference-items/kubernetes/helm/helm-server-side/helm-server-side.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/kubernetes/helm/helm-server-side/helm-server-side.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubTitle } from "../../../../../../../renderer/components/layout/sub-title";
 import { Switch } from "../../../../../../../renderer/components/switch";
 import userPreferencesStateInjectable from "../../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubectl/kubectl-binary-download/kubectl-binary-download.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubectl/kubectl-binary-download/kubectl-binary-download.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubTitle } from "../../../../../../../renderer/components/layout/sub-title";
 import { Switch } from "../../../../../../../renderer/components/switch";
 import userPreferencesStateInjectable from "../../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubectl/kubectl-directory-for-binaries/kubectl-directory-for-binaries.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubectl/kubectl-directory-for-binaries/kubectl-directory-for-binaries.tsx
@@ -6,7 +6,7 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useState } from "react";
+import { useState } from "react";
 import directoryForBinariesInjectable from "../../../../../../../common/app-paths/directory-for-binaries/directory-for-binaries.injectable";
 import { Input, InputValidators } from "../../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../../renderer/components/layout/sub-title";

--- a/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubectl/kubectl-download-mirror/kubectl-download-mirror.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubectl/kubectl-download-mirror/kubectl-download-mirror.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Input, InputValidators } from "../../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../../renderer/components/select";

--- a/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubectl/kubectl-path-to-binary/kubectl-path-to-binary.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubectl/kubectl-path-to-binary/kubectl-path-to-binary.tsx
@@ -6,7 +6,7 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useState } from "react";
+import { useState } from "react";
 import directoryForKubectlBinariesInjectable from "../../../../../../../common/app-paths/directory-for-kubectl-binaries/directory-for-kubectl-binaries.injectable";
 import { Input, InputValidators } from "../../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../../renderer/components/layout/sub-title";

--- a/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubernetes-preference-page.injectable.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubernetes-preference-page.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { HorizontalLine } from "../../../../../renderer/components/horizontal-line/horizontal-line";
 import { PreferencePageComponent } from "../../preference-page-component";
 import { preferenceItemInjectionToken } from "../preference-item-injection-token";

--- a/packages/core/src/features/preferences/renderer/preference-items/preference-tab-root.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/preference-tab-root.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { HorizontalLine } from "../../../../renderer/components/horizontal-line/horizontal-line";
 import styles from "./preference-tab-root.module.scss";
 

--- a/packages/core/src/features/preferences/renderer/preference-items/proxy/allow-untrusted-certificates/allow-untrusted-certificates.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/proxy/allow-untrusted-certificates/allow-untrusted-certificates.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Switch } from "../../../../../../renderer/components/switch";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/proxy/proxy-preference-page.injectable.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/proxy/proxy-preference-page.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { HorizontalLine } from "../../../../../renderer/components/horizontal-line/horizontal-line";
 import { PreferencePageComponent } from "../../preference-page-component";
 import { preferenceItemInjectionToken } from "../preference-item-injection-token";

--- a/packages/core/src/features/preferences/renderer/preference-items/terminal/copy-paste-from-terminal/copy-paste-from-terminal.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/terminal/copy-paste-from-terminal/copy-paste-from-terminal.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Switch } from "../../../../../../renderer/components/switch";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-font-family/terminal-font-family.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-font-family/terminal-font-family.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
 import terminalFontPreferencePresenterInjectable from "./terminal-font-options.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-font-family/terminal-font-options.injectable.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-font-family/terminal-font-options.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { action, computed } from "mobx";
-import React from "react";
 import { defaultTerminalFontFamily } from "../../../../../../common/vars";
 import { terminalFontInjectionToken } from "../../../../../terminal/renderer/fonts/token";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-font-size/terminal-font-size.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-font-size/terminal-font-size.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Input } from "../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";

--- a/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-page-preference-item.injectable.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-page-preference-item.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { PreferencePageComponent } from "../../preference-page-component";
 import { preferenceItemInjectionToken } from "../preference-item-injection-token";
 

--- a/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-shell-path/terminal-shell-path.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-shell-path/terminal-shell-path.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import defaultShellInjectable from "../../../../../../common/vars/default-shell.injectable";
 import { Input } from "../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";

--- a/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-theme/terminal-theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/terminal/terminal-theme/terminal-theme.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
 import { lensThemeDeclarationInjectionToken } from "../../../../../../renderer/themes/declaration";

--- a/packages/core/src/features/preferences/renderer/preference-navigation/preferences-navigation-tab.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-navigation/preferences-navigation-tab.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Tab } from "../../../../renderer/components/tabs";
 import preferenceTabIsActiveInjectable from "./navigate-to-preference-tab/preference-tab-is-active.injectable";
 

--- a/packages/core/src/features/preferences/renderer/preference-navigation/preferences-navigation.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-navigation/preferences-navigation.tsx
@@ -7,7 +7,6 @@
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { checkThatAllDiscriminablesAreExhausted } from "../../../../common/utils/composable-responsibilities/discriminable/discriminable";
 import { compositeHasDescendant } from "../../../../common/utils/composite/composite-has-descendant/composite-has-descendant";
 import { Map } from "../../../../renderer/components/map/map";

--- a/packages/core/src/features/preferences/renderer/preferences.tsx
+++ b/packages/core/src/features/preferences/renderer/preferences.tsx
@@ -8,7 +8,6 @@ import "./preferences.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { checkThatAllDiscriminablesAreExhausted } from "../../../common/utils/composable-responsibilities/discriminable/discriminable";
 import { Gutter } from "../../../renderer/components/gutter";
 import { SettingLayout } from "../../../renderer/components/layout/setting-layout";

--- a/packages/core/src/features/preferences/renderer/removable-item/removable-item.tsx
+++ b/packages/core/src/features/preferences/renderer/removable-item/removable-item.tsx
@@ -6,7 +6,6 @@
 
 import { Icon } from "@freelensapp/icon";
 import { cssNames } from "@freelensapp/utilities";
-import React from "react";
 import styles from "./removable-item.module.scss";
 
 import type { DOMAttributes } from "react";

--- a/packages/core/src/features/preferences/urls-of-legacy-extensions.test.tsx
+++ b/packages/core/src/features/preferences/urls-of-legacy-extensions.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { discoverFor } from "@freelensapp/react-testing-library-discovery";
-import React from "react";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import navigateInjectable from "../../renderer/navigation/navigate.injectable";
 

--- a/packages/core/src/features/routes/extension-api/reactively-disable-global-pages.test.tsx
+++ b/packages/core/src/features/routes/extension-api/reactively-disable-global-pages.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { computed, observable, runInAction } from "mobx";
-import React from "react";
 import { getApplicationBuilder } from "../../../renderer/components/test-utils/get-application-builder";
 
 import type { RenderResult } from "@testing-library/react";

--- a/packages/core/src/features/status-bar/status-bar-items-originating-from-extensions.test.tsx
+++ b/packages/core/src/features/status-bar/status-bar-items-originating-from-extensions.test.tsx
@@ -6,7 +6,6 @@
 
 import { getRandomIdInjectionToken } from "@freelensapp/random";
 import { computed } from "mobx";
-import React from "react";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
 import type { RenderResult } from "@testing-library/react";

--- a/packages/core/src/features/top-bar/extension-api/extendability-using-extension-api.test.tsx
+++ b/packages/core/src/features/top-bar/extension-api/extendability-using-extension-api.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { getApplicationBuilder } from "../../../renderer/components/test-utils/get-application-builder";
 
 import type { RenderResult } from "@testing-library/react";

--- a/packages/core/src/features/welcome/setting-welcome-page.test.tsx
+++ b/packages/core/src/features/welcome/setting-welcome-page.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import welcomeRouteInjectable from "../../common/front-end-routing/routes/welcome/welcome-route.injectable";
 import welcomeRouteConfigInjectable from "../../common/front-end-routing/routes/welcome/welcome-route-config.injectable";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";

--- a/packages/core/src/renderer/before-frame-starts/runnables/setup-weblink-context-menu-open.injectable.tsx
+++ b/packages/core/src/renderer/before-frame-starts/runnables/setup-weblink-context-menu-open.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import catalogCategoryRegistryInjectable from "../../../common/catalog/category-registry.injectable";
 import { WeblinkAddCommand } from "../../components/catalog-entities/weblink-add-command";
 import commandOverlayInjectable from "../../components/command-palette/command-overlay.injectable";

--- a/packages/core/src/renderer/components/avatar/__tests__/avatar.test.tsx
+++ b/packages/core/src/renderer/components/avatar/__tests__/avatar.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import "@testing-library/jest-dom/vitest";
 
 import { Icon } from "@freelensapp/icon";

--- a/packages/core/src/renderer/components/avatar/avatar.tsx
+++ b/packages/core/src/renderer/components/avatar/avatar.tsx
@@ -6,7 +6,6 @@
 
 import { cssNames } from "@freelensapp/utilities";
 import randomColor from "randomcolor";
-import React from "react";
 import { computeDefaultShortName } from "../../../common/catalog/helpers";
 import styles from "./avatar.module.scss";
 

--- a/packages/core/src/renderer/components/badge/badge-boolean.tsx
+++ b/packages/core/src/renderer/components/badge/badge-boolean.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Badge } from "./badge";
 import styles from "./badge-boolean.module.scss";
 

--- a/packages/core/src/renderer/components/catalog/__tests__/catalog-add-button.test.tsx
+++ b/packages/core/src/renderer/components/catalog/__tests__/catalog-add-button.test.tsx
@@ -6,7 +6,6 @@
 
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
 import { CatalogCategory } from "../../../../common/catalog";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import { type DiRender, renderFor } from "../../test-utils/renderFor";

--- a/packages/core/src/renderer/components/catalog/__tests__/catalog-category-label.test.tsx
+++ b/packages/core/src/renderer/components/catalog/__tests__/catalog-category-label.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { render, screen } from "@testing-library/react";
-import React from "react";
 import "@testing-library/jest-dom/vitest";
 
 import { CatalogCategory } from "../../../../common/catalog";

--- a/packages/core/src/renderer/components/catalog/catalog-category-label.tsx
+++ b/packages/core/src/renderer/components/catalog/catalog-category-label.tsx
@@ -4,8 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
-
 import type { CatalogCategory } from "../../../common/catalog/catalog-entity";
 
 interface CatalogCategoryLabelProps {

--- a/packages/core/src/renderer/components/catalog/catalog-menu.tsx
+++ b/packages/core/src/renderer/components/catalog/catalog-menu.tsx
@@ -7,7 +7,6 @@
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import filteredCategoriesInjectable from "../../../common/catalog/filtered-categories.injectable";
 import { HorizontalLine } from "../horizontal-line/horizontal-line";
 import { TreeGroup, TreeItem, TreeView } from "../tree-view/tree-view";

--- a/packages/core/src/renderer/components/catalog/columns/default-category.injectable.tsx
+++ b/packages/core/src/renderer/components/catalog/columns/default-category.injectable.tsx
@@ -11,7 +11,6 @@
 
 import { KubeObject } from "@freelensapp/kube-object";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import styles from "../catalog.module.scss";
 import getLabelBadgesInjectable from "../get-label-badges.injectable";
 

--- a/packages/core/src/renderer/components/catalog/columns/kubernetes-api-version.injectable.tsx
+++ b/packages/core/src/renderer/components/catalog/columns/kubernetes-api-version.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { customCatalogCategoryColumnInjectionToken } from "./custom-token";
 
 import type { KubernetesCluster } from "../../../../common/catalog-entities";

--- a/packages/core/src/renderer/components/catalog/columns/kubernetes-distribution.injectable.tsx
+++ b/packages/core/src/renderer/components/catalog/columns/kubernetes-distribution.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { customCatalogCategoryColumnInjectionToken } from "./custom-token";
 
 import type { KubernetesCluster } from "../../../../common/catalog-entities";

--- a/packages/core/src/renderer/components/catalog/columns/render-named-category-column-cell.injectable.tsx
+++ b/packages/core/src/renderer/components/catalog/columns/render-named-category-column-cell.injectable.tsx
@@ -12,7 +12,6 @@
 import { Icon } from "@freelensapp/icon";
 import { prevDefault } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import activeHotbarInjectable from "../../../../features/hotbar/storage/common/active.injectable";
 import { Avatar } from "../../avatar";
 import styles from "../catalog.module.scss";

--- a/packages/core/src/renderer/components/catalog/entity-details/component.injectable.tsx
+++ b/packages/core/src/renderer/components/catalog/entity-details/component.injectable.tsx
@@ -9,7 +9,6 @@ import { getInjectable } from "@ogre-tools/injectable";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { computed } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
 import catalogEntityRegistryInjectable from "../../../api/catalog/entity/registry.injectable";
 import hideEntityDetailsInjectable from "./hide.injectable";
 import selectedCatalogEntityInjectable from "./selected-entity.injectable";

--- a/packages/core/src/renderer/components/catalog/entity-details/internal/kubernetes-cluster-details.injectable.tsx
+++ b/packages/core/src/renderer/components/catalog/entity-details/internal/kubernetes-cluster-details.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { KubernetesCluster } from "../../../../../common/catalog-entities";
 import { DrawerItem, DrawerTitle } from "../../../drawer";
 import { catalogEntityDetailItemInjectionToken } from "../token";

--- a/packages/core/src/renderer/components/catalog/entity-details/internal/weblink-details.injectable.tsx
+++ b/packages/core/src/renderer/components/catalog/entity-details/internal/weblink-details.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { WebLink } from "../../../../../common/catalog-entities";
 import { DrawerItem, DrawerTitle } from "../../../drawer";
 import { catalogEntityDetailItemInjectionToken } from "../token";

--- a/packages/core/src/renderer/components/catalog/hotbar-toggle-menu-item.tsx
+++ b/packages/core/src/renderer/components/catalog/hotbar-toggle-menu-item.tsx
@@ -5,7 +5,7 @@
  */
 
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React, { useState } from "react";
+import { useState } from "react";
 import activeHotbarInjectable from "../../../features/hotbar/storage/common/active.injectable";
 import { MenuItem } from "../menu";
 

--- a/packages/core/src/renderer/components/chart/bar-chart.test.tsx
+++ b/packages/core/src/renderer/components/chart/bar-chart.test.tsx
@@ -6,7 +6,6 @@
 
 import { computed } from "mobx";
 import moment from "moment";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import activeThemeInjectable from "../../themes/active.injectable";
 import { renderFor } from "../test-utils/renderFor";

--- a/packages/core/src/renderer/components/chart/bar-chart.tsx
+++ b/packages/core/src/renderer/components/chart/bar-chart.tsx
@@ -11,7 +11,6 @@ import Color from "color";
 import { merge } from "es-toolkit/compat";
 import { observer } from "mobx-react";
 import moment from "moment";
-import React from "react";
 import activeThemeInjectable from "../../themes/active.injectable";
 import { NoMetrics } from "../resource-metrics/no-metrics";
 import { Chart, ChartKind } from "./chart";

--- a/packages/core/src/renderer/components/chart/pie-chart.tsx
+++ b/packages/core/src/renderer/components/chart/pie-chart.tsx
@@ -9,7 +9,6 @@ import "./pie-chart.scss";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import activeThemeInjectable from "../../themes/active.injectable";
 import { Chart } from "./chart";
 

--- a/packages/core/src/renderer/components/cluster-manager/cluster-manager-root-frame-child-component.injectable.tsx
+++ b/packages/core/src/renderer/components/cluster-manager/cluster-manager-root-frame-child-component.injectable.tsx
@@ -8,7 +8,6 @@ import { ErrorBoundary } from "@freelensapp/error-boundary";
 import { rootFrameChildComponentInjectionToken } from "@freelensapp/react-application";
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import React from "react";
 import { ClusterManager } from "./cluster-manager";
 
 const clusterManagerRootFrameChildComponentInjectable = getInjectable({

--- a/packages/core/src/renderer/components/cluster-settings/__tests__/cluster-local-terminal-settings.test.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/__tests__/cluster-local-terminal-settings.test.tsx
@@ -7,7 +7,6 @@
 import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
 import { Cluster } from "../../../../common/cluster/cluster";
 import loadKubeconfigInjectable from "../../../../common/cluster/load-kubeconfig.injectable";
 import statInjectable from "../../../../common/fs/stat.injectable";

--- a/packages/core/src/renderer/components/cluster-settings/__tests__/icon-settings.test.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/__tests__/icon-settings.test.tsx
@@ -12,7 +12,6 @@ import { type DiContainer, getInjectable } from "@ogre-tools/injectable";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { runInAction } from "mobx";
-import React from "react";
 import { KubernetesCluster } from "../../../../common/catalog-entities";
 import { Cluster } from "../../../../common/cluster/cluster";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";

--- a/packages/core/src/renderer/components/cluster-settings/local-terminal-settings.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/local-terminal-settings.tsx
@@ -10,7 +10,6 @@ import { Spinner } from "@freelensapp/spinner";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { action, runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
 import validateDirectoryInjectable from "../../../common/fs/validate-directory.injectable";
 import resolveTildeInjectable from "../../../common/path/resolve-tilde.injectable";
 import isWindowsInjectable from "../../../common/vars/is-windows.injectable";

--- a/packages/core/src/renderer/components/cluster/cluster-metric-switchers.tsx
+++ b/packages/core/src/renderer/components/cluster/cluster-metric-switchers.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Radio, RadioGroup } from "../radio";
 import styles from "./cluster-metric-switchers.module.css";
 import { MetricsTimeRangeSelector } from "./metrics-time-range-selector";

--- a/packages/core/src/renderer/components/cluster/cluster-metrics.test.tsx
+++ b/packages/core/src/renderer/components/cluster/cluster-metrics.test.tsx
@@ -7,7 +7,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, screen } from "@testing-library/react";
 import { computed, observable } from "mobx";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import { renderFor } from "../test-utils/renderFor";
 import { ClusterMetrics } from "./cluster-metrics";

--- a/packages/core/src/renderer/components/cluster/cluster-metrics.tsx
+++ b/packages/core/src/renderer/components/cluster/cluster-metrics.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "@freelensapp/spinner";
 import { bytesToUnits, cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { getMetricLastPoints, normalizeMetrics } from "../../../common/k8s-api/endpoints/metrics.api";
 import { BarChart } from "../chart";
 import { ZebraStripesPlugin } from "../chart/zebra-stripes.plugin";

--- a/packages/core/src/renderer/components/cluster/cluster-no-metrics.tsx
+++ b/packages/core/src/renderer/components/cluster/cluster-no-metrics.tsx
@@ -7,7 +7,6 @@
 import { Icon } from "@freelensapp/icon";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import navigateToEntitySettingsInjectable from "../../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
 import hostedClusterInjectable from "../../cluster-frame-context/hosted-cluster.injectable";
 import styles from "./cluster-no-metrics.module.scss";

--- a/packages/core/src/renderer/components/cluster/cluster-overview-sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/cluster/cluster-overview-sidebar-item.injectable.tsx
@@ -7,7 +7,6 @@
 import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import clusterOverviewRouteInjectable from "../../../common/front-end-routing/routes/cluster/overview/cluster-overview-route.injectable";
 import navigateToClusterOverviewInjectable from "../../../common/front-end-routing/routes/cluster/overview/navigate-to-cluster-overview.injectable";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";

--- a/packages/core/src/renderer/components/cluster/cluster-pie-charts.test.tsx
+++ b/packages/core/src/renderer/components/cluster/cluster-pie-charts.test.tsx
@@ -7,7 +7,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, screen } from "@testing-library/react";
 import { computed, observable } from "mobx";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import activeThemeInjectable from "../../themes/active.injectable";
 import { renderFor } from "../test-utils/renderFor";

--- a/packages/core/src/renderer/components/cluster/cluster-pie-charts.tsx
+++ b/packages/core/src/renderer/components/cluster/cluster-pie-charts.tsx
@@ -9,7 +9,7 @@ import { Spinner } from "@freelensapp/spinner";
 import { bytesToUnits, cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useRef } from "react";
+import { useRef } from "react";
 import { getMetricLastPoints } from "../../../common/k8s-api/endpoints/metrics.api";
 import activeThemeInjectable from "../../themes/active.injectable";
 import { PieChart } from "../chart";

--- a/packages/core/src/renderer/components/cluster/metrics-time-range-selector.test.tsx
+++ b/packages/core/src/renderer/components/cluster/metrics-time-range-selector.test.tsx
@@ -8,7 +8,6 @@ import "@testing-library/jest-dom/vitest";
 import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { act, fireEvent, screen } from "@testing-library/react";
 import { computed, observable } from "mobx";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import { renderFor } from "../test-utils/renderFor";
 import { MetricsTimeRangeSelector } from "./metrics-time-range-selector";

--- a/packages/core/src/renderer/components/clusters/search-command.tsx
+++ b/packages/core/src/renderer/components/clusters/search-command.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { isKubernetesCluster, KubernetesCluster } from "../../../common/catalog-entities";
 import { broadcastMessage } from "../../../common/ipc";
 import { catalogEntityRunListener } from "../../../common/ipc/catalog";

--- a/packages/core/src/renderer/components/command-palette/command-dialog.tsx
+++ b/packages/core/src/renderer/components/command-palette/command-dialog.tsx
@@ -7,7 +7,7 @@
 import { iter } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useState } from "react";
+import { useState } from "react";
 import { broadcastMessage } from "../../../common/ipc";
 import { IpcRendererNavigationEvents } from "../../../common/ipc/navigation-events";
 import activeEntityInjectable from "../../api/catalog/entity/active.injectable";

--- a/packages/core/src/renderer/components/config-horizontal-pod-autoscalers/details.test.tsx
+++ b/packages/core/src/renderer/components/config-horizontal-pod-autoscalers/details.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { HorizontalPodAutoscaler } from "@freelensapp/kube-object";
-import React from "react";
 import directoryForKubeConfigsInjectable from "../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import directoryForUserDataInjectable from "../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import { Cluster } from "../../../common/cluster/cluster";

--- a/packages/core/src/renderer/components/config-mutating-webhook-configurations/details.test.tsx
+++ b/packages/core/src/renderer/components/config-mutating-webhook-configurations/details.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { MutatingWebhookConfiguration } from "@freelensapp/kube-object";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import { renderFor } from "../test-utils/renderFor";
 import { MutatingWebhookDetails } from "./mutating-webhook-configurations-details";

--- a/packages/core/src/renderer/components/config-mutating-webhook-configurations/mutating-webhook-configurations.tsx
+++ b/packages/core/src/renderer/components/config-mutating-webhook-configurations/mutating-webhook-configurations.tsx
@@ -8,7 +8,6 @@ import "./mutating-webhook-configurations.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectListLayout } from "../kube-object-list-layout";
 import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";

--- a/packages/core/src/renderer/components/config-pod-disruption-budgets/__tests__/pod-distruption-budgets.test.tsx
+++ b/packages/core/src/renderer/components/config-pod-disruption-budgets/__tests__/pod-distruption-budgets.test.tsx
@@ -7,7 +7,6 @@
 import { maybeKubeApiInjectable } from "@freelensapp/kube-api-specifics";
 import { PodDisruptionBudget } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
-import React from "react";
 import { Cluster } from "../../../../common/cluster/cluster";
 import selectedNamespacesStorageInjectable from "../../../../features/namespace-filtering/renderer/storage.injectable";
 import userPreferencesStateInjectable from "../../../../features/user-preferences/common/state.injectable";

--- a/packages/core/src/renderer/components/config-pod-disruption-budgets/pod-disruption-budgets-details.tsx
+++ b/packages/core/src/renderer/components/config-pod-disruption-budgets/pod-disruption-budgets-details.tsx
@@ -7,7 +7,6 @@
 import "./pod-disruption-budgets-details.scss";
 
 import { observer } from "mobx-react";
-import React from "react";
 import { Badge } from "../badge";
 import { DrawerItem } from "../drawer";
 import { KubeObjectConditionsDrawer } from "../kube-object-conditions";

--- a/packages/core/src/renderer/components/config-runtime-classes/runtime-classes-details-tolerations.tsx
+++ b/packages/core/src/renderer/components/config-runtime-classes/runtime-classes-details-tolerations.tsx
@@ -6,7 +6,6 @@
 
 import "./runtime-classes-details-tolerations.scss";
 
-import React from "react";
 import { DrawerItem, DrawerParamToggler } from "../drawer";
 import { RuntimeClassTolerations } from "./runtime-classes-tolerations";
 

--- a/packages/core/src/renderer/components/config-runtime-classes/runtime-classes-tolerations.tsx
+++ b/packages/core/src/renderer/components/config-runtime-classes/runtime-classes-tolerations.tsx
@@ -7,7 +7,6 @@
 import "./runtime-classes-tolerations.scss";
 
 import { uniqueId } from "es-toolkit/compat";
-import React from "react";
 import { Table, TableCell, TableHead, TableRow } from "../table";
 
 import type { Toleration } from "@freelensapp/kube-object";

--- a/packages/core/src/renderer/components/config-secrets/__tests__/secret-details.test.tsx
+++ b/packages/core/src/renderer/components/config-secrets/__tests__/secret-details.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Secret, SecretType } from "@freelensapp/kube-object";
-import React from "react";
 import directoryForKubeConfigsInjectable from "../../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import directoryForUserDataInjectable from "../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import { Cluster } from "../../../../common/cluster/cluster";

--- a/packages/core/src/renderer/components/config-validating-admission-policies/details.test.tsx
+++ b/packages/core/src/renderer/components/config-validating-admission-policies/details.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { ValidatingAdmissionPolicy } from "@freelensapp/kube-object";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import { renderFor } from "../test-utils/renderFor";
 import { ValidatingAdmissionPolicyDetails } from "./validating-admission-policies-details";

--- a/packages/core/src/renderer/components/config-validating-admission-policies/validating-admission-policies.tsx
+++ b/packages/core/src/renderer/components/config-validating-admission-policies/validating-admission-policies.tsx
@@ -8,7 +8,6 @@ import "./validating-admission-policies.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectListLayout } from "../kube-object-list-layout";
 import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";

--- a/packages/core/src/renderer/components/config-validating-admission-policy-bindings/details.test.tsx
+++ b/packages/core/src/renderer/components/config-validating-admission-policy-bindings/details.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { ValidatingAdmissionPolicyBinding } from "@freelensapp/kube-object";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import { renderFor } from "../test-utils/renderFor";
 import { ValidatingAdmissionPolicyBindingDetails } from "./validating-admission-policy-bindings-details";

--- a/packages/core/src/renderer/components/config-validating-admission-policy-bindings/validating-admission-policy-bindings.tsx
+++ b/packages/core/src/renderer/components/config-validating-admission-policy-bindings/validating-admission-policy-bindings.tsx
@@ -8,7 +8,6 @@ import "./validating-admission-policy-bindings.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectListLayout } from "../kube-object-list-layout";
 import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";

--- a/packages/core/src/renderer/components/config-validating-webhook-configurations/details.test.tsx
+++ b/packages/core/src/renderer/components/config-validating-webhook-configurations/details.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { ValidatingWebhookConfiguration } from "@freelensapp/kube-object";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import { renderFor } from "../test-utils/renderFor";
 import { ValidatingWebhookDetails } from "./validating-webhook-configurations-details";

--- a/packages/core/src/renderer/components/config-validating-webhook-configurations/validating-webhook-configurations.tsx
+++ b/packages/core/src/renderer/components/config-validating-webhook-configurations/validating-webhook-configurations.tsx
@@ -8,7 +8,6 @@ import "./validating-webhook-configurations.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectListLayout } from "../kube-object-list-layout";
 import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";

--- a/packages/core/src/renderer/components/config/config-sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/config/config-sidebar-item.injectable.tsx
@@ -8,7 +8,6 @@ import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
 import { noop } from "es-toolkit";
-import React from "react";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";
 import { getClusterPageMenuOrderInjectable } from "../../../features/user-preferences/common/cluster-page-menu-order.injectable";
 

--- a/packages/core/src/renderer/components/countdown/countdown.test.tsx
+++ b/packages/core/src/renderer/components/countdown/countdown.test.tsx
@@ -7,7 +7,6 @@
 import { noop } from "@freelensapp/utilities";
 import { createContainer } from "@ogre-tools/injectable";
 import { observe } from "mobx";
-import React from "react";
 import { advanceFakeTime, testUsingFakeTime } from "../../../test-utils/use-fake-time";
 import { renderFor } from "../test-utils/renderFor";
 import { Countdown } from "./countdown";

--- a/packages/core/src/renderer/components/countdown/countdown.tsx
+++ b/packages/core/src/renderer/components/countdown/countdown.tsx
@@ -5,7 +5,6 @@
  */
 
 import { observer } from "mobx-react";
-import React from "react";
 
 import type { IComputedValue } from "mobx";
 import type { HTMLAttributes } from "react";

--- a/packages/core/src/renderer/components/custom-resources/__tests__/custom-resource-details.test.tsx
+++ b/packages/core/src/renderer/components/custom-resources/__tests__/custom-resource-details.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { CustomResourceDefinition, KubeObject } from "@freelensapp/kube-object";
-import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import { renderFor } from "../../test-utils/renderFor";
 import { CustomResourceDetails } from "../details";

--- a/packages/core/src/renderer/components/custom-resources/sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/custom-resources/sidebar-item.injectable.tsx
@@ -8,7 +8,6 @@ import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { noop } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";
 import { getClusterPageMenuOrderInjectable } from "../../../features/user-preferences/common/cluster-page-menu-order.injectable";
 

--- a/packages/core/src/renderer/components/dialog/logs-dialog.tsx
+++ b/packages/core/src/renderer/components/dialog/logs-dialog.tsx
@@ -12,7 +12,6 @@ import { showSuccessNotificationInjectable } from "@freelensapp/notifications";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { clipboard } from "electron";
 import { kebabCase } from "es-toolkit";
-import React from "react";
 import { Dialog } from "../dialog";
 import { Wizard, WizardStep } from "../wizard";
 

--- a/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.injectable.tsx
@@ -11,7 +11,6 @@ import { waitUntilDefined } from "@freelensapp/utilities";
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import * as yaml from "js-yaml";
 import { action, computed, observable, runInAction } from "mobx";
-import React from "react";
 import { createPatch, type Operation } from "rfc6902";
 import { defaultYamlDumpOptions } from "../../../../../common/kube-helpers";
 import editResourceTabStoreInjectable from "../store.injectable";

--- a/packages/core/src/renderer/components/dock/edit-resource/view.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/view.tsx
@@ -7,7 +7,6 @@
 import { Spinner } from "@freelensapp/spinner";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Badge } from "../../badge";
 import { Checkbox } from "../../checkbox";
 import { Notice } from "../../extensions/notice";

--- a/packages/core/src/renderer/components/dock/editor-panel.tsx
+++ b/packages/core/src/renderer/components/dock/editor-panel.tsx
@@ -9,7 +9,7 @@ import { withInjectables } from "@ogre-tools/injectable-react";
 import { throttle } from "es-toolkit/compat";
 import { reaction } from "mobx";
 import { observer } from "mobx-react";
-import React, { createRef, useEffect } from "react";
+import { createRef, useEffect } from "react";
 import { MonacoEditor } from "../monaco-editor";
 import dockStoreInjectable from "./dock/store.injectable";
 import styles from "./editor-panel.module.scss";

--- a/packages/core/src/renderer/components/dock/install-chart/install-chart-model.injectable.tsx
+++ b/packages/core/src/renderer/components/dock/install-chart/install-chart-model.injectable.tsx
@@ -8,7 +8,6 @@ import assert from "node:assert";
 import { waitUntilDefined } from "@freelensapp/utilities";
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import { action, computed, observable, runInAction } from "mobx";
-import React from "react";
 import navigateToHelmReleasesInjectable from "../../../../common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable";
 import requestHelmChartValuesInjectable from "../../../../common/k8s-api/endpoints/helm-charts.api/request-values.injectable";
 import requestHelmChartVersionsInjectable from "../../../../common/k8s-api/endpoints/helm-charts.api/request-versions.injectable";

--- a/packages/core/src/renderer/components/dock/install-chart/view.tsx
+++ b/packages/core/src/renderer/components/dock/install-chart/view.tsx
@@ -12,7 +12,6 @@ import { Spinner } from "@freelensapp/spinner";
 import { prevDefault } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Badge } from "../../badge";
 import { Checkbox } from "../../checkbox";
 import { LogsDialog } from "../../dialog/logs-dialog";

--- a/packages/core/src/renderer/components/dock/logs/__test__/controls.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/controls.test.tsx
@@ -6,7 +6,6 @@
 
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
 import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import { renderFor } from "../../../test-utils/renderFor";

--- a/packages/core/src/renderer/components/dock/logs/__test__/list.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/list.test.tsx
@@ -6,7 +6,6 @@
 
 import "@testing-library/jest-dom/vitest";
 import { waitFor } from "@testing-library/react";
-import React from "react";
 import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import { renderFor } from "../../../test-utils/renderFor";
@@ -26,7 +25,6 @@ import type { TabId } from "../../dock/store";
 const virtualListMock = vi.fn();
 
 vi.mock("../../../virtual-list", () => {
-  const React = require("react");
 
   return {
     VirtualList: (props: any) => {

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 
 import type { MockedFunction } from "vitest";
 import "@testing-library/jest-dom/vitest";

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
@@ -6,7 +6,6 @@
 
 import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
 import userPreferencesStateInjectable from "../../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
 import { renderFor } from "../../../test-utils/renderFor";

--- a/packages/core/src/renderer/components/dock/logs/__test__/to-bottom.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/to-bottom.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import "@testing-library/jest-dom/vitest";
 
 import { noop } from "@freelensapp/utilities";

--- a/packages/core/src/renderer/components/dock/logs/controls.tsx
+++ b/packages/core/src/renderer/components/dock/logs/controls.tsx
@@ -5,7 +5,6 @@
  */
 
 import { observer } from "mobx-react";
-import React from "react";
 import { Checkbox } from "../../checkbox";
 import styles from "./controls.module.scss";
 import { DownloadLogsDropdown } from "./download-logs-dropdown";

--- a/packages/core/src/renderer/components/dock/logs/download-logs-dropdown.tsx
+++ b/packages/core/src/renderer/components/dock/logs/download-logs-dropdown.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Icon } from "@freelensapp/icon";
-import React, { useState } from "react";
+import { useState } from "react";
 import { act } from "react-dom/test-utils";
 import { Dropdown } from "../../dropdown/dropdown";
 import { MenuItem } from "../../menu";

--- a/packages/core/src/renderer/components/dock/logs/resource-selector.tsx
+++ b/packages/core/src/renderer/components/dock/logs/resource-selector.tsx
@@ -7,7 +7,6 @@
 import "./resource-selector.scss";
 
 import { observer } from "mobx-react";
-import React from "react";
 import { Badge } from "../../badge";
 import { Select } from "../../select";
 import { findOptimalDefaultContainerOfPod } from "./default-container-helper";

--- a/packages/core/src/renderer/components/dock/logs/to-bottom.tsx
+++ b/packages/core/src/renderer/components/dock/logs/to-bottom.tsx
@@ -6,7 +6,6 @@
 
 import { Button } from "@freelensapp/button";
 import { Icon } from "@freelensapp/icon";
-import React from "react";
 
 export function ToBottom({ onClick }: { onClick: () => void }) {
   return (

--- a/packages/core/src/renderer/components/dock/logs/view.tsx
+++ b/packages/core/src/renderer/components/dock/logs/view.tsx
@@ -7,7 +7,7 @@
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { createRef, useEffect } from "react";
+import { createRef, useEffect } from "react";
 import subscribeStoresInjectable from "../../../kube-watch-api/subscribe-stores.injectable";
 import podStoreInjectable from "../../workloads-pods/store.injectable";
 import { InfoPanel } from "../info-panel";

--- a/packages/core/src/renderer/components/drawer/drawer-item-labels.tsx
+++ b/packages/core/src/renderer/components/drawer/drawer-item-labels.tsx
@@ -5,7 +5,6 @@
  */
 
 import { KubeObject } from "@freelensapp/kube-object";
-import React from "react";
 import { Badge } from "../badge";
 import { DrawerItem } from "./drawer-item";
 

--- a/packages/core/src/renderer/components/drawer/drawer-param-toggler.test.tsx
+++ b/packages/core/src/renderer/components/drawer/drawer-param-toggler.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import { type DiRender, renderFor } from "../test-utils/renderFor";
 import { DrawerParamToggler } from "./drawer-param-toggler";

--- a/packages/core/src/renderer/components/drawer/drawer-title.tsx
+++ b/packages/core/src/renderer/components/drawer/drawer-title.tsx
@@ -7,7 +7,6 @@
 import "./drawer-title.scss";
 
 import { cssNames } from "@freelensapp/utilities";
-import React from "react";
 
 import type { StrictReactNode } from "@freelensapp/utilities";
 

--- a/packages/core/src/renderer/components/dropdown/dropdown.tsx
+++ b/packages/core/src/renderer/components/dropdown/dropdown.tsx
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React, { useState } from "react";
+import { useState } from "react";
 import { Menu } from "../menu";
 
 import type { StrictReactNode } from "@freelensapp/utilities";

--- a/packages/core/src/renderer/components/duration/reactive-duration.tsx
+++ b/packages/core/src/renderer/components/duration/reactive-duration.tsx
@@ -6,7 +6,6 @@
 
 import { formatDuration } from "@freelensapp/utilities";
 import { observer } from "mobx-react";
-import React from "react";
 import { reactiveNow } from "../../../common/utils/reactive-now/reactive-now";
 
 export interface ReactiveDurationProps {

--- a/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/general-settings.injectable.tsx
+++ b/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/general-settings.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getClusterByIdInjectable from "../../../../features/cluster/storage/common/get-by-id.injectable";
 import { ClusterIconSetting } from "../../cluster-settings/icon-settings";
 import { ClusterKubeconfig } from "../../cluster-settings/kubeconfig";

--- a/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/metrics-settings.injectable.tsx
+++ b/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/metrics-settings.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getClusterByIdInjectable from "../../../../features/cluster/storage/common/get-by-id.injectable";
 import { ClusterMetricsSetting } from "../../cluster-settings/metrics-setting";
 import { ClusterPrometheusSetting } from "../../cluster-settings/prometheus-setting";

--- a/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/namespace-settings.injectable.tsx
+++ b/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/namespace-settings.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getClusterByIdInjectable from "../../../../features/cluster/storage/common/get-by-id.injectable";
 import { ClusterAccessibleNamespaces } from "../../cluster-settings/accessible-namespaces";
 import { entitySettingInjectionToken } from "../token";

--- a/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/node-shell-settings.injectable.tsx
+++ b/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/node-shell-settings.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getClusterByIdInjectable from "../../../../features/cluster/storage/common/get-by-id.injectable";
 import { ClusterNodeShellSetting } from "../../cluster-settings/node-shell-setting";
 import { entitySettingInjectionToken } from "../token";

--- a/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/proxy-settings.injectable.tsx
+++ b/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/proxy-settings.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getClusterByIdInjectable from "../../../../features/cluster/storage/common/get-by-id.injectable";
 import { ClusterProxySetting } from "../../cluster-settings/proxy-setting";
 import { entitySettingInjectionToken } from "../token";

--- a/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/terminal-settings.injectable.tsx
+++ b/packages/core/src/renderer/components/entity-settings/internal-kubernetes-cluster/terminal-settings.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getClusterByIdInjectable from "../../../../features/cluster/storage/common/get-by-id.injectable";
 import { ClusterLocalTerminalSetting } from "../../cluster-settings/local-terminal-settings";
 import { entitySettingInjectionToken } from "../token";

--- a/packages/core/src/renderer/components/events/duration-absolute.tsx
+++ b/packages/core/src/renderer/components/events/duration-absolute.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { ReactiveDuration } from "../duration/reactive-duration";
 import { LocaleDate } from "../locale-date";
 

--- a/packages/core/src/renderer/components/events/event-details.tsx
+++ b/packages/core/src/renderer/components/events/event-details.tsx
@@ -12,7 +12,6 @@ import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { kebabCase } from "es-toolkit/compat";
 import { observer } from "mobx-react";
-import React from "react";
 import { Link } from "react-router-dom";
 import apiManagerInjectable from "../../../common/k8s-api/api-manager/manager.injectable";
 import { DrawerItem, DrawerTitle } from "../drawer";

--- a/packages/core/src/renderer/components/events/events-sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/events/events-sidebar-item.injectable.tsx
@@ -7,7 +7,6 @@
 import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import eventsRouteInjectable from "../../../common/front-end-routing/routes/cluster/events/events-route.injectable";
 import navigateToEventsInjectable from "../../../common/front-end-routing/routes/cluster/events/navigate-to-events.injectable";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";

--- a/packages/core/src/renderer/components/extensions/__tests__/extensions.test.tsx
+++ b/packages/core/src/renderer/components/extensions/__tests__/extensions.test.tsx
@@ -10,7 +10,6 @@ import "@testing-library/jest-dom/vitest";
 import assert from "node:assert";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { observable, when } from "mobx";
-import React from "react";
 import directoryForDownloadsInjectable from "../../../../common/app-paths/directory-for-downloads/directory-for-downloads.injectable";
 import directoryForUserDataInjectable from "../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import removePathInjectable from "../../../../common/fs/remove.injectable";

--- a/packages/core/src/renderer/components/extensions/attempt-install-by-info.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/attempt-install-by-info.injectable.tsx
@@ -9,7 +9,6 @@ import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { isObject } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import { reduce } from "es-toolkit/compat";
-import React from "react";
 import { SemVer } from "semver";
 import getBasenameOfPathInjectable from "../../../common/path/get-basename.injectable";
 import extensionInstallationStateStoreInjectable from "../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";

--- a/packages/core/src/renderer/components/extensions/attempt-install/attempt-install.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/attempt-install/attempt-install.injectable.tsx
@@ -10,7 +10,6 @@ import { disposer } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import { shell } from "electron";
 import { remove as removeDir } from "fs-extra";
-import React from "react";
 import { ExtensionInstallationState } from "../../../../extensions/extension-installation-state-store/extension-installation-state-store";
 import extensionInstallationStateStoreInjectable from "../../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
 import extensionLoaderInjectable from "../../../../extensions/extension-loader/extension-loader.injectable";

--- a/packages/core/src/renderer/components/extensions/attempt-install/create-temp-files-and-validate.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/attempt-install/create-temp-files-and-validate.injectable.tsx
@@ -7,7 +7,6 @@
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import writeFileInjectable from "../../../../common/fs/write-file.injectable";
 import tempDirectoryPathInjectable from "../../../../common/os/temp-directory-path.injectable";
 import joinPathsInjectable from "../../../../common/path/join-paths.injectable";

--- a/packages/core/src/renderer/components/extensions/attempt-install/unpack-extension.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/attempt-install/unpack-extension.injectable.tsx
@@ -11,7 +11,6 @@ import { noop } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import fse from "fs-extra";
 import { when } from "mobx";
-import React from "react";
 import extractTarInjectable from "../../../../common/fs/extract-tar.injectable";
 import extensionInstallationStateStoreInjectable from "../../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
 import extensionLoaderInjectable from "../../../../extensions/extension-loader/extension-loader.injectable";

--- a/packages/core/src/renderer/components/extensions/confirm-uninstall-extension.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/confirm-uninstall-extension.injectable.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { extensionDisplayName } from "../../../extensions/lens-extension";
 import confirmInjectable from "../confirm-dialog/confirm.injectable";
 import uninstallExtensionInjectable from "./uninstall-extension.injectable";

--- a/packages/core/src/renderer/components/extensions/extensions.tsx
+++ b/packages/core/src/renderer/components/extensions/extensions.tsx
@@ -10,7 +10,6 @@
  */
 
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { Gutter } from "../gutter";
 import { DropFileInput } from "../input";
 import { SettingLayout } from "../layout/setting-layout";

--- a/packages/core/src/renderer/components/extensions/get-base-registry-url/get-base-registry-url.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/get-base-registry-url/get-base-registry-url.injectable.tsx
@@ -7,7 +7,6 @@
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import execFileInjectable from "../../../../common/fs/exec-file.injectable";
 import { defaultExtensionRegistryUrl } from "../../../../features/user-preferences/common/preferences-helpers";
 import userPreferencesStateInjectable from "../../../../features/user-preferences/common/state.injectable";

--- a/packages/core/src/renderer/components/extensions/install-extension-from-input.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/install-extension-from-input.injectable.tsx
@@ -7,7 +7,6 @@
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import getBasenameOfPathInjectable from "../../../common/path/get-basename.injectable";
 import extensionInstallationStateStoreInjectable from "../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
 import downloadBinaryViaChannelInjectable from "../../../renderer/fetch/download-binary-via-channel.injectable";

--- a/packages/core/src/renderer/components/extensions/install.tsx
+++ b/packages/core/src/renderer/components/extensions/install.tsx
@@ -15,7 +15,7 @@ import { TooltipPosition } from "@freelensapp/tooltip";
 import { prevDefault } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import extensionInstallationStateStoreInjectable from "../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
 import { Input, InputValidators } from "../input";
 import { unionInputValidatorsAsync } from "../input/input_validators";

--- a/packages/core/src/renderer/components/extensions/installed-extensions.tsx
+++ b/packages/core/src/renderer/components/extensions/installed-extensions.tsx
@@ -14,7 +14,6 @@ import { Spinner } from "@freelensapp/spinner";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import extensionDiscoveryInjectable from "../../../extensions/extension-discovery/extension-discovery.injectable";
 import extensionInstallationStateStoreInjectable from "../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
 import { List } from "../list/list";

--- a/packages/core/src/renderer/components/extensions/notice.tsx
+++ b/packages/core/src/renderer/components/extensions/notice.tsx
@@ -5,7 +5,6 @@
  */
 
 import { cssNames } from "@freelensapp/utilities";
-import React from "react";
 import styles from "./notice.module.scss";
 
 import type { DOMAttributes } from "react";

--- a/packages/core/src/renderer/components/extensions/uninstall-extension.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/uninstall-extension.injectable.tsx
@@ -8,7 +8,6 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { showErrorNotificationInjectable, showSuccessNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
 import { when } from "mobx";
-import React from "react";
 import extensionDiscoveryInjectable from "../../../extensions/extension-discovery/extension-discovery.injectable";
 import extensionInstallationStateStoreInjectable from "../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
 import extensionLoaderInjectable from "../../../extensions/extension-loader/extension-loader.injectable";

--- a/packages/core/src/renderer/components/favorites/overview/overview.tsx
+++ b/packages/core/src/renderer/components/favorites/overview/overview.tsx
@@ -8,7 +8,6 @@ import { Icon } from "@freelensapp/icon";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { FavoriteItem } from "../../../../features/favorites/common/storage.injectable";
 import { Checkbox } from "../../checkbox";
 import { TabLayout } from "../../layout/tab-layout";

--- a/packages/core/src/renderer/components/favorites/sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/favorites/sidebar-item.injectable.tsx
@@ -8,7 +8,6 @@ import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
 import { noop } from "es-toolkit";
-import React from "react";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";
 import { getClusterPageMenuOrderInjectable } from "../../../features/user-preferences/common/cluster-page-menu-order.injectable";
 

--- a/packages/core/src/renderer/components/gutter/gutter.tsx
+++ b/packages/core/src/renderer/components/gutter/gutter.tsx
@@ -5,7 +5,6 @@
  */
 
 import { cssNames } from "@freelensapp/utilities";
-import React from "react";
 import styles from "./gutter.module.scss";
 
 interface GutterProps {

--- a/packages/core/src/renderer/components/helm-charts/__tests__/icon.test.tsx
+++ b/packages/core/src/renderer/components/helm-charts/__tests__/icon.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { render, screen } from "@testing-library/react";
-import React from "react";
 import { HelmChartIcon } from "../icon";
 
 const mainImageSrc = "https://example.com/main-picture.jpg";

--- a/packages/core/src/renderer/components/helm-charts/helm-chart-details.tsx
+++ b/packages/core/src/renderer/components/helm-charts/helm-chart-details.tsx
@@ -14,7 +14,7 @@ import { styled, Tooltip } from "@mui/material";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import autoBindReact from "auto-bind/react";
 import { observer } from "mobx-react";
-import React, { Component } from "react";
+import { Component } from "react";
 import { Badge } from "../badge";
 import createInstallChartTabInjectable from "../dock/install-chart/create-install-chart-tab.injectable";
 import { Drawer, DrawerItem } from "../drawer";

--- a/packages/core/src/renderer/components/helm-charts/helm-charts.tsx
+++ b/packages/core/src/renderer/components/helm-charts/helm-charts.tsx
@@ -9,7 +9,7 @@ import "./helm-charts.scss";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { noop } from "es-toolkit";
 import { observer } from "mobx-react";
-import React, { Component } from "react";
+import { Component } from "react";
 import navigateToHelmChartsInjectable from "../../../common/front-end-routing/routes/cluster/helm/charts/navigate-to-helm-charts.injectable";
 import { ItemListLayout } from "../item-object-list/list-layout";
 import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";

--- a/packages/core/src/renderer/components/helm-charts/icon.tsx
+++ b/packages/core/src/renderer/components/helm-charts/icon.tsx
@@ -5,7 +5,7 @@
  */
 
 import { cssNames } from "@freelensapp/utilities";
-import React, { useState } from "react";
+import { useState } from "react";
 import styles from "./icon.module.css";
 
 export interface HelmChartIconProps {

--- a/packages/core/src/renderer/components/helm-releases/release-details/release-details-content.tsx
+++ b/packages/core/src/renderer/components/helm-releases/release-details/release-details-content.tsx
@@ -12,7 +12,6 @@ import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { kebabCase } from "es-toolkit";
 import { observer } from "mobx-react";
-import React from "react";
 import { Link } from "react-router-dom";
 import { Badge } from "../../badge";
 import { Checkbox } from "../../checkbox";

--- a/packages/core/src/renderer/components/helm-releases/release-details/release-details-drawer-toolbar.tsx
+++ b/packages/core/src/renderer/components/helm-releases/release-details/release-details-drawer-toolbar.tsx
@@ -8,7 +8,6 @@ import "./release-details.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import navigateToHelmReleasesInjectable from "../../../../common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable";
 import { HelmReleaseMenu } from "../release-menu";
 import releaseDetailsModelInjectable from "./release-details-model/release-details-model.injectable";

--- a/packages/core/src/renderer/components/helm-releases/release-details/release-details-drawer.tsx
+++ b/packages/core/src/renderer/components/helm-releases/release-details/release-details-drawer.tsx
@@ -9,7 +9,6 @@ import "./release-details.scss";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import navigateToHelmReleasesInjectable from "../../../../common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable";
 import activeThemeTypeInjectable from "../../../themes/active-type.injectable";
 import { Drawer } from "../../drawer";

--- a/packages/core/src/renderer/components/helm-releases/release-details/release-details-model/release-details-model.injectable.tsx
+++ b/packages/core/src/renderer/components/helm-releases/release-details/release-details-model/release-details-model.injectable.tsx
@@ -10,7 +10,6 @@ import { waitUntilDefined } from "@freelensapp/utilities";
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import { groupBy } from "es-toolkit";
 import { action, computed, observable, runInAction } from "mobx";
-import React from "react";
 import navigateToHelmReleasesInjectable from "../../../../../common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable";
 import requestHelmReleaseConfigurationInjectable from "../../../../../common/k8s-api/endpoints/helm-releases.api/request-configuration.injectable";
 import hostedClusterIdInjectable from "../../../../cluster-frame-context/hosted-cluster-id.injectable";

--- a/packages/core/src/renderer/components/helm-releases/release-details/release-details.tsx
+++ b/packages/core/src/renderer/components/helm-releases/release-details/release-details.tsx
@@ -8,7 +8,6 @@ import "./release-details.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { ReleaseDetailsDrawer } from "./release-details-drawer";
 import targetHelmReleaseInjectable from "./target-helm-release.injectable";
 

--- a/packages/core/src/renderer/components/helm-releases/releases.tsx
+++ b/packages/core/src/renderer/components/helm-releases/releases.tsx
@@ -10,7 +10,7 @@ import "./releases.scss";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { kebabCase } from "es-toolkit";
 import moment from "moment-timezone";
-import React, { Component } from "react";
+import { Component } from "react";
 import navigateToHelmReleasesInjectable from "../../../common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable";
 import { ItemListLayout } from "../item-object-list";
 import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";

--- a/packages/core/src/renderer/components/helm/sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/helm/sidebar-item.injectable.tsx
@@ -8,7 +8,6 @@ import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
 import { noop } from "es-toolkit";
-import React from "react";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";
 import { getClusterPageMenuOrderInjectable } from "../../../features/user-preferences/common/cluster-page-menu-order.injectable";
 

--- a/packages/core/src/renderer/components/horizontal-line/horizontal-line.tsx
+++ b/packages/core/src/renderer/components/horizontal-line/horizontal-line.tsx
@@ -5,7 +5,6 @@
  */
 
 import { cssNames } from "@freelensapp/utilities";
-import React from "react";
 import styles from "./horizontal-line.module.scss";
 
 interface HorizontalLineProps {

--- a/packages/core/src/renderer/components/hotbar/__tests__/hotbar-menu-auto-hide.test.tsx
+++ b/packages/core/src/renderer/components/hotbar/__tests__/hotbar-menu-auto-hide.test.tsx
@@ -7,7 +7,6 @@
 import "@testing-library/jest-dom/vitest";
 
 import { fireEvent, waitFor } from "@testing-library/react";
-import React from "react";
 import directoryForUserDataInjectable from "../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import userPreferencesStateInjectable from "../../../../features/user-preferences/common/state.injectable";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";

--- a/packages/core/src/renderer/components/hotbar/__tests__/hotbar-remove-command.test.tsx
+++ b/packages/core/src/renderer/components/hotbar/__tests__/hotbar-remove-command.test.tsx
@@ -7,7 +7,6 @@
 import "@testing-library/jest-dom/vitest";
 
 import { fireEvent } from "@testing-library/react";
-import React from "react";
 import directoryForUserDataInjectable from "../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import createHotbarInjectable from "../../../../features/hotbar/storage/common/create-hotbar.injectable";
 import hotbarsInjectable from "../../../../features/hotbar/storage/common/hotbars.injectable";

--- a/packages/core/src/renderer/components/hotbar/__tests__/hotbar-switch-command.test.tsx
+++ b/packages/core/src/renderer/components/hotbar/__tests__/hotbar-switch-command.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import directoryForUserDataInjectable from "../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import createHotbarInjectable, {
   type CreateHotbar,

--- a/packages/core/src/renderer/components/hotbar/hotbar-add-command.tsx
+++ b/packages/core/src/renderer/components/hotbar/hotbar-add-command.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import addHotbarInjectable from "../../../features/hotbar/storage/common/add.injectable";
 import commandOverlayInjectable from "../command-palette/command-overlay.injectable";
 import { Input } from "../input";

--- a/packages/core/src/renderer/components/hotbar/hotbar-icon.tsx
+++ b/packages/core/src/renderer/components/hotbar/hotbar-icon.tsx
@@ -9,7 +9,7 @@ import { Tooltip } from "@freelensapp/tooltip";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useState } from "react";
+import { useState } from "react";
 import normalizeCatalogEntityContextMenuInjectable from "../../catalog/normalize-menu-item.injectable";
 import { Avatar } from "../avatar";
 import { Menu, MenuItem } from "../menu";

--- a/packages/core/src/renderer/components/hotbar/hotbar-menu.tsx
+++ b/packages/core/src/renderer/components/hotbar/hotbar-menu.tsx
@@ -22,7 +22,7 @@ import {
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { UserPreferencesState } from "../../../extensions/common-api/app";
 import activeHotbarInjectable from "../../../features/hotbar/storage/common/active.injectable";

--- a/packages/core/src/renderer/components/hotbar/hotbar-remove-command.tsx
+++ b/packages/core/src/renderer/components/hotbar/hotbar-remove-command.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import computeHotbarDisplayLabelInjectable from "../../../features/hotbar/storage/common/compute-display-label.injectable";
 import hotbarsInjectable from "../../../features/hotbar/storage/common/hotbars.injectable";
 import removeHotbarInjectable from "../../../features/hotbar/storage/common/remove.injectable";

--- a/packages/core/src/renderer/components/hotbar/hotbar-rename-command.tsx
+++ b/packages/core/src/renderer/components/hotbar/hotbar-rename-command.tsx
@@ -7,7 +7,7 @@
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { action } from "mobx";
 import { observer } from "mobx-react";
-import React, { useState } from "react";
+import { useState } from "react";
 import computeHotbarDisplayLabelInjectable from "../../../features/hotbar/storage/common/compute-display-label.injectable";
 import getHotbarByIdInjectable from "../../../features/hotbar/storage/common/get-by-id.injectable";
 import hotbarsInjectable from "../../../features/hotbar/storage/common/hotbars.injectable";

--- a/packages/core/src/renderer/components/hotbar/hotbar-switch-command.tsx
+++ b/packages/core/src/renderer/components/hotbar/hotbar-switch-command.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import computeHotbarDisplayLabelInjectable from "../../../features/hotbar/storage/common/compute-display-label.injectable";
 import hotbarsInjectable from "../../../features/hotbar/storage/common/hotbars.injectable";
 import setAsActiveHotbarInjectable from "../../../features/hotbar/storage/common/set-as-active.injectable";

--- a/packages/core/src/renderer/components/item-object-list/filter-icon.tsx
+++ b/packages/core/src/renderer/components/item-object-list/filter-icon.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Icon } from "@freelensapp/icon";
-import React from "react";
 import { FilterType } from "./page-filters/store";
 
 import type { IconProps } from "@freelensapp/icon";

--- a/packages/core/src/renderer/components/item-object-list/filters.tsx
+++ b/packages/core/src/renderer/components/item-object-list/filters.tsx
@@ -7,7 +7,6 @@
 import "./item-list-layout.scss";
 
 import { observer } from "mobx-react";
-import React from "react";
 import { PageFiltersList } from "./page-filters/list";
 
 import type { Filter } from "./page-filters/store";

--- a/packages/core/src/renderer/components/item-object-list/page-filters/list.tsx
+++ b/packages/core/src/renderer/components/item-object-list/page-filters/list.tsx
@@ -10,7 +10,6 @@ import { Icon } from "@freelensapp/icon";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Badge } from "../../badge";
 import searchUrlPageParamInjectable from "../../input/search-url-page-param.injectable";
 import { FilterIcon } from "../filter-icon";

--- a/packages/core/src/renderer/components/kube-object-conditions/components.tsx
+++ b/packages/core/src/renderer/components/kube-object-conditions/components.tsx
@@ -2,7 +2,6 @@ import { cssNames } from "@freelensapp/utilities";
 import { upperFirst } from "es-toolkit";
 import * as yaml from "js-yaml";
 import moment from "moment-timezone";
-import React from "react";
 import { defaultYamlDumpOptions } from "../../../common/kube-helpers";
 import { DurationAbsoluteTimestamp } from "../events";
 

--- a/packages/core/src/renderer/components/kube-object-conditions/kube-object-conditions-drawer.tsx
+++ b/packages/core/src/renderer/components/kube-object-conditions/kube-object-conditions-drawer.tsx
@@ -6,7 +6,6 @@
 
 import { KubeObject } from "@freelensapp/kube-object";
 import { observer } from "mobx-react";
-import React from "react";
 import { Badge } from "../badge";
 import { DrawerItem } from "../drawer";
 import { getClassName, getTooltip } from "./components";

--- a/packages/core/src/renderer/components/kube-object-conditions/kube-object-conditions-list.tsx
+++ b/packages/core/src/renderer/components/kube-object-conditions/kube-object-conditions-list.tsx
@@ -7,7 +7,6 @@
 import { KubeObject } from "@freelensapp/kube-object";
 import { Tooltip } from "@freelensapp/tooltip";
 import { observer } from "mobx-react";
-import React from "react";
 import { getClassName, getTooltip } from "./components";
 import { sortConditions } from "./utils";
 

--- a/packages/core/src/renderer/components/kube-object-details/custom-resource-detail-item.injectable.tsx
+++ b/packages/core/src/renderer/components/kube-object-details/custom-resource-detail-item.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import React from "react";
 import customResourceDefinitionStoreInjectable from "../custom-resource-definitions/store.injectable";
 import { CustomResourceDetails } from "../custom-resources/details";
 import currentKubeObjectInDetailsInjectable from "./current-kube-object-in-details.injectable";

--- a/packages/core/src/renderer/components/kube-object-details/kube-object-detail-items/metrics/details-metrics-container.tsx
+++ b/packages/core/src/renderer/components/kube-object-details/kube-object-detail-items/metrics/details-metrics-container.tsx
@@ -5,7 +5,6 @@
  */
 
 import { observer } from "mobx-react";
-import React from "react";
 
 import type { KubeObject } from "@freelensapp/kube-object";
 import type { KubeObjectDetailMetrics } from "@freelensapp/metrics";

--- a/packages/core/src/renderer/components/kube-object-details/kube-object-detail-items/metrics/get-metrics-kube-object-detail-item.injectable.tsx
+++ b/packages/core/src/renderer/components/kube-object-details/kube-object-detail-items/metrics/get-metrics-kube-object-detail-item.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { getInjectable } from "@ogre-tools/injectable";
 import { computedInjectManyInjectable } from "@ogre-tools/injectable-extension-for-mobx";
-import React from "react";
 import metricsDetailsComponentEnabledInjectable from "../../../../api/catalog/entity/metrics-details-component-enabled.injectable";
 import { DetailsMetricsContainer } from "./details-metrics-container";
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-cluster-role.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-cluster-role.tsx
@@ -7,7 +7,6 @@
 import { clusterRoleApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-config-map.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-config-map.tsx
@@ -7,7 +7,6 @@
 import { configMapApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-job.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-job.tsx
@@ -7,7 +7,6 @@
 import { jobApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-namespace.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-namespace.tsx
@@ -7,7 +7,6 @@
 import { namespaceApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-node.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-node.tsx
@@ -7,7 +7,6 @@
 import { nodeApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-pod.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-pod.tsx
@@ -7,7 +7,6 @@
 import { podApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-priority-class.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-priority-class.tsx
@@ -7,7 +7,6 @@
 import { priorityClassApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-replica-set.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-replica-set.tsx
@@ -7,7 +7,6 @@
 import { replicaSetApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-role.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-role.tsx
@@ -7,7 +7,6 @@
 import { roleApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-runtime-class.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-runtime-class.tsx
@@ -7,7 +7,6 @@
 import { runtimeClassApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-secret.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-secret.tsx
@@ -7,7 +7,6 @@
 import { secretApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-service-account.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-service-account.tsx
@@ -7,7 +7,6 @@
 import { serviceAccountApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-link/link-to-storage-class.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-storage-class.tsx
@@ -7,7 +7,6 @@
 import { storageClassApiInjectable } from "@freelensapp/kube-api-specifics";
 import { stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import getMaybeDetailsUrlInjectable, {
   type GetMaybeDetailsUrl,
 } from "../kube-detail-params/get-maybe-details-url.injectable";

--- a/packages/core/src/renderer/components/kube-object-list-layout/kube-object-list-layout.test.tsx
+++ b/packages/core/src/renderer/components/kube-object-list-layout/kube-object-list-layout.test.tsx
@@ -8,7 +8,6 @@ import type { DiContainer } from "@ogre-tools/injectable";
 import "@testing-library/jest-dom/vitest";
 
 import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
-import React from "react";
 import appPathsStateInjectable from "../../../common/app-paths/app-paths-state.injectable";
 import directoryForKubeConfigsInjectable from "../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import directoryForUserDataInjectable from "../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";

--- a/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
+++ b/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { screen, waitFor } from "@testing-library/react";
-import React from "react";
 
 import type { RenderResult } from "@testing-library/react";
 import type { Mocked } from "vitest";

--- a/packages/core/src/renderer/components/kube-object-meta/kube-object-meta.tsx
+++ b/packages/core/src/renderer/components/kube-object-meta/kube-object-meta.tsx
@@ -9,7 +9,6 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import * as yaml from "js-yaml";
 import { observer } from "mobx-react";
-import React from "react";
 import { Link } from "react-router-dom";
 import apiManagerInjectable from "../../../common/k8s-api/api-manager/manager.injectable";
 import { defaultYamlDumpOptions } from "../../../common/kube-helpers";

--- a/packages/core/src/renderer/components/kube-object/age.tsx
+++ b/packages/core/src/renderer/components/kube-object/age.tsx
@@ -5,7 +5,6 @@
  */
 
 import moment from "moment-timezone";
-import React from "react";
 import { ReactiveDuration } from "../duration/reactive-duration";
 import { WithTooltip } from "../with-tooltip";
 

--- a/packages/core/src/renderer/components/layout/__tests__/sidebar-cluster.test.tsx
+++ b/packages/core/src/renderer/components/layout/__tests__/sidebar-cluster.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import "@testing-library/jest-dom/vitest";
 
 import { fireEvent } from "@testing-library/react";

--- a/packages/core/src/renderer/components/layout/close-button.tsx
+++ b/packages/core/src/renderer/components/layout/close-button.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Icon } from "@freelensapp/icon";
-import React from "react";
 import styles from "./close-button.module.scss";
 
 import type { HTMLAttributes } from "react";

--- a/packages/core/src/renderer/components/layout/extension-sidebar-item-registrator.injectable.tsx
+++ b/packages/core/src/renderer/components/layout/extension-sidebar-item-registrator.injectable.tsx
@@ -7,7 +7,6 @@
 import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import React from "react";
 import { navigateToRouteInjectionToken } from "../../../common/front-end-routing/navigate-to-route-injection-token";
 import { extensionRegistratorInjectionToken } from "../../../extensions/extension-loader/extension-registrator-injection-token";
 import { getExtensionId, sanitizeExtensionName } from "../../../extensions/lens-extension";

--- a/packages/core/src/renderer/components/layout/siblings-in-tab-layout.tsx
+++ b/packages/core/src/renderer/components/layout/siblings-in-tab-layout.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import siblingTabsInjectable from "../../routes/sibling-tabs.injectable";
 import { TabLayout } from "./tab-layout-2";
 

--- a/packages/core/src/renderer/components/layout/sidebar.tsx
+++ b/packages/core/src/renderer/components/layout/sidebar.tsx
@@ -8,7 +8,6 @@ import { SidebarItemDeclaration, sidebarItemsInjectable } from "@freelensapp/clu
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import userPreferencesStateInjectable, {
   UserPreferencesState,
 } from "../../../features/user-preferences/common/state.injectable";

--- a/packages/core/src/renderer/components/layout/tab-layout-2.tsx
+++ b/packages/core/src/renderer/components/layout/tab-layout-2.tsx
@@ -9,7 +9,6 @@ import "./tab-layout.scss";
 import { ErrorBoundary } from "@freelensapp/error-boundary";
 import { cssNames } from "@freelensapp/utilities";
 import { observer } from "mobx-react";
-import React from "react";
 import { Tab, Tabs } from "../tabs";
 
 import type { SidebarItemDeclaration } from "@freelensapp/cluster-sidebar";

--- a/packages/core/src/renderer/components/layout/top-bar/top-bar-items/context-menu/context-menu.tsx
+++ b/packages/core/src/renderer/components/layout/top-bar/top-bar-items/context-menu/context-menu.tsx
@@ -20,7 +20,6 @@
  */
 
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import styles from "../../top-bar.module.scss";
 import openAppContextMenuInjectable from "./open-app-context-menu/open-app-context-menu.injectable";
 

--- a/packages/core/src/renderer/components/layout/top-bar/top-bar-items/navigation-to-back/navigation-to-back.tsx
+++ b/packages/core/src/renderer/components/layout/top-bar/top-bar-items/navigation-to-back/navigation-to-back.tsx
@@ -7,7 +7,6 @@
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import goBackInjectable from "./go-back/go-back.injectable";
 import topBarPrevEnabledInjectable from "./prev-enabled.injectable";
 

--- a/packages/core/src/renderer/components/layout/top-bar/top-bar-items/navigation-to-forward/navigation-to-forward.tsx
+++ b/packages/core/src/renderer/components/layout/top-bar/top-bar-items/navigation-to-forward/navigation-to-forward.tsx
@@ -7,7 +7,6 @@
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import goForwardInjectable from "./go-forward/go-forward.injectable";
 import topBarNextEnabledInjectable from "./next-enabled.injectable";
 

--- a/packages/core/src/renderer/components/layout/top-bar/top-bar-items/navigation-to-home/navigation-to-home.tsx
+++ b/packages/core/src/renderer/components/layout/top-bar/top-bar-items/navigation-to-home/navigation-to-home.tsx
@@ -7,7 +7,6 @@
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import navigateToWelcomeInjectable from "../../../../../../common/front-end-routing/routes/welcome/navigate-to-welcome.injectable";
 import welcomeRouteInjectable from "../../../../../../common/front-end-routing/routes/welcome/welcome-route.injectable";
 import routeIsActiveInjectable from "../../../../../routes/route-is-active.injectable";

--- a/packages/core/src/renderer/components/layout/top-bar/top-bar-items/window-controls/window-controls.tsx
+++ b/packages/core/src/renderer/components/layout/top-bar/top-bar-items/window-controls/window-controls.tsx
@@ -21,7 +21,6 @@
 
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import isLinuxInjectable from "../../../../../../common/vars/is-linux.injectable";
 import toggleMaximizeWindowInjectable from "../../toggle-maximize-window/toggle-maximize-window.injectable";
 import styles from "../../top-bar.module.scss";

--- a/packages/core/src/renderer/components/layout/top-bar/top-bar.test.tsx
+++ b/packages/core/src/renderer/components/layout/top-bar/top-bar.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { fireEvent } from "@testing-library/react";
-import React from "react";
 
 import type { MockedFunction } from "vitest";
 import "@testing-library/jest-dom/vitest";

--- a/packages/core/src/renderer/components/layout/top-bar/top-bar.tsx
+++ b/packages/core/src/renderer/components/layout/top-bar/top-bar.tsx
@@ -11,7 +11,7 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import watchHistoryStateInjectable from "../../../remote-helpers/watch-history-state.injectable";
 import { Gutter } from "../../gutter";
 import { Map } from "../../map";

--- a/packages/core/src/renderer/components/list/list.tsx
+++ b/packages/core/src/renderer/components/list/list.tsx
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React, { useState } from "react";
+import { useState } from "react";
 import { SearchInput } from "../input";
 import { ReactTable } from "../table/react-table";
 import styles from "./list.module.scss";

--- a/packages/core/src/renderer/components/locale-date/locale-date.tsx
+++ b/packages/core/src/renderer/components/locale-date/locale-date.tsx
@@ -7,7 +7,6 @@
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import moment from "moment-timezone";
-import React from "react";
 import userPreferencesStateInjectable from "../../../features/user-preferences/common/state.injectable";
 
 import type { UserPreferencesState } from "../../../features/user-preferences/common/state.injectable";

--- a/packages/core/src/renderer/components/map/map.test.tsx
+++ b/packages/core/src/renderer/components/map/map.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { render } from "@testing-library/react";
-import React from "react";
 import { Map } from "./map";
 
 import type { RenderResult } from "@testing-library/react";

--- a/packages/core/src/renderer/components/markdown-viewer/markdown-viewer.tsx
+++ b/packages/core/src/renderer/components/markdown-viewer/markdown-viewer.tsx
@@ -11,7 +11,7 @@ import "./markdown-viewer.scss";
 import { cssNames } from "@freelensapp/utilities";
 import DOMPurify from "dompurify";
 import { marked } from "marked";
-import React, { Component } from "react";
+import { Component } from "react";
 
 DOMPurify.addHook("afterSanitizeAttributes", function (node) {
   // Set all elements owning target to target=_blank

--- a/packages/core/src/renderer/components/namespaces/metrics-details-component.tsx
+++ b/packages/core/src/renderer/components/namespaces/metrics-details-component.tsx
@@ -6,7 +6,6 @@
 
 import { type IAsyncComputed, withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import { PodCharts, podMetricTabs } from "../workloads-pods/pod-charts";
 import namespaceMetricsInjectable from "./metrics.injectable";

--- a/packages/core/src/renderer/components/namespaces/namespace-select-badge.tsx
+++ b/packages/core/src/renderer/components/namespaces/namespace-select-badge.tsx
@@ -11,7 +11,6 @@
 
 import { cssNames, prevDefault } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { Badge } from "../badge";
 import styles from "./namespace-select-badge.module.scss";
 import filterByNamespaceInjectable from "./namespace-select-filter-model/filter-by-namespace.injectable";

--- a/packages/core/src/renderer/components/namespaces/namespace-select-filter.test.tsx
+++ b/packages/core/src/renderer/components/namespaces/namespace-select-filter.test.tsx
@@ -8,7 +8,6 @@ import asyncFn from "@async-fn/vitest";
 import { Namespace } from "@freelensapp/kube-object";
 import { disposer } from "@freelensapp/utilities";
 import { fireEvent } from "@testing-library/react";
-import React from "react";
 import directoryForKubeConfigsInjectable from "../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import directoryForUserDataInjectable from "../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import { Cluster } from "../../../common/cluster/cluster";

--- a/packages/core/src/renderer/components/namespaces/namespace-select-filter.tsx
+++ b/packages/core/src/renderer/components/namespaces/namespace-select-filter.tsx
@@ -8,7 +8,6 @@ import "./namespace-select-filter.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { components } from "react-select";
 import { Select } from "../select";
 import namespaceSelectFilterModelInjectable from "./namespace-select-filter-model/namespace-select-filter-model.injectable";

--- a/packages/core/src/renderer/components/namespaces/namespace-select.tsx
+++ b/packages/core/src/renderer/components/namespaces/namespace-select.tsx
@@ -11,7 +11,7 @@ import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { computed } from "mobx";
 import { observer } from "mobx-react";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import { Select } from "../select";
 

--- a/packages/core/src/renderer/components/namespaces/namespace-tree-view.test.tsx
+++ b/packages/core/src/renderer/components/namespaces/namespace-tree-view.test.tsx
@@ -6,7 +6,6 @@
 
 import { Namespace } from "@freelensapp/kube-object";
 import { fireEvent } from "@testing-library/react";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import { renderFor } from "../test-utils/renderFor";
 import hierarchicalNamespacesInjectable from "./hierarchical-namespaces.injectable";

--- a/packages/core/src/renderer/components/namespaces/namespaces-sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/namespaces/namespaces-sidebar-item.injectable.tsx
@@ -7,7 +7,6 @@
 import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import namespacesRouteInjectable from "../../../common/front-end-routing/routes/cluster/namespaces/namespaces-route.injectable";
 import navigateToNamespacesInjectable from "../../../common/front-end-routing/routes/cluster/namespaces/navigate-to-namespaces.injectable";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";

--- a/packages/core/src/renderer/components/namespaces/route.tsx
+++ b/packages/core/src/renderer/components/namespaces/route.tsx
@@ -7,7 +7,6 @@
 import "./namespaces.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { Badge } from "../badge";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectListLayout } from "../kube-object-list-layout";

--- a/packages/core/src/renderer/components/network-ingresses/ingress-charts.test.tsx
+++ b/packages/core/src/renderer/components/network-ingresses/ingress-charts.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import selectedMetricsTimeRangeInjectable from "../cluster/overview/selected-metrics-time-range.injectable";
 import { ResourceMetricsContext } from "../resource-metrics";

--- a/packages/core/src/renderer/components/network-ingresses/ingress-charts.tsx
+++ b/packages/core/src/renderer/components/network-ingresses/ingress-charts.tsx
@@ -6,7 +6,7 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { isMetricsEmpty, normalizeMetrics } from "../../../common/k8s-api/endpoints/metrics.api";
 import { BarChart } from "../chart";
 import { type MetricsTab, metricTabOptions } from "../chart/options";

--- a/packages/core/src/renderer/components/network-ingresses/ingress-class-menu.injectable.tsx
+++ b/packages/core/src/renderer/components/network-ingresses/ingress-class-menu.injectable.tsx
@@ -8,7 +8,6 @@ import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { computed } from "mobx";
-import React from "react";
 import hideDetailsInjectable from "../kube-detail-params/hide-details.injectable";
 import { kubeObjectMenuItemInjectionToken } from "../kube-object-menu/kube-object-menu-item-injection-token";
 import { MenuItem } from "../menu";

--- a/packages/core/src/renderer/components/network-ingresses/ingress-classes.tsx
+++ b/packages/core/src/renderer/components/network-ingresses/ingress-classes.tsx
@@ -9,7 +9,6 @@ import "./ingress-classes.scss";
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { KubeObjectAge } from "../kube-object";
 import { KubeObjectListLayout } from "../kube-object-list-layout";
 import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";

--- a/packages/core/src/renderer/components/network-ingresses/ingresses.tsx
+++ b/packages/core/src/renderer/components/network-ingresses/ingresses.tsx
@@ -9,7 +9,6 @@ import "./ingresses.scss";
 import { type ComputedIngressRoute, computeRouteDeclarations } from "@freelensapp/kube-object";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectListLayout } from "../kube-object-list-layout";
 import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";

--- a/packages/core/src/renderer/components/network-ingresses/metrics-details-component.tsx
+++ b/packages/core/src/renderer/components/network-ingresses/metrics-details-component.tsx
@@ -6,7 +6,6 @@
 
 import { type IAsyncComputed, withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import { IngressCharts } from "./ingress-charts";
 import ingressMetricsInjectable from "./metrics.injectable";

--- a/packages/core/src/renderer/components/network-policies/__tests__/network-policy-details.test.tsx
+++ b/packages/core/src/renderer/components/network-policies/__tests__/network-policy-details.test.tsx
@@ -6,7 +6,6 @@
 
 import { NetworkPolicy } from "@freelensapp/kube-object";
 import { findByTestId, findByText } from "@testing-library/react";
-import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import { renderFor } from "../../test-utils/renderFor";
 import { NetworkPolicyDetails } from "../network-policy-details";

--- a/packages/core/src/renderer/components/network/network-sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/network/network-sidebar-item.injectable.tsx
@@ -8,7 +8,6 @@ import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
 import { noop } from "es-toolkit";
-import React from "react";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";
 import { getClusterPageMenuOrderInjectable } from "../../../features/user-preferences/common/cluster-page-menu-order.injectable";
 

--- a/packages/core/src/renderer/components/no-items/no-items.tsx
+++ b/packages/core/src/renderer/components/no-items/no-items.tsx
@@ -7,7 +7,6 @@
 import "./no-items.scss";
 
 import { cssNames } from "@freelensapp/utilities";
-import React from "react";
 
 import type { IClassName, StrictReactNode } from "@freelensapp/utilities";
 

--- a/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-attach-menu.test.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-attach-menu.test.tsx
@@ -1,5 +1,4 @@
 import os from "node:os";
-import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import createTerminalTabInjectable from "../../dock/terminal/create-terminal-tab.injectable";
 import sendCommandInjectable from "../../dock/terminal/send-command.injectable";

--- a/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-logs-menu.test.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-logs-menu.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import createPodLogsTabInjectable from "../../dock/logs/create-pod-logs-tab.injectable";
 import hideDetailsInjectable from "../../kube-detail-params/hide-details.injectable";

--- a/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-shell-menu.test.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/__tests__/pod-shell-menu.test.tsx
@@ -1,5 +1,4 @@
 import os from "node:os";
-import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import createTerminalTabInjectable from "../../dock/terminal/create-terminal-tab.injectable";
 import sendCommandInjectable from "../../dock/terminal/send-command.injectable";

--- a/packages/core/src/renderer/components/nodes/details-resources.tsx
+++ b/packages/core/src/renderer/components/nodes/details-resources.tsx
@@ -5,7 +5,6 @@
  */
 
 import { bytesToUnits, unitsToBytes } from "@freelensapp/utilities";
-import React from "react";
 import { DrawerItem } from "../drawer";
 import { WithTooltip } from "../with-tooltip";
 

--- a/packages/core/src/renderer/components/nodes/metrics-details-component.tsx
+++ b/packages/core/src/renderer/components/nodes/metrics-details-component.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import nodeMetricsInjectable from "./metrics.injectable";
 import { NodeCharts } from "./node-charts";

--- a/packages/core/src/renderer/components/nodes/node-charts.test.tsx
+++ b/packages/core/src/renderer/components/nodes/node-charts.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { computed } from "mobx";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import activeThemeInjectable from "../../themes/active.injectable";
 import selectedMetricsTimeRangeInjectable from "../cluster/overview/selected-metrics-time-range.injectable";

--- a/packages/core/src/renderer/components/nodes/node-charts.tsx
+++ b/packages/core/src/renderer/components/nodes/node-charts.tsx
@@ -7,7 +7,7 @@
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { mapValues } from "es-toolkit";
 import { observer } from "mobx-react";
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { isMetricsEmpty, normalizeMetrics } from "../../../common/k8s-api/endpoints/metrics.api";
 import activeThemeInjectable from "../../themes/active.injectable";
 import { BarChart } from "../chart";

--- a/packages/core/src/renderer/components/nodes/nodes-sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/nodes/nodes-sidebar-item.injectable.tsx
@@ -7,7 +7,6 @@
 import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import navigateToNodesInjectable from "../../../common/front-end-routing/routes/cluster/nodes/navigate-to-nodes.injectable";
 import nodesRouteInjectable from "../../../common/front-end-routing/routes/cluster/nodes/nodes-route.injectable";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";

--- a/packages/core/src/renderer/components/path-picker/path-picker.tsx
+++ b/packages/core/src/renderer/components/path-picker/path-picker.tsx
@@ -8,7 +8,6 @@ import { Button } from "@freelensapp/button";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import openPathPickingDialogInjectable from "../../../features/path-picking-dialog/renderer/pick-paths.injectable";
 
 import type { FileFilter, OpenDialogOptions } from "electron";

--- a/packages/core/src/renderer/components/render-delay/__tests__/render-delay.test.tsx
+++ b/packages/core/src/renderer/components/render-delay/__tests__/render-delay.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { advanceFakeTime, testUsingFakeTime } from "../../../../test-utils/use-fake-time";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import { renderFor } from "../../test-utils/renderFor";

--- a/packages/core/src/renderer/components/render-delay/render-delay.tsx
+++ b/packages/core/src/renderer/components/render-delay/render-delay.tsx
@@ -5,7 +5,7 @@
  */
 
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import cancelIdleCallbackInjectable from "./cancel-idle-callback.injectable";
 import idleCallbackTimeoutInjectable from "./idle-callback-timeout.injectable";
 import requestIdleCallbackInjectable from "./request-idle-callback.injectable";

--- a/packages/core/src/renderer/components/resource-metrics/no-metrics.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/no-metrics.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Icon } from "@freelensapp/icon";
-import React from "react";
 
 export function NoMetrics() {
   return (

--- a/packages/core/src/renderer/components/resource-metrics/resource-metrics.test.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/resource-metrics.test.tsx
@@ -7,7 +7,7 @@
 import "@testing-library/jest-dom/vitest";
 import { act, screen } from "@testing-library/react";
 import { computed, observable } from "mobx";
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { renderFor } from "../test-utils/renderFor";
 import { ResourceMetrics, ResourceMetricsContext } from "./resource-metrics";
 

--- a/packages/core/src/renderer/components/resource-metrics/time-ranged-resource-metrics.test.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/time-ranged-resource-metrics.test.tsx
@@ -6,7 +6,6 @@
 
 import "@testing-library/jest-dom/vitest";
 import { screen } from "@testing-library/react";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import selectedMetricsTimeRangeInjectable from "../cluster/overview/selected-metrics-time-range.injectable";
 import { renderFor } from "../test-utils/renderFor";

--- a/packages/core/src/renderer/components/resource-metrics/time-ranged-resource-metrics.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/time-ranged-resource-metrics.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { MetricsTimeRangeSelector } from "../cluster/metrics-time-range-selector";
 import selectedMetricsTimeRangeInjectable, {
   type SelectedMetricsTimeRange,

--- a/packages/core/src/renderer/components/select/select.test.tsx
+++ b/packages/core/src/renderer/components/select/select.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import "@testing-library/jest-dom/vitest";
 
 import { computed } from "mobx";

--- a/packages/core/src/renderer/components/slider/slider.tsx
+++ b/packages/core/src/renderer/components/slider/slider.tsx
@@ -11,7 +11,7 @@ import "./slider.scss";
 import assert from "node:assert";
 import { cssNames } from "@freelensapp/utilities";
 import MaterialSlider from "@mui/material/Slider";
-import React, { Component } from "react";
+import { Component } from "react";
 
 import type { SliderProps as MaterialSliderProps, SliderClassKey } from "@mui/material/Slider";
 

--- a/packages/core/src/renderer/components/status-bar/status-bar.test.tsx
+++ b/packages/core/src/renderer/components/status-bar/status-bar.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { getRandomIdInjectionToken } from "@freelensapp/random";
-import React from "react";
 import { getApplicationBuilder } from "../test-utils/get-application-builder";
 import setStatusBarStatusInjectable from "./set-status-bar-status.injectable";
 

--- a/packages/core/src/renderer/components/status-bar/status-bar.tsx
+++ b/packages/core/src/renderer/components/status-bar/status-bar.tsx
@@ -12,7 +12,6 @@
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import statusBarCurrentStatusInjectable from "./current-status.injectable";
 import styles from "./status-bar.module.scss";
 import statusBarItemsInjectable from "./status-bar-items.injectable";

--- a/packages/core/src/renderer/components/storage-volume-claims/metrics-details-component.tsx
+++ b/packages/core/src/renderer/components/storage-volume-claims/metrics-details-component.tsx
@@ -6,7 +6,6 @@
 
 import { type IAsyncComputed, withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import persistentVolumeClaimMetricsInjectable from "./metrics.injectable";
 import { VolumeClaimDiskChart } from "./volume-claim-disk-chart";

--- a/packages/core/src/renderer/components/storage-volume-claims/volume-claim-disk-chart.test.tsx
+++ b/packages/core/src/renderer/components/storage-volume-claims/volume-claim-disk-chart.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { computed } from "mobx";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import activeThemeInjectable from "../../themes/active.injectable";
 import selectedMetricsTimeRangeInjectable from "../cluster/overview/selected-metrics-time-range.injectable";

--- a/packages/core/src/renderer/components/storage-volume-claims/volume-claim-disk-chart.tsx
+++ b/packages/core/src/renderer/components/storage-volume-claims/volume-claim-disk-chart.tsx
@@ -6,7 +6,7 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { isMetricsEmpty, normalizeMetrics } from "../../../common/k8s-api/endpoints/metrics.api";
 import activeThemeInjectable from "../../themes/active.injectable";
 import { BarChart, memoryOptions } from "../chart";

--- a/packages/core/src/renderer/components/storage/storage-sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/storage/storage-sidebar-item.injectable.tsx
@@ -8,7 +8,6 @@ import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
 import { noop } from "es-toolkit";
-import React from "react";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";
 import { getClusterPageMenuOrderInjectable } from "../../../features/user-preferences/common/cluster-page-menu-order.injectable";
 

--- a/packages/core/src/renderer/components/switch/__tests__/switch.test.tsx
+++ b/packages/core/src/renderer/components/switch/__tests__/switch.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { fireEvent, render } from "@testing-library/react";
-import React from "react";
 import "@testing-library/jest-dom/vitest";
 
 import { Switch } from "../switch";

--- a/packages/core/src/renderer/components/switch/switch.tsx
+++ b/packages/core/src/renderer/components/switch/switch.tsx
@@ -5,7 +5,6 @@
  */
 
 import { cssNames } from "@freelensapp/utilities";
-import React from "react";
 import styles from "./switch.module.scss";
 
 import type { ChangeEvent, HTMLProps } from "react";

--- a/packages/core/src/renderer/components/table/react-table.tsx
+++ b/packages/core/src/renderer/components/table/react-table.tsx
@@ -8,7 +8,7 @@ import "./react-table.scss";
 
 import { Icon } from "@freelensapp/icon";
 import { cssNames } from "@freelensapp/utilities";
-import React, { useCallback, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useFlexLayout, useSortBy, useTable } from "react-table";
 
 import type { Row, UseTableOptions } from "react-table";

--- a/packages/core/src/renderer/components/tree-view/tree-view.tsx
+++ b/packages/core/src/renderer/components/tree-view/tree-view.tsx
@@ -6,7 +6,7 @@
 
 import { Icon } from "@freelensapp/icon";
 import { cssNames } from "@freelensapp/utilities";
-import React, { useState } from "react";
+import { useState } from "react";
 import styles from "./tree-view.module.scss";
 
 import type { StrictReactNode } from "@freelensapp/utilities";

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/__tests__/dialog.test.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/__tests__/dialog.test.tsx
@@ -6,7 +6,6 @@
 
 import { ClusterRole } from "@freelensapp/kube-object";
 import userEvent from "@testing-library/user-event";
-import React from "react";
 import directoryForKubeConfigsInjectable from "../../../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import directoryForUserDataInjectable from "../../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import { Cluster } from "../../../../../common/cluster/cluster";

--- a/packages/core/src/renderer/components/user-management/role-bindings/__tests__/dialog.test.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/__tests__/dialog.test.tsx
@@ -6,7 +6,6 @@
 
 import { ClusterRole } from "@freelensapp/kube-object";
 import userEvent from "@testing-library/user-event";
-import React from "react";
 import directoryForKubeConfigsInjectable from "../../../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import directoryForUserDataInjectable from "../../../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import { Cluster } from "../../../../../common/cluster/cluster";

--- a/packages/core/src/renderer/components/user-management/service-accounts/service-account-menu.tsx
+++ b/packages/core/src/renderer/components/user-management/service-accounts/service-account-menu.tsx
@@ -6,7 +6,6 @@
 
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import openServiceAccountKubeConfigDialogInjectable from "../../kubeconfig-dialog/open-service-account-kube-config-dialog.injectable";
 import { MenuItem } from "../../menu";
 

--- a/packages/core/src/renderer/components/user-management/user-management-sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/user-management/user-management-sidebar-item.injectable.tsx
@@ -8,7 +8,6 @@ import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
 import { noop } from "es-toolkit";
-import React from "react";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";
 import { getClusterPageMenuOrderInjectable } from "../../../features/user-preferences/common/cluster-page-menu-order.injectable";
 

--- a/packages/core/src/renderer/components/virtual-list/virtual-list.test.tsx
+++ b/packages/core/src/renderer/components/virtual-list/virtual-list.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { render } from "@testing-library/react";
-import React from "react";
 import { VirtualList } from "./virtual-list";
 
 import type { RenderResult } from "@testing-library/react";

--- a/packages/core/src/renderer/components/welcome/new-version-notification.injectable.test.tsx
+++ b/packages/core/src/renderer/components/welcome/new-version-notification.injectable.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { showInfoNotificationInjectable } from "@freelensapp/notifications";
-import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { buildVersionInitializable } from "../../../features/vars/build-version/common/token";
 import getLatestVersionViaChannelInjectable from "../../common/utils/get-latest-version-via-channel.injectable";

--- a/packages/core/src/renderer/components/welcome/new-version-notification.injectable.tsx
+++ b/packages/core/src/renderer/components/welcome/new-version-notification.injectable.tsx
@@ -7,7 +7,6 @@
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { showInfoNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import * as semver from "semver";
 import productNameInjectable from "../../../common/vars/product-name.injectable";
 import { buildVersionInitializable } from "../../../features/vars/build-version/common/token";

--- a/packages/core/src/renderer/components/welcome/welcome.tsx
+++ b/packages/core/src/renderer/components/welcome/welcome.tsx
@@ -9,7 +9,7 @@ import "./welcome.scss";
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { forumsUrl } from "../../../common/vars";
 import productNameInjectable from "../../../common/vars/product-name.injectable";
 import newVersionNotificationInjectable from "./new-version-notification.injectable";

--- a/packages/core/src/renderer/components/workloads-cronjobs/cron-job-menu.tsx
+++ b/packages/core/src/renderer/components/workloads-cronjobs/cron-job-menu.tsx
@@ -8,7 +8,6 @@ import { Icon } from "@freelensapp/icon";
 import { cronJobApiInjectable } from "@freelensapp/kube-api-specifics";
 import { showCheckedErrorNotificationInjectable } from "@freelensapp/notifications";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import openConfirmDialogInjectable from "../confirm-dialog/open.injectable";
 import { MenuItem } from "../menu";
 import openCronJobTriggerDialogInjectable from "./trigger-dialog/open.injectable";

--- a/packages/core/src/renderer/components/workloads-cronjobs/cronjobs.tsx
+++ b/packages/core/src/renderer/components/workloads-cronjobs/cronjobs.tsx
@@ -9,7 +9,6 @@ import "./cronjobs.scss";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
 import moment from "moment-timezone";
-import React from "react";
 import { BadgeBoolean } from "../badge";
 import eventStoreInjectable from "../events/store.injectable";
 import { KubeObjectAge } from "../kube-object/age";

--- a/packages/core/src/renderer/components/workloads-cronjobs/trigger-dialog/view.tsx
+++ b/packages/core/src/renderer/components/workloads-cronjobs/trigger-dialog/view.tsx
@@ -12,7 +12,7 @@ import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
-import React, { Component } from "react";
+import { Component } from "react";
 import { Dialog } from "../../dialog";
 import { Input } from "../../input";
 import { maxLength, systemName } from "../../input/input_validators";

--- a/packages/core/src/renderer/components/workloads-daemonsets/daemonset-menu.tsx
+++ b/packages/core/src/renderer/components/workloads-daemonsets/daemonset-menu.tsx
@@ -8,7 +8,6 @@ import { Icon } from "@freelensapp/icon";
 import { daemonSetApiInjectable } from "@freelensapp/kube-api-specifics";
 import { showCheckedErrorNotificationInjectable } from "@freelensapp/notifications";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import openConfirmDialogInjectable from "../confirm-dialog/open.injectable";
 import { MenuItem } from "../menu";
 

--- a/packages/core/src/renderer/components/workloads-daemonsets/daemonsets.tsx
+++ b/packages/core/src/renderer/components/workloads-daemonsets/daemonsets.tsx
@@ -8,7 +8,6 @@ import "./daemonsets.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Badge } from "../badge";
 import eventStoreInjectable from "../events/store.injectable";
 import { KubeObjectAge } from "../kube-object/age";

--- a/packages/core/src/renderer/components/workloads-daemonsets/metrics-details-component.tsx
+++ b/packages/core/src/renderer/components/workloads-daemonsets/metrics-details-component.tsx
@@ -6,7 +6,6 @@
 
 import { type IAsyncComputed, withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import { PodCharts, podMetricTabs } from "../workloads-pods/pod-charts";
 import daemonSetMetricsInjectable from "./metrics.injectable";

--- a/packages/core/src/renderer/components/workloads-deployments/deployment-menu.tsx
+++ b/packages/core/src/renderer/components/workloads-deployments/deployment-menu.tsx
@@ -8,7 +8,6 @@ import { Icon } from "@freelensapp/icon";
 import { deploymentApiInjectable } from "@freelensapp/kube-api-specifics";
 import { showCheckedErrorNotificationInjectable } from "@freelensapp/notifications";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import openConfirmDialogInjectable from "../confirm-dialog/open.injectable";
 import { MenuItem } from "../menu";
 import openDeploymentScaleDialogInjectable from "./scale/open.injectable";

--- a/packages/core/src/renderer/components/workloads-deployments/metrics-details-component.tsx
+++ b/packages/core/src/renderer/components/workloads-deployments/metrics-details-component.tsx
@@ -6,7 +6,6 @@
 
 import { type IAsyncComputed, withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import { PodCharts, podMetricTabs } from "../workloads-pods/pod-charts";
 import deploymentMetricsInjectable from "./metrics.injectable";

--- a/packages/core/src/renderer/components/workloads-deployments/scale/dialog.test.tsx
+++ b/packages/core/src/renderer/components/workloads-deployments/scale/dialog.test.tsx
@@ -7,7 +7,6 @@
 import { deploymentApiInjectable } from "@freelensapp/kube-api-specifics";
 import { Deployment } from "@freelensapp/kube-object";
 import { fireEvent, waitFor } from "@testing-library/react";
-import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import storesAndApisCanBeCreatedInjectable from "../../../stores-apis-can-be-created.injectable";
 import { renderFor } from "../../test-utils/renderFor";

--- a/packages/core/src/renderer/components/workloads-deployments/scale/dialog.tsx
+++ b/packages/core/src/renderer/components/workloads-deployments/scale/dialog.tsx
@@ -13,7 +13,7 @@ import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { computed, makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
-import React, { Component } from "react";
+import { Component } from "react";
 import { Dialog } from "../../dialog";
 import { Slider } from "../../slider";
 import { Wizard, WizardStep } from "../../wizard";

--- a/packages/core/src/renderer/components/workloads-jobs/job-menu.tsx
+++ b/packages/core/src/renderer/components/workloads-jobs/job-menu.tsx
@@ -8,7 +8,6 @@ import { Icon } from "@freelensapp/icon";
 import { jobApiInjectable } from "@freelensapp/kube-api-specifics";
 import { showCheckedErrorNotificationInjectable } from "@freelensapp/notifications";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import openConfirmDialogInjectable from "../confirm-dialog/open.injectable";
 import { MenuItem } from "../menu";
 

--- a/packages/core/src/renderer/components/workloads-jobs/jobs.tsx
+++ b/packages/core/src/renderer/components/workloads-jobs/jobs.tsx
@@ -9,7 +9,6 @@ import "./jobs.scss";
 import { formatDuration } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Badge, BadgeBoolean } from "../badge";
 import { DurationAbsoluteTimestamp } from "../events";
 import eventStoreInjectable from "../events/store.injectable";

--- a/packages/core/src/renderer/components/workloads-jobs/metrics-details-component.tsx
+++ b/packages/core/src/renderer/components/workloads-jobs/metrics-details-component.tsx
@@ -6,7 +6,6 @@
 
 import { type IAsyncComputed, withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import { PodCharts, podMetricTabs } from "../workloads-pods/pod-charts";
 import jobMetricsInjectable from "./metrics.injectable";

--- a/packages/core/src/renderer/components/workloads-overview/overview-statuses.tsx
+++ b/packages/core/src/renderer/components/workloads-overview/overview-statuses.tsx
@@ -8,7 +8,6 @@ import "./overview-statuses.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { formatKubeApiResource } from "../../../common/rbac";
 import { OverviewWorkloadStatus } from "./overview-workload-status";
 import workloadsInjectable from "./workloads/workloads.injectable";

--- a/packages/core/src/renderer/components/workloads-overview/overview-workload-status.tsx
+++ b/packages/core/src/renderer/components/workloads-overview/overview-workload-status.tsx
@@ -10,7 +10,6 @@ import { object } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { capitalize } from "es-toolkit";
 import { observer } from "mobx-react";
-import React from "react";
 import activeThemeInjectable from "../../themes/active.injectable";
 import { PieChart } from "../chart";
 

--- a/packages/core/src/renderer/components/workloads-pods/__tests__/pod-container-env.test.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/__tests__/pod-container-env.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { ConfigMap, Pod, Secret, SecretType } from "@freelensapp/kube-object";
-import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import configMapStoreInjectable from "../../config-maps/store.injectable";
 import secretStoreInjectable from "../../config-secrets/store.injectable";

--- a/packages/core/src/renderer/components/workloads-pods/__tests__/pod-details-container.test.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/__tests__/pod-details-container.test.tsx
@@ -7,7 +7,6 @@
 import { Pod } from "@freelensapp/kube-object";
 import { disposer } from "@freelensapp/utilities";
 import { screen } from "@testing-library/react";
-import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import portForwardStoreInjectable from "../../../port-forward/port-forward-store/port-forward-store.injectable";
 import { renderFor } from "../../test-utils/renderFor";

--- a/packages/core/src/renderer/components/workloads-pods/__tests__/pod-tolerations.test.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/__tests__/pod-tolerations.test.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import "@testing-library/jest-dom/vitest";
 
 import { fireEvent } from "@testing-library/react";

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-age-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-age-column.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { KubeObjectAge } from "../../kube-object/age";
 import { COLUMN_PRIORITY } from "./column-priority";
 

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-cpu-usage-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-cpu-usage-column.injectable.tsx
@@ -7,7 +7,6 @@
 import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
 import { getInjectable } from "@ogre-tools/injectable";
 import { observer } from "mobx-react";
-import React from "react";
 import podStoreInjectable from "../../workloads-pods/store.injectable";
 import { COLUMN_PRIORITY } from "./column-priority";
 

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-ip-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-ip-column.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { WithTooltip } from "../../with-tooltip";
 import { COLUMN_PRIORITY } from "./column-priority";
 

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-memory-usage-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-memory-usage-column.injectable.tsx
@@ -8,7 +8,6 @@ import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
 import { bytesToUnits } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import { observer } from "mobx-react";
-import React from "react";
 import podStoreInjectable from "../../workloads-pods/store.injectable";
 import { COLUMN_PRIORITY } from "./column-priority";
 

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-name-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-name-column.injectable.tsx
@@ -7,7 +7,6 @@
 import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
 import { getConvertedParts } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { WithTooltip } from "../../with-tooltip";
 import { COLUMN_PRIORITY } from "./column-priority";
 

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-namespace-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-namespace-column.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { NamespaceSelectBadge } from "../../namespaces/namespace-select-badge";
 import { COLUMN_PRIORITY } from "./column-priority";
 

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-node-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-node-column.injectable.tsx
@@ -6,7 +6,6 @@
 
 import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { LinkToNode } from "../../kube-object-link";
 import { WithTooltip } from "../../with-tooltip";
 import { COLUMN_PRIORITY } from "./column-priority";

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-owners-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-owners-column.injectable.tsx
@@ -7,7 +7,6 @@
 import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
 import { stopPropagation } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { Link } from "react-router-dom";
 import apiManagerInjectable from "../../../../common/k8s-api/api-manager/manager.injectable";
 import { Badge } from "../../badge";

--- a/packages/core/src/renderer/components/workloads-pods/container-charts.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/container-charts.tsx
@@ -8,7 +8,7 @@ import { withInjectables } from "@ogre-tools/injectable-react";
 import { mapValues } from "es-toolkit";
 import { toJS } from "mobx";
 import { observer } from "mobx-react";
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { getItemMetrics, isMetricsEmpty, normalizeMetrics } from "../../../common/k8s-api/endpoints/metrics.api";
 import activeThemeInjectable from "../../themes/active.injectable";
 import { BarChart } from "../chart";

--- a/packages/core/src/renderer/components/workloads-pods/details/containers/pod-details-containers.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/containers/pod-details-containers.tsx
@@ -5,7 +5,6 @@
  */
 
 import { observer } from "mobx-react";
-import React from "react";
 import { DrawerTitle } from "../../../drawer";
 import { PodDetailsContainer } from "../../pod-details-container";
 

--- a/packages/core/src/renderer/components/workloads-pods/details/containers/pod-details-ephemeral-containers.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/containers/pod-details-ephemeral-containers.tsx
@@ -5,7 +5,6 @@
  */
 
 import { observer } from "mobx-react";
-import React from "react";
 import { DrawerTitle } from "../../../drawer";
 import { PodDetailsContainer } from "../../pod-details-container";
 

--- a/packages/core/src/renderer/components/workloads-pods/details/containers/pod-details-init-containers.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/containers/pod-details-init-containers.tsx
@@ -5,7 +5,6 @@
  */
 
 import { observer } from "mobx-react";
-import React from "react";
 import { DrawerTitle } from "../../../drawer";
 import { PodDetailsContainer } from "../../pod-details-container";
 

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variant.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variant.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Icon } from "@freelensapp/icon";
-import React from "react";
 import { DrawerItem } from "../../../drawer";
 import { AwsElasticBlockStore } from "./variants/aws-elastic-block-store";
 import { AzureDisk } from "./variants/azure-disk";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/__tests__/ceph-fs.test.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/__tests__/ceph-fs.test.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Pod } from "@freelensapp/kube-object";
-import React from "react";
 import { getDiForUnitTesting } from "../../../../../../getDiForUnitTesting";
 import storesAndApisCanBeCreatedInjectable from "../../../../../../stores-apis-can-be-created.injectable";
 import { renderFor } from "../../../../../test-utils/renderFor";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/aws-elastic-block-store.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/aws-elastic-block-store.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/azure-disk.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/azure-disk.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/azure-file.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/azure-file.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/ceph-fs.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/ceph-fs.tsx
@@ -6,7 +6,6 @@
 
 import { secretApiInjectable } from "@freelensapp/kube-api-specifics";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 import { LocalRef } from "../variant-helpers";
 

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/cinder.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/cinder.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/config-map.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/config-map.tsx
@@ -6,7 +6,6 @@
 
 import { configMapApiInjectable } from "@freelensapp/kube-api-specifics";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { LocalRef } from "../variant-helpers";
 
 import type { ConfigMapApi } from "@freelensapp/kube-api";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/container-storage-interface.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/container-storage-interface.tsx
@@ -6,7 +6,6 @@
 
 import { secretApiInjectable } from "@freelensapp/kube-api-specifics";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 import { LocalRef } from "../variant-helpers";
 

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/downward-api.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/downward-api.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/empty-dir.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/empty-dir.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/ephemeral.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/ephemeral.tsx
@@ -5,7 +5,6 @@
  */
 
 import { dump } from "js-yaml";
-import React from "react";
 import { DrawerItem, DrawerItemLabels } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/fiber-channel.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/fiber-channel.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/flex-volume.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/flex-volume.tsx
@@ -6,7 +6,6 @@
 
 import { secretApiInjectable } from "@freelensapp/kube-api-specifics";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 import { LocalRef } from "../variant-helpers";
 

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/flocker.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/flocker.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/gce-persistent-disk.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/gce-persistent-disk.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/git-repo.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/git-repo.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/gluster-fs.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/gluster-fs.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/host-path.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/host-path.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/i-scsi.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/i-scsi.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/image.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/image.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/local.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/local.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/network-fs.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/network-fs.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/persistent-volume-claim.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/persistent-volume-claim.tsx
@@ -6,7 +6,6 @@
 
 import { persistentVolumeClaimApiInjectable } from "@freelensapp/kube-api-specifics";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { LocalRef } from "../variant-helpers";
 
 import type { PersistentVolumeClaimApi } from "@freelensapp/kube-api";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/photon-persistent-disk.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/photon-persistent-disk.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/portworx-volume.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/portworx-volume.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/projected.test.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/projected.test.tsx
@@ -6,7 +6,6 @@
 
 import { Pod } from "@freelensapp/kube-object";
 import { render } from "@testing-library/react";
-import React from "react";
 import { Projected } from "./projected";
 
 import type { ProjectedSource } from "@freelensapp/kube-object";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/quobyte.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/quobyte.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/rados-block-device.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/rados-block-device.tsx
@@ -6,7 +6,6 @@
 
 import { secretApiInjectable } from "@freelensapp/kube-api-specifics";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 import { LocalRef } from "../variant-helpers";
 

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/scale-io.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/scale-io.tsx
@@ -6,7 +6,6 @@
 
 import { secretApiInjectable } from "@freelensapp/kube-api-specifics";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 import { LocalRef } from "../variant-helpers";
 

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/secret.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/secret.tsx
@@ -6,7 +6,6 @@
 
 import { secretApiInjectable } from "@freelensapp/kube-api-specifics";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 import { LocalRef } from "../variant-helpers";
 

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/storage-os.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/storage-os.tsx
@@ -6,7 +6,6 @@
 
 import { secretApiInjectable } from "@freelensapp/kube-api-specifics";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 import { LocalRef } from "../variant-helpers";
 

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/vsphere-volume.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/variants/vsphere-volume.tsx
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React from "react";
 import { DrawerItem } from "../../../../drawer";
 
 import type { VolumeVariantComponent } from "../variant-helpers";

--- a/packages/core/src/renderer/components/workloads-pods/details/volumes/view.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/details/volumes/view.tsx
@@ -6,7 +6,6 @@
 
 import { Icon } from "@freelensapp/icon";
 import { observer } from "mobx-react";
-import React from "react";
 import { DrawerTitle } from "../../../drawer";
 import { VolumeVariant } from "./variant";
 

--- a/packages/core/src/renderer/components/workloads-pods/pod-charts.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-charts.tsx
@@ -7,7 +7,7 @@
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { mapValues } from "es-toolkit";
 import { observer } from "mobx-react";
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { isMetricsEmpty, normalizeMetrics } from "../../../common/k8s-api/endpoints/metrics.api";
 import { BarChart } from "../chart";
 import { metricTabOptions } from "../chart/options";

--- a/packages/core/src/renderer/components/workloads-pods/pod-details-container-metrics.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details-container-metrics.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import { ContainerCharts } from "./container-charts";
 import podContainerMetricsInjectable from "./container-metrics.injectable";

--- a/packages/core/src/renderer/components/workloads-pods/pod-details-secrets.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details-secrets.tsx
@@ -10,7 +10,7 @@ import { secretApiInjectable } from "@freelensapp/kube-api-specifics";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { reaction } from "mobx";
 import { observer } from "mobx-react";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import getDetailsUrlInjectable from "../kube-detail-params/get-details-url.injectable";
 

--- a/packages/core/src/renderer/components/workloads-pods/pod-details-tolerations.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details-tolerations.tsx
@@ -6,7 +6,6 @@
 
 import "./pod-details-tolerations.scss";
 
-import React from "react";
 import { DrawerItem, DrawerParamToggler } from "../drawer";
 import { PodTolerations } from "./pod-tolerations";
 

--- a/packages/core/src/renderer/components/workloads-pods/pod-metrics-details-component.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-metrics-details-component.tsx
@@ -6,7 +6,6 @@
 
 import { type IAsyncComputed, withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import podMetricsInjectable from "./metrics.injectable";
 import { PodCharts, podMetricTabs } from "./pod-charts";

--- a/packages/core/src/renderer/components/workloads-pods/pod-tolerations.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-tolerations.tsx
@@ -7,7 +7,6 @@
 import "./pod-tolerations.scss";
 
 import { uniqueId } from "es-toolkit/compat";
-import React from "react";
 import { Table, TableCell, TableHead, TableRow } from "../table";
 
 import type { Toleration } from "@freelensapp/kube-object";

--- a/packages/core/src/renderer/components/workloads-pods/pods.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pods.tsx
@@ -10,7 +10,7 @@ import { podListLayoutColumnInjectionToken } from "@freelensapp/list-layout";
 import { interval } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import eventStoreInjectable from "../events/store.injectable";
 import { KubeObjectListLayout } from "../kube-object-list-layout";
 import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";

--- a/packages/core/src/renderer/components/workloads-pods/secret-key.test.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/secret-key.test.tsx
@@ -8,7 +8,6 @@ import asyncFn from "@async-fn/vitest";
 import { Secret, SecretType } from "@freelensapp/kube-object";
 import { base64 } from "@freelensapp/utilities";
 import { act } from "@testing-library/react";
-import React from "react";
 import { getDiForUnitTesting } from "../../getDiForUnitTesting";
 import secretStoreInjectable from "../config-secrets/store.injectable";
 import { renderFor } from "../test-utils/renderFor";

--- a/packages/core/src/renderer/components/workloads-replicasets/metrics-details-component.tsx
+++ b/packages/core/src/renderer/components/workloads-replicasets/metrics-details-component.tsx
@@ -6,7 +6,6 @@
 
 import { type IAsyncComputed, withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import { PodCharts, podMetricTabs } from "../workloads-pods/pod-charts";
 import replicaSetMetricsInjectable from "./metrics.injectable";

--- a/packages/core/src/renderer/components/workloads-replicasets/replica-set-menu.tsx
+++ b/packages/core/src/renderer/components/workloads-replicasets/replica-set-menu.tsx
@@ -6,7 +6,6 @@
 
 import { Icon } from "@freelensapp/icon";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import { MenuItem } from "../menu";
 import openReplicaSetScaleDialogInjectable from "./scale-dialog/open.injectable";
 

--- a/packages/core/src/renderer/components/workloads-replicasets/replicasets.tsx
+++ b/packages/core/src/renderer/components/workloads-replicasets/replicasets.tsx
@@ -8,7 +8,6 @@ import "./replicasets.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import eventStoreInjectable from "../events/store.injectable";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectListLayout } from "../kube-object-list-layout";

--- a/packages/core/src/renderer/components/workloads-replicasets/scale-dialog/dialog.test.tsx
+++ b/packages/core/src/renderer/components/workloads-replicasets/scale-dialog/dialog.test.tsx
@@ -7,7 +7,6 @@
 import { replicaSetApiInjectable } from "@freelensapp/kube-api-specifics";
 import { ReplicaSet } from "@freelensapp/kube-object";
 import { fireEvent, waitFor } from "@testing-library/react";
-import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import storesAndApisCanBeCreatedInjectable from "../../../stores-apis-can-be-created.injectable";
 import { type DiRender, renderFor } from "../../test-utils/renderFor";

--- a/packages/core/src/renderer/components/workloads-replicasets/scale-dialog/dialog.tsx
+++ b/packages/core/src/renderer/components/workloads-replicasets/scale-dialog/dialog.tsx
@@ -13,7 +13,7 @@ import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { computed, makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
-import React, { Component } from "react";
+import { Component } from "react";
 import { Dialog } from "../../dialog";
 import { Slider } from "../../slider";
 import { Wizard, WizardStep } from "../../wizard";

--- a/packages/core/src/renderer/components/workloads-replication-controllers/replication-controllers.tsx
+++ b/packages/core/src/renderer/components/workloads-replication-controllers/replication-controllers.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { Badge } from "../badge";
 import { KubeObjectListLayout } from "../kube-object-list-layout";
 import { SiblingsInTabLayout } from "../layout/siblings-in-tab-layout";

--- a/packages/core/src/renderer/components/workloads-statefulsets/metrics-details-component.tsx
+++ b/packages/core/src/renderer/components/workloads-statefulsets/metrics-details-component.tsx
@@ -6,7 +6,6 @@
 
 import { type IAsyncComputed, withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { TimeRangedResourceMetrics } from "../resource-metrics";
 import { PodCharts, podMetricTabs } from "../workloads-pods/pod-charts";
 import statefulSetMetricsInjectable from "./metrics.injectable";

--- a/packages/core/src/renderer/components/workloads-statefulsets/scale/dialog.test.tsx
+++ b/packages/core/src/renderer/components/workloads-statefulsets/scale/dialog.test.tsx
@@ -7,7 +7,6 @@
 import { statefulSetApiInjectable } from "@freelensapp/kube-api-specifics";
 import { StatefulSet } from "@freelensapp/kube-object";
 import { fireEvent, waitFor } from "@testing-library/react";
-import React from "react";
 import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
 import storesAndApisCanBeCreatedInjectable from "../../../stores-apis-can-be-created.injectable";
 import { type DiRender, renderFor } from "../../test-utils/renderFor";

--- a/packages/core/src/renderer/components/workloads-statefulsets/scale/dialog.tsx
+++ b/packages/core/src/renderer/components/workloads-statefulsets/scale/dialog.tsx
@@ -13,7 +13,7 @@ import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { computed, makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
-import React, { Component } from "react";
+import { Component } from "react";
 import { Dialog } from "../../dialog";
 import { Slider } from "../../slider";
 import { Wizard, WizardStep } from "../../wizard";

--- a/packages/core/src/renderer/components/workloads-statefulsets/statefulset-menu.tsx
+++ b/packages/core/src/renderer/components/workloads-statefulsets/statefulset-menu.tsx
@@ -8,7 +8,6 @@ import { Icon } from "@freelensapp/icon";
 import { statefulSetApiInjectable } from "@freelensapp/kube-api-specifics";
 import { showCheckedErrorNotificationInjectable } from "@freelensapp/notifications";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import React from "react";
 import openConfirmDialogInjectable from "../confirm-dialog/open.injectable";
 import { MenuItem } from "../menu";
 

--- a/packages/core/src/renderer/components/workloads-statefulsets/statefulsets.tsx
+++ b/packages/core/src/renderer/components/workloads-statefulsets/statefulsets.tsx
@@ -8,7 +8,6 @@ import "./statefulsets.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import eventStoreInjectable from "../events/store.injectable";
 import { KubeObjectAge } from "../kube-object/age";
 import { KubeObjectListLayout } from "../kube-object-list-layout";

--- a/packages/core/src/renderer/components/workloads/workloads-sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads/workloads-sidebar-item.injectable.tsx
@@ -8,7 +8,6 @@ import { sidebarItemInjectionToken } from "@freelensapp/cluster-sidebar";
 import { Icon } from "@freelensapp/icon";
 import { getInjectable } from "@ogre-tools/injectable";
 import { noop } from "es-toolkit";
-import React from "react";
 import { SidebarMenuItem, sidebarMenuItemIds } from "../../../common/sidebar-menu-items-starting-order";
 import { getClusterPageMenuOrderInjectable } from "../../../features/user-preferences/common/cluster-page-menu-order.injectable";
 

--- a/packages/core/src/renderer/frames/cluster-frame/cluster-frame.test.tsx
+++ b/packages/core/src/renderer/frames/cluster-frame/cluster-frame.test.tsx
@@ -8,7 +8,6 @@ import { historyInjectionToken } from "@freelensapp/routing";
 import { DiContextProvider } from "@ogre-tools/injectable-react";
 import { render as testingLibraryRender } from "@testing-library/react";
 import { computed } from "mobx";
-import React from "react";
 import { Router } from "react-router";
 import directoryForUserDataInjectable from "../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import { Cluster } from "../../../common/cluster/cluster";

--- a/packages/core/src/renderer/frames/cluster-frame/cluster-frame.tsx
+++ b/packages/core/src/renderer/frames/cluster-frame/cluster-frame.tsx
@@ -10,7 +10,7 @@ import { disposer } from "@freelensapp/utilities";
 import { computedInjectManyInjectable } from "@ogre-tools/injectable-extension-for-mobx";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { Observer, observer } from "mobx-react";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import namespaceStoreInjectable from "../../components/namespaces/store.injectable";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import watchHistoryStateInjectable from "../../remote-helpers/watch-history-state.injectable";

--- a/packages/core/src/renderer/frames/routing-react-application-hoc.injectable.tsx
+++ b/packages/core/src/renderer/frames/routing-react-application-hoc.injectable.tsx
@@ -7,7 +7,6 @@
 import { reactApplicationHigherOrderComponentInjectionToken } from "@freelensapp/react-application";
 import { historyInjectionToken } from "@freelensapp/routing";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { Router } from "react-router";
 
 const routingReactApplicationHocInjectable = getInjectable({

--- a/packages/core/src/renderer/frames/theme-provider-react-application-hoc.injectable.tsx
+++ b/packages/core/src/renderer/frames/theme-provider-react-application-hoc.injectable.tsx
@@ -7,7 +7,6 @@
 import { reactApplicationHigherOrderComponentInjectionToken } from "@freelensapp/react-application";
 import { StyledEngineProvider, ThemeProvider } from "@mui/material";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { defaultMuiBaseTheme } from "../mui-base-theme";
 
 const themeProviderReactApplicationHocInjectable = getInjectable({

--- a/packages/core/src/renderer/initializers/add-sync-entries.injectable.tsx
+++ b/packages/core/src/renderer/initializers/add-sync-entries.injectable.tsx
@@ -7,7 +7,6 @@
 import { showSuccessNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
 import { runInAction } from "mobx";
-import React from "react";
 import navigateToKubernetesPreferencesInjectable from "../../features/preferences/common/navigate-to-kubernetes-preferences.injectable";
 import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
 

--- a/packages/core/src/renderer/initializers/workload-events.tsx
+++ b/packages/core/src/renderer/initializers/workload-events.tsx
@@ -6,7 +6,6 @@
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { shouldShowResourceInjectionToken } from "../../features/cluster/showing-kube-resources/common/allowed-resources-injection-token";
 import { Events } from "../components/events/events";
 

--- a/packages/core/src/renderer/ipc/list-namespaces-forbidden-handler.injectable.tsx
+++ b/packages/core/src/renderer/ipc/list-namespaces-forbidden-handler.injectable.tsx
@@ -7,7 +7,6 @@
 import { Button } from "@freelensapp/button";
 import { notificationsStoreInjectable, showSuccessNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import navigateToEntitySettingsInjectable from "../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
 import { getMillisecondsFromUnixEpoch } from "../../common/utils/date/get-current-date-time";
 import getClusterByIdInjectable from "../../features/cluster/storage/common/get-by-id.injectable";

--- a/packages/core/src/renderer/port-forward/about-port-forwarding.injectable.tsx
+++ b/packages/core/src/renderer/port-forward/about-port-forwarding.injectable.tsx
@@ -7,7 +7,6 @@
 import { Button } from "@freelensapp/button";
 import { showSuccessNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import navigateToPortForwardsInjectable from "../../common/front-end-routing/routes/cluster/network/port-forwards/navigate-to-port-forwards.injectable";
 
 const aboutPortForwardingInjectable = getInjectable({

--- a/packages/core/src/renderer/port-forward/notify-error-port-forwarding.injectable.tsx
+++ b/packages/core/src/renderer/port-forward/notify-error-port-forwarding.injectable.tsx
@@ -7,7 +7,6 @@
 import { Button } from "@freelensapp/button";
 import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import navigateToPortForwardsInjectable from "../../common/front-end-routing/routes/cluster/network/port-forwards/navigate-to-port-forwards.injectable";
 
 const notifyErrorPortForwardingInjectable = getInjectable({

--- a/packages/core/src/renderer/port-forward/port-forward-dialog.tsx
+++ b/packages/core/src/renderer/port-forward/port-forward-dialog.tsx
@@ -12,7 +12,7 @@ import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
-import React, { Component } from "react";
+import { Component } from "react";
 import { Checkbox } from "../components/checkbox";
 import { Dialog } from "../components/dialog";
 import { Input } from "../components/input";

--- a/packages/core/src/renderer/protocol-handler/bind-protocol-add-route-handlers/bind-protocol-add-route-handlers.tsx
+++ b/packages/core/src/renderer/protocol-handler/bind-protocol-add-route-handlers/bind-protocol-add-route-handlers.tsx
@@ -5,7 +5,6 @@
  */
 
 import assert from "node:assert";
-import React from "react";
 import { EXTENSION_NAME_MATCH, EXTENSION_PUBLISHER_MATCH, LensProtocolRouter } from "../../../common/protocol-handler";
 
 import type { ShowNotification } from "@freelensapp/notifications";

--- a/packages/core/src/renderer/protocol-handler/lens-protocol-router-renderer/lens-protocol-router-renderer.tsx
+++ b/packages/core/src/renderer/protocol-handler/lens-protocol-router-renderer/lens-protocol-router-renderer.tsx
@@ -5,7 +5,6 @@
  */
 
 import { ipcRenderer } from "electron";
-import React from "react";
 import * as proto from "../../../common/protocol-handler";
 import { foldAttemptResults, ProtocolHandlerInvalid, RouteAttempt } from "../../../common/protocol-handler";
 

--- a/packages/core/src/renderer/routes/extension-route-registrator.injectable.tsx
+++ b/packages/core/src/renderer/routes/extension-route-registrator.injectable.tsx
@@ -7,7 +7,6 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
 import { frontEndRouteInjectionToken } from "../../common/front-end-routing/front-end-route-injection-token";
 import { extensionRegistratorInjectionToken } from "../../extensions/extension-loader/extension-registrator-injection-token";
 import { SiblingsInTabLayout } from "../components/layout/siblings-in-tab-layout";

--- a/packages/core/src/vitest.setup.tsx
+++ b/packages/core/src/vitest.setup.tsx
@@ -8,7 +8,6 @@ import { TextDecoder as TextDecoderNode, TextEncoder } from "node:util";
 import { enableMapSet, setAutoFreeze } from "immer";
 import { configure } from "mobx";
 import freelensFetch from "node-fetch";
-import React from "react";
 
 import type * as K8slensTooltip from "@freelensapp/tooltip";
 

--- a/packages/infrastructure/typescript/config/base.json
+++ b/packages/infrastructure/typescript/config/base.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "jsx": "react",
-    "target": "ES2022",
+    "jsx": "react-jsx",
+    "target": "ESNext",
     "module": "ESNext",
-    "lib": ["ES2022", "DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["ES2025", "DOM", "DOM.Iterable"],
     "moduleResolution": "Bundler",
     "sourceMap": true,
     "strict": true,

--- a/packages/technical-features/messaging/computed-channel/src/computed-channel/computed-channel.test.tsx
+++ b/packages/technical-features/messaging/computed-channel/src/computed-channel/computed-channel.test.tsx
@@ -9,7 +9,6 @@ import { registerMobX } from "@ogre-tools/injectable-extension-for-mobx";
 import { act, RenderResult } from "@testing-library/react";
 import { computed, IComputedValue, IObservableValue, observable, reaction, runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
 import { computedChannelFeature } from "../feature";
 import { computedChannelInjectionToken, computedChannelObserverInjectionToken } from "./computed-channel.injectable";
 import {

--- a/packages/technical-features/react-application/src/react-application.test.tsx
+++ b/packages/technical-features/react-application/src/react-application.test.tsx
@@ -6,7 +6,6 @@ import { registerMobX } from "@ogre-tools/injectable-extension-for-mobx";
 import { registerInjectableReact } from "@ogre-tools/injectable-react";
 import { act, render } from "@testing-library/react";
 import { computed, IObservableValue, observable, runInAction } from "mobx";
-import React from "react";
 import { clusterFrameChildComponentInjectionToken } from "./cluster-frame/cluster-frame-child-component-injection-token";
 import { reactApplicationFeature } from "./feature";
 import { reactApplicationChildrenInjectionToken } from "./react-application/react-application-children-injection-token";

--- a/packages/technical-features/react-application/src/react-application/react-application-content.tsx
+++ b/packages/technical-features/react-application/src/react-application/react-application-content.tsx
@@ -1,7 +1,6 @@
 import { computedInjectManyInjectable } from "@ogre-tools/injectable-extension-for-mobx";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { Observer, observer } from "mobx-react";
-import React from "react";
 import {
   ReactApplicationChildren,
   reactApplicationChildrenInjectionToken,

--- a/packages/technical-features/react-application/src/react-application/react-application.tsx
+++ b/packages/technical-features/react-application/src/react-application/react-application.tsx
@@ -1,7 +1,6 @@
 import { computedInjectManyInjectable } from "@ogre-tools/injectable-extension-for-mobx";
 import { DiContextProvider } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
-import React from "react";
 import { ReactApplicationContent } from "./react-application-content";
 import {
   ReactApplicationHigherOrderComponent,

--- a/packages/technical-features/react-application/src/render-application/render-application-when-application-is-ready.injectable.tsx
+++ b/packages/technical-features/react-application/src/render-application/render-application-when-application-is-ready.injectable.tsx
@@ -1,6 +1,5 @@
 import { afterApplicationIsLoadedInjectionToken } from "@freelensapp/application";
 import { getInjectable } from "@ogre-tools/injectable";
-import React from "react";
 import { ReactApplication } from "../react-application/react-application";
 import renderInjectable from "./render.injectable";
 

--- a/packages/ui-components/button/src/button.tsx
+++ b/packages/ui-components/button/src/button.tsx
@@ -8,7 +8,7 @@ import "./button.scss";
 
 import { withTooltip } from "@freelensapp/tooltip";
 import { cssNames, type StrictReactNode } from "@freelensapp/utilities";
-import React, { type ButtonHTMLAttributes } from "react";
+import { type ButtonHTMLAttributes } from "react";
 
 export interface ButtonProps extends ButtonHTMLAttributes<any> {
   label?: StrictReactNode;

--- a/packages/ui-components/icon/src/icon.test.tsx
+++ b/packages/ui-components/icon/src/icon.test.tsx
@@ -12,7 +12,6 @@ import { createContainer } from "@ogre-tools/injectable";
 import { registerMobX } from "@ogre-tools/injectable-extension-for-mobx";
 import { registerInjectableReact } from "@ogre-tools/injectable-react";
 import { runInAction } from "mobx";
-import React from "react";
 import { Icon } from "./icon";
 
 import type { Logger } from "@freelensapp/logger";

--- a/packages/ui-components/tooltip/src/tooltip.test.tsx
+++ b/packages/ui-components/tooltip/src/tooltip.test.tsx
@@ -7,7 +7,6 @@
 import assert from "node:assert";
 import { render } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
-import React from "react";
 import { computeNextPosition, RectangleDimensions } from "./helpers";
 import { Tooltip, TooltipPosition } from "./tooltip";
 

--- a/packages/ui-components/tooltip/src/withTooltip.test.tsx
+++ b/packages/ui-components/tooltip/src/withTooltip.test.tsx
@@ -6,7 +6,6 @@
 
 import { RenderResult, render } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
-import React from "react";
 import { withTooltip } from "./withTooltip";
 
 import type { StrictReactNode } from "@freelensapp/utilities";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "target": "ESNext",
     "module": "ESNext",
     "lib": ["ES2025", "DOM", "DOM.Iterable"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "target": "ES2025",
+    "target": "ESNext",
     "module": "ESNext",
     "lib": ["ES2025", "DOM", "DOM.Iterable"],
     "moduleResolution": "Bundler",

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["tsconfig*.json", "packages/infrastructure/typescript/config/*.json"],
   "globalPassThroughEnv": [
     "APPLEID",
     "APPLEIDPASS",


### PR DESCRIPTION
Switch the JSX transform from the classic runtime (`jsx: "react"`) to the automatic runtime (`jsx: "react-jsx"`), finish the ES2025 tsconfig alignment, and make turbo's cache aware of the tsconfig files. Follow-up to #2228.

## Changes

1. **`tsconfig.json` → `target: ESNext`** (was `ES2025`). #2228 raised the base target to `ES2025`, but the esbuild version electron-vite builds with (0.25.x) only recognizes targets up to `es2024` and emitted `▲ [WARNING] Unrecognized target environment "ES2025"` during `pnpm build`. esbuild reads tsconfig `target` (it ignores `lib`), so `ESNext` — accepted by every esbuild version and `>=` the ES2025 lib floor — silences the warning. The real emit target is still governed by electron-vite's `build.target`; `lib` stays pinned at `ES2025`.

2. **`jsx: "react"` → `"react-jsx"`** in `tsconfig.json` and the shared package base (`packages/infrastructure/typescript/config/base.json`). `@vitejs/plugin-react` already used the automatic runtime for the actual transform, so this only aligns type-checking with the real build output — runtime behavior is unchanged.

3. **Remove ~398 now-unused `React` imports.** With the automatic runtime, `import React from "react"` used only to bring React into scope for classic JSX becomes dead and trips `noUnusedLocals`. Default-only imports are dropped; mixed imports keep their named bindings (`import React, { useState }` → `import { useState }`). 397 files touched.

4. **Finish ES2025 alignment for the shared package base**, which #2228 left on `ES2022` / `jsx: react`: `target: ESNext`, `lib: ES2025`, `jsx: react-jsx`.

5. **Make turbo cache aware of tsconfig.** Turbo hashes each task's own package files and does not follow tsconfig `extends`, and had no `globalDependencies`, so a change to the root `tsconfig.json` / `tsconfig.typecheck.json` or the shared base was invisible to the cache — a warm cache would replay stale output built with the previous compiler options. Added those config globs to `turbo.json` `globalDependencies`, and mirrored them in the `actions/cache` turborepo key across the workflows (knip, unit-tests, integration-tests, claude, claude-task).

6. **Keep `react` as a dependency of `packages/ui-components/button` for knip.** After the migration `button.tsx` imports only a type from react; its JSX compiles to `react/jsx-runtime`, which knip's `--production --strict` pass does not attribute to `react`, so knip flagged it as unused. It is a real runtime dependency, so it is added to the button package's knip `ignoreDependencies` (same pattern as electron in freelens/core).

## Verification

- `pnpm type:check` passes clean (0 errors).
- `pnpm knip:production` (the strict pass CI runs) passes clean; the `react` entry surfaces only as a development configuration hint, which is informational.
- `turbo run build --dry=json` confirms `tsconfig.json`, `tsconfig.typecheck.json`, and the shared base now appear in turbo's global cache inputs.
- Import cleanup applied only at the exact locations TypeScript flagged; files still referencing `React` are untouched. Changed `.ts`/`.tsx` files formatted with `biome check --write`.
