### PR TITLE
Verify app.asar in release and integration-tests workflows

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -274,6 +274,24 @@ jobs:
         env:
           npm_config_user_agent: pnpm
 
+      - name: Verify app.asar
+        shell: bash
+        run: |
+          set -eo pipefail
+          found=0
+          while IFS= read -r asar; do
+            tmpdir=$(mktemp -d)
+            echo "::group::asar extract ${asar}"
+            pnpm dlx @electron/asar extract "${asar}" "${tmpdir}"
+            echo "::endgroup::"
+            rm -rf "${tmpdir}"
+            found=$((found + 1))
+          done < <(find freelens/dist -type f -name app.asar)
+          if [[ "${found}" -eq 0 ]]; then
+            echo "No app.asar found under freelens/dist" >&2
+            exit 1
+          fi
+
       - name: Restore dev node_modules
         shell: bash
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -187,6 +187,13 @@ jobs:
         shell: bash
         run: pnpm install --color=always --prefer-offline --frozen-lockfile
 
+      - name: Install Electron binary
+        shell: bash
+        working-directory: freelens
+        env:
+          electron_config_cache: ${{ env.ELECTRON_CACHE }}
+        run: node "$(node -p "require.resolve('electron/install.js')")"
+
       - name: Build packages
         if: runner.os != 'Windows'
         run: pnpm --color=always --stream build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -319,6 +319,24 @@ jobs:
         env:
           DEBUG: electron-builder,electron-builder:*
 
+      - name: Verify app.asar
+        shell: bash
+        run: |
+          set -eo pipefail
+          found=0
+          while IFS= read -r asar; do
+            tmpdir=$(mktemp -d)
+            echo "::group::asar extract ${asar}"
+            pnpm dlx @electron/asar extract "${asar}" "${tmpdir}"
+            echo "::endgroup::"
+            rm -rf "${tmpdir}"
+            found=$((found + 1))
+          done < <(find freelens/dist -type f -name app.asar)
+          if [[ "${found}" -eq 0 ]]; then
+            echo "No app.asar found under freelens/dist" >&2
+            exit 1
+          fi
+
       - name: List unpacked binaries to sign (Windows)
         id: sign-list
         if: runner.os == 'Windows'


### PR DESCRIPTION
Backports two CI hardening steps from freelensapp/freelens-nightly-builds, which mirrors this repo's `release.yaml` to produce nightly builds.

- **Verify app.asar** (release.yaml, integration-tests.yaml): after packaging, extract every produced `app.asar` to a temp directory to confirm it is a valid, non-corrupt archive, and fail if none was produced. Catches broken packaging (e.g. a bad electron-builder run) before artifacts are signed, uploaded, or tested. Backported from freelensapp/freelens-nightly-builds#85.
- **Install Electron binary** (release.yaml): since the vite migration, Electron fetches its runtime binary lazily on first `require()` rather than at `pnpm install` time. The existing "Use Electron cache" step had nothing populating it deterministically, so electron-builder ended up fetching Electron at pack time instead. Download it once up front, matching the step already used in `unit-tests.yaml`, so the GitHub-cached `ELECTRON_CACHE` is warmed the same way.

## Test plan

- [x] `trunk check` passes on both modified workflow files
- [x] CI runs `release.yaml` / `integration-tests.yaml` successfully with the new steps
