### PR TITLE
Fix bootstrap crash from path-to-regexp v8 rejecting react-router v5 route schema

### DIFF
--- a/packages/core/src/common/protocol-handler/router.ts
+++ b/packages/core/src/common/protocol-handler/router.ts
@@ -55,6 +55,23 @@ export enum RouteAttempt {
   MISSING_EXTENSION = "no-extension",
 }
 
+/**
+ * Route schemas in this project are authored in the `react-router` v5 dialect
+ * (which still bundles `path-to-regexp` v1): optional parameters are written as
+ * `/:param?` and custom patterns are inlined as `/:param(regex)`. Since v8,
+ * `path-to-regexp` dropped inline patterns entirely and expresses an optional
+ * parameter as the group `{/:param}`, throwing on the v5 syntax.
+ *
+ * The schemas are shared verbatim with `react-router` for the actual matching,
+ * so they must stay in the v5 dialect. Convert them to the v8 dialect only here,
+ * at the boundary where the standalone `path-to-regexp` v8 validates them.
+ */
+function toPathToRegexpV8Syntax(urlSchema: string): string {
+  return urlSchema
+    .replace(/\([^)]*\)/g, "") // drop inline custom patterns (v8 has no equivalent)
+    .replace(/\/(:[A-Za-z0-9_]+)\?/g, "{/$1}"); // optional parameter -> optional group
+}
+
 export function foldAttemptResults(mainAttempt: RouteAttempt, rendererAttempt: RouteAttempt): RouteAttempt {
   switch (mainAttempt) {
     case RouteAttempt.MATCHED:
@@ -273,7 +290,7 @@ export abstract class LensProtocolRouter {
    * @param handler a function that will be called if a protocol path matches
    */
   public addInternalHandler(urlSchema: string, handler: RouteHandler): this {
-    pathToRegexp(urlSchema); // verify now that the schema is valid
+    pathToRegexp(toPathToRegexpV8Syntax(urlSchema)); // verify now that the schema is valid
     this.dependencies.logger.info(`${LensProtocolRouter.LoggingPrefix}: internal registering ${urlSchema}`);
     this.internalRoutes.set(urlSchema, handler);
 

--- a/packages/core/src/main/protocol-handler/__test__/router.test.ts
+++ b/packages/core/src/main/protocol-handler/__test__/router.test.ts
@@ -283,6 +283,15 @@ describe("protocol router tests", () => {
     expect(() => lpr.addInternalHandler("/:@", noop)).toThrowError();
   });
 
+  it("should accept a react-router v5 schema with an inline optional custom pattern", () => {
+    expect(() =>
+      lpr.addInternalHandler(
+        "/extensions/install/:LENS_INTERNAL_EXTENSION_PUBLISHER_MATCH(@[A-Za-z0-9_]+)?/:LENS_INTERNAL_EXTENSION_NAME_MATCH",
+        noop,
+      ),
+    ).not.toThrow();
+  });
+
   it("should call most exact handler with 3 found handlers", async () => {
     let called: any = 0;
 


### PR DESCRIPTION
Fixes #2238.

### Problem

The renderer crashed at bootstrap with `TypeError: Unexpected ( at index 60` because `LensProtocolRouter.addInternalHandler` validates route schemas with `path-to-regexp` v8, but the extension-install schema uses the react-router v5 dialect inline optional custom pattern `(@[A-Za-z0-9_]+)?` which v8 no longer supports.

### Fix

Convert the schema to the v8 dialect only at the validation boundary (mirroring the existing handling in `utilities/buildUrl.ts`). The schema stays in the v5 dialect for react-router's actual matching. Adds a regression test.

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`