### PR TITLE
Move electron from dependencies to devDependencies

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -167,6 +167,22 @@
       // only explicit react import here is type-only (ButtonHTMLAttributes),
       // so react looks unused even though it is a real runtime dependency.
       "ignoreDependencies": ["react"]
+    },
+
+    // electron is provided by the host app at runtime, so it is declared only
+    // as a devDependency; production code in these packages imports it, which
+    // the --production --strict pass reports as unlisted (same as freelens and
+    // packages/core above)
+    "packages/technical-features/application/application-for-electron-main": {
+      "ignoreDependencies": ["electron"]
+    },
+
+    "packages/technical-features/messaging/messaging-for-main": {
+      "ignoreDependencies": ["electron"]
+    },
+
+    "packages/technical-features/messaging/messaging-for-renderer": {
+      "ignoreDependencies": ["electron"]
     }
   },
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -8,11 +8,14 @@
   // written against the enabled globals never import it directly.
   "ignoreDependencies": ["vitest"],
 
-  // Note: the ignoreDependencies entries for electron (freelens, core) and
-  // @freelensapp/core (extensions) are only needed in --production --strict
-  // mode, where devDependency imports in production files count as unlisted.
-  // The development run reports them as removable configuration hints; hints
-  // are informational and do not fail the check.
+  // Note: several ignoreDependencies entries below (electron for freelens,
+  // core, and the technical-feature packages; @freelensapp/core for extensions;
+  // react for the button package) are only needed in --production --strict
+  // mode, where devDependency imports in production files count as unlisted. In
+  // the plain development run these entries look redundant, so knip would report
+  // them as removable configuration hints. Since a single config must satisfy
+  // both runs, the shared knip script runs with --no-config-hints (see the
+  // "knip" script in package.json) to silence those unavoidable hints.
 
   "workspaces": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "compute-versions": "pnpm -r compute-versions",
     "dev": "turbo run dev --parallel --",
     "fmt": "pnpm trunk fmt",
-    "knip": "pnpm dlx knip@6.24.0 --dependencies --no-gitignore",
+    "knip": "pnpm dlx knip@6.24.0 --dependencies --no-gitignore --no-config-hints",
     "knip:check": "pnpm \"/^knip:(development|production)\\$/\"",
     "knip:development": "pnpm knip",
     "knip:production": "pnpm knip --production --strict",

--- a/packages/technical-features/application/application-for-electron-main/package.json
+++ b/packages/technical-features/application/application-for-electron-main/package.json
@@ -27,13 +27,13 @@
     "@freelensapp/application": "workspace:^",
     "@freelensapp/feature-core": "workspace:^",
     "@freelensapp/run-many": "workspace:^",
-    "@ogre-tools/injectable": "^17.11.1",
-    "electron": "^42.7.0"
+    "@ogre-tools/injectable": "^17.11.1"
   },
   "devDependencies": {
     "@async-fn/vitest": "^1.8.0",
     "@freelensapp/typescript": "workspace:^",
     "@ogre-tools/test-utils": "^17.11.1",
+    "electron": "^42.7.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   },

--- a/packages/technical-features/messaging/messaging-for-main/package.json
+++ b/packages/technical-features/messaging/messaging-for-main/package.json
@@ -26,13 +26,13 @@
   "dependencies": {
     "@freelensapp/feature-core": "workspace:^",
     "@freelensapp/messaging": "workspace:^",
-    "@ogre-tools/injectable": "^17.11.1",
-    "electron": "^42.7.0"
+    "@ogre-tools/injectable": "^17.11.1"
   },
   "devDependencies": {
     "@async-fn/vitest": "^1.8.0",
     "@freelensapp/test-utils": "workspace:^",
     "@freelensapp/typescript": "workspace:^",
+    "electron": "^42.7.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   },

--- a/packages/technical-features/messaging/messaging-for-renderer/package.json
+++ b/packages/technical-features/messaging/messaging-for-renderer/package.json
@@ -27,13 +27,13 @@
     "@freelensapp/application": "workspace:^",
     "@freelensapp/feature-core": "workspace:^",
     "@freelensapp/messaging": "workspace:^",
-    "@ogre-tools/injectable": "^17.11.1",
-    "electron": "^42.7.0"
+    "@ogre-tools/injectable": "^17.11.1"
   },
   "devDependencies": {
     "@async-fn/vitest": "^1.8.0",
     "@freelensapp/typescript": "workspace:^",
     "@ogre-tools/injectable-extension-for-mobx": "^17.11.1",
+    "electron": "^42.7.0",
     "mobx": "^6.15.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1279,9 +1279,6 @@ importers:
       '@ogre-tools/injectable':
         specifier: ^17.11.1
         version: 17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(lodash@4.18.1)
-      electron:
-        specifier: ^42.7.0
-        version: 42.7.0
     devDependencies:
       '@async-fn/vitest':
         specifier: ^1.8.0
@@ -1292,6 +1289,9 @@ importers:
       '@ogre-tools/test-utils':
         specifier: ^17.11.1
         version: 17.11.1(lodash@4.18.1)
+      electron:
+        specifier: ^42.7.0
+        version: 42.7.0
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -1470,9 +1470,6 @@ importers:
       '@ogre-tools/injectable':
         specifier: ^17.11.1
         version: 17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(lodash@4.18.1)
-      electron:
-        specifier: ^42.7.0
-        version: 42.7.0
     devDependencies:
       '@async-fn/vitest':
         specifier: ^1.8.0
@@ -1483,6 +1480,9 @@ importers:
       '@freelensapp/typescript':
         specifier: workspace:^
         version: link:../../../infrastructure/typescript
+      electron:
+        specifier: ^42.7.0
+        version: 42.7.0
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -1504,9 +1504,6 @@ importers:
       '@ogre-tools/injectable':
         specifier: ^17.11.1
         version: 17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(lodash@4.18.1)
-      electron:
-        specifier: ^42.7.0
-        version: 42.7.0
     devDependencies:
       '@async-fn/vitest':
         specifier: ^1.8.0
@@ -1517,6 +1514,9 @@ importers:
       '@ogre-tools/injectable-extension-for-mobx':
         specifier: ^17.11.1
         version: 17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(@ogre-tools/injectable@17.11.1(@ogre-tools/fp@17.11.1(lodash@4.18.1))(lodash@4.18.1))(lodash@4.18.1)(mobx@6.15.0)
+      electron:
+        specifier: ^42.7.0
+        version: 42.7.0
       mobx:
         specifier: ^6.15.0
         version: 6.15.0


### PR DESCRIPTION
Moves `electron` from `dependencies` to `devDependencies` in the three technical-feature packages that only need it at build/test time (electron is provided by the host app at runtime, matching `packages/core` and `freelens`):

- @freelensapp/application-for-electron-main
- @freelensapp/messaging-for-main
- @freelensapp/messaging-for-renderer

A broader scan of other runtime deps found the remaining build/test tooling in `dependencies` to be intentional (published types, test-support re-exports, build tools).

Closes #2246

Generated with [Claude Code](https://claude.ai/code)