### PR TITLE
Make confirmation dialog and dialog selects follow the dark theme

### DIFF
--- a/packages/core/src/features/cluster/delete-dialog/__snapshots__/delete-cluster-dialog.test.tsx.snap
+++ b/packages/core/src/features/cluster/delete-dialog/__snapshots__/delete-cluster-dialog.test.tsx.snap
@@ -2376,7 +2376,7 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
           class="mt-4"
         >
           <div
-            class="Select theme-light ml-[1px] mr-[1px] css-b62m3t-container"
+            class="Select theme-lens ml-[1px] mr-[1px] css-b62m3t-container"
           >
             <span
               class="css-1f43avz-a11yText-A11yText"
@@ -3266,7 +3266,7 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
           class="mt-4"
         >
           <div
-            class="Select theme-light ml-[1px] mr-[1px] css-b62m3t-container"
+            class="Select theme-lens ml-[1px] mr-[1px] css-b62m3t-container"
           >
             <span
               class="css-1f43avz-a11yText-A11yText"

--- a/packages/core/src/renderer/components/config-resource-quotas/add-dialog/view.tsx
+++ b/packages/core/src/renderer/components/config-resource-quotas/add-dialog/view.tsx
@@ -182,7 +182,7 @@ class NonInjectedAddQuotaDialog extends React.Component<AddQuotaDialogProps & De
               id="namespace-input"
               value={this.namespace}
               placeholder="Namespace"
-              themeName="light"
+              themeName="lens"
               className="grow shrink-0 basis-0"
               onChange={(option) => (this.namespace = option?.value ?? null)}
             />
@@ -192,7 +192,7 @@ class NonInjectedAddQuotaDialog extends React.Component<AddQuotaDialogProps & De
               <Select
                 id="quota-input"
                 className="quota-select"
-                themeName="light"
+                themeName="lens"
                 placeholder="Select a quota.."
                 options={Object.keys(this.quotas).map((quota) => ({
                   value: quota,

--- a/packages/core/src/renderer/components/config-secrets/add-dialog/view.tsx
+++ b/packages/core/src/renderer/components/config-secrets/add-dialog/view.tsx
@@ -217,7 +217,7 @@ class NonInjectedAddSecretDialog extends React.Component<AddSecretDialogProps & 
                 <SubTitle title="Namespace" />
                 <NamespaceSelect
                   id="secret-namespace-input"
-                  themeName="light"
+                  themeName="lens"
                   value={namespace}
                   onChange={(option) => (this.namespace = option?.value ?? "default")}
                 />
@@ -226,7 +226,7 @@ class NonInjectedAddSecretDialog extends React.Component<AddSecretDialogProps & 
                 <SubTitle title="Secret type" />
                 <Select
                   id="secret-input"
-                  themeName="light"
+                  themeName="lens"
                   options={Object.keys(this.secretTemplate) as SecretType[]}
                   value={type}
                   onChange={(option) => (this.type = option?.value ?? SecretType.Opaque)}

--- a/packages/core/src/renderer/components/confirm-dialog/confirm-dialog.scss
+++ b/packages/core/src/renderer/components/confirm-dialog/confirm-dialog.scss
@@ -18,7 +18,8 @@
   > .dialog-content {
     max-width: 50vw;
     min-width: 45 * $unit;
-    background-color: white;
+    color: var(--dialogTextColor);
+    background-color: var(--dialogBackground);
     border-radius: $radius;
     line-height: 1.5;
   }
@@ -46,7 +47,7 @@
   }
 
   .confirm-buttons {
-    background: #f4f4f4;
+    background: var(--dialogFooterBackground);
     padding: $padding * 2.5;
     display: flex;
     justify-content: flex-end;

--- a/packages/core/src/renderer/components/delete-cluster-dialog/view.tsx
+++ b/packages/core/src/renderer/components/delete-cluster-dialog/view.tsx
@@ -116,7 +116,7 @@ class NonInjectedDeleteClusterDialog extends React.Component<Dependencies> {
               });
             }
           }}
-          themeName="light"
+          themeName="lens"
           className="ml-[1px] mr-[1px]"
           placeholder="Select new context..."
         />

--- a/packages/core/src/renderer/components/helm-releases/dialog/dialog.tsx
+++ b/packages/core/src/renderer/components/helm-releases/dialog/dialog.tsx
@@ -95,7 +95,7 @@ class NonInjectedReleaseRollbackDialog extends React.Component<ReleaseRollbackDi
         <b>Revision</b>
         <Select
           id="revision-input"
-          themeName="light"
+          themeName="lens"
           value={revision}
           options={this.revisionOptions.get()}
           onChange={(option) => this.revision.set(option?.value)}

--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
@@ -179,7 +179,7 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
         <SubTitle title="Cluster Role Reference" />
         <Select
           id="cluster-role-input"
-          themeName="light"
+          themeName="lens"
           placeholder="Select cluster role ..."
           isDisabled={this.isEditing}
           options={this.clusterRoleOptions}
@@ -240,7 +240,7 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
         <Select
           id="service-account-input"
           isMulti
-          themeName="light"
+          themeName="lens"
           placeholder="Select service accounts ..."
           options={this.serviceAccountOptions}
           formatOptionLabel={(option) => (

--- a/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
@@ -198,7 +198,7 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
         <SubTitle title="Namespace" />
         <NamespaceSelect
           id="dialog-namespace-input"
-          themeName="light"
+          themeName="lens"
           isDisabled={this.isEditing}
           value={this.bindingNamespace}
           autoFocus={!this.isEditing}
@@ -208,7 +208,7 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
         <SubTitle title="Role Reference" />
         <Select
           id="role-reference-input"
-          themeName="light"
+          themeName="lens"
           placeholder="Select role or cluster role ..."
           isDisabled={this.isEditing}
           options={this.roleRefOptions}
@@ -249,7 +249,7 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
         <Select
           id="service-account-input"
           isMulti
-          themeName="light"
+          themeName="lens"
           placeholder="Select service accounts ..."
           options={this.serviceAccountOptions}
           formatOptionLabel={(option) => (

--- a/packages/core/src/renderer/components/user-management/roles/add-dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/roles/add-dialog/view.tsx
@@ -75,7 +75,7 @@ class NonInjectedAddRoleDialog extends React.Component<AddRoleDialogProps & Depe
             <SubTitle title="Namespace" />
             <NamespaceSelect
               id="add-dialog-namespace-select-input"
-              themeName="light"
+              themeName="lens"
               value={state.namespace.get()}
               onChange={(option) => state.namespace.set(option?.value ?? "default")}
             />

--- a/packages/core/src/renderer/components/user-management/service-accounts/create-dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/service-accounts/create-dialog/view.tsx
@@ -82,7 +82,7 @@ class NonInjectedCreateServiceAccountDialog extends React.Component<CreateServic
             <SubTitle title="Namespace" />
             <NamespaceSelect
               id="create-dialog-namespace-select-input"
-              themeName="light"
+              themeName="lens"
               value={state.namespace.get()}
               onChange={(option) => state.namespace.set(option?.value ?? "default")}
             />


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #2256

**Description of changes:**

- `ConfirmDialog` used hardcoded light colors (`white` content background and `#f4f4f4` footer), so the delete confirmation rendered as a white box in the dark theme. Replaced them with the `--dialogBackground` / `--dialogFooterBackground` / `--dialogTextColor` theme variables (the same ones the Wizard dialogs use, fixed for dark in #2196).
- Several dialogs forced their `Select` controls to `themeName="light"`. `select.scss` only styles `.theme-light` and `.theme-lens` (there is no `.theme-dark`), so `"light"` always renders a white control regardless of the active theme. Switched these to `themeName="lens"`, which reads the `--inputControl*` variables and follows both the light and dark themes (matching the newer preferences/metrics selects).

Affected dialogs: delete confirmation, create secret (namespace + secret type), helm release rollback (revision), cluster role binding, role binding, add role, create service account, add resource quota, and delete cluster.

**Validation:**

- `biome check` (TSX) and `trunk check` (SCSS) pass.
- Verified live in the dev app: the Create Secret selects and the Delete confirmation dialog now render dark, matching the theme.