### PR TITLE
Mock selfsigned in core unit tests to avoid worker teardown crash

### DIFF
--- a/packages/core/__mocks__/selfsigned.ts
+++ b/packages/core/__mocks__/selfsigned.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+// `selfsigned` v5 exposes an async, native WebCrypto based `generate()` that
+// runs an RSA key generation job on the libuv threadpool. When a Vitest worker
+// (core runs on `pool: "threads"`) is torn down at end of a test file while
+// such a job is still in flight, Node aborts the worker with
+// `Assertion failed: try_catch.CanContinue()` (exit code 129) in
+// crypto_keygen.h. Because the startup runnable `setup-lens-proxy-certificate`
+// fires this keygen for every test that bootstraps the full main-app DI, and
+// the failing shard depends on how files are distributed, this surfaces as a
+// non-deterministic (flaky) crash.
+//
+// This mock replaces the native keygen with a static certificate resolved
+// synchronously, so no real RSA key is ever generated inside a worker. Tests
+// that assert on certificate contents override the certificate injectables and
+// never observe these placeholder values.
+
+import type { SelfSignedCert } from "../src/common/certificate/certificate";
+
+const staticCert: SelfSignedCert = {
+  private: "-----BEGIN PRIVATE KEY-----\nMOCK-SELFSIGNED-PRIVATE-KEY\n-----END PRIVATE KEY-----",
+  public: "-----BEGIN PUBLIC KEY-----\nMOCK-SELFSIGNED-PUBLIC-KEY\n-----END PUBLIC KEY-----",
+  cert: "-----BEGIN CERTIFICATE-----\nMOCK-SELFSIGNED-CERTIFICATE\n-----END CERTIFICATE-----",
+};
+
+export const generate = async (): Promise<SelfSignedCert> => staticCert;
+
+export default { generate };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,10 @@ const setupCandidates = ["src/vitest.setup.tsx", "src/vitest-after-env.setup.ts"
 const coreDir = join(root, "packages/core");
 const coreMockAliases = {
   electron: join(coreDir, "__mocks__/electron.ts"),
+  // selfsigned's native RSA keygen can crash a threads-pool worker at teardown
+  // (Assertion failed: try_catch.CanContinue()); the mock returns a static
+  // certificate so no real key is generated inside a Vitest worker.
+  selfsigned: join(coreDir, "__mocks__/selfsigned.ts"),
   "monaco-editor": join(coreDir, "__mocks__/monaco-editor.ts"),
   "node-pty": join(coreDir, "__mocks__/node-pty.ts"),
   "react-virtualized-auto-sizer": join(coreDir, "__mocks__/react-virtualized-auto-sizer.tsx"),


### PR DESCRIPTION
## Problem

Core unit-test shards intermittently crash with exit code 129 and a native Node.js abort, e.g. [run 29817111074 / shard 1/4](https://github.com/freelensapp/freelens/actions/runs/29817111074/job/88590924964):

```
node[...]: ...node::crypto::KeyGenJob<...RsaKeyGenTraits>::ToResult(...) at ../src/crypto/crypto_keygen.h:142
Assertion failed: try_catch.CanContinue()
 ...
 node::worker::Worker::Run()
```

This is not a test assertion failure — every test passes — but a native crash in Node's RSA key generation running on a `worker_threads` worker.

## Root cause

`selfsigned`'s `generate()` runs an asynchronous RSA-2048 key generation job on the libuv threadpool. The startup runnable `setup-lens-proxy-certificate` (`beforeApplicationIsLoadingInjectionToken`) fires it for every test that bootstraps the full main-app DI. Core runs on `pool: "threads"`; when a worker is torn down at the end of a test file while such a keygen job is still in flight, Node aborts the worker with `Assertion failed: try_catch.CanContinue()` (exit 129).

Because which shard runs the triggering file depends on how test files are distributed across shards, this surfaced as a non-deterministic (flaky) crash. It is unrelated to any specific PR (it was observed on the Renovate pnpm bump PR #2260, but the cause is in the test harness).

## Fix

Add a core `__mocks__` alias for `selfsigned` whose `generate()` returns a static certificate synchronously, so no real RSA key is ever generated inside a Vitest worker. Wired the same way as the existing `electron` / `monaco-editor` / `node-pty` core mock aliases in `vitest.config.ts`.

Tests that assert on certificate contents (`session-certificate-verifier`, `kube-api-upgrade-request`) already override the certificate injectables, so they never observe the placeholder values.

Considered switching core to `pool: "forks"` (the crash is specific to `worker_threads`), but that costs ~8% suite time and still wastes time on real keygen; mocking removes the keygen at the source.

## Validation

- `session-certificate-verifier` + `kube-api-upgrade-request` — pass
- `sync-box` + `app-paths` (full main-app bootstrap that fires the keygen runnable) — pass
- Confirmed the `selfsigned` import resolves to the mock inside the core project
- `biome check` clean