### PR TITLE
Vendor path-to-regexp v1 into @freelensapp/routing and drop the external dependency

### DIFF
--- a/freelens/package.json
+++ b/freelens/package.json
@@ -94,7 +94,6 @@
     "node-fetch": "^3.3.2",
     "node-pty": "1.2.0-beta.14",
     "p-limit": "^7.3.0",
-    "path-to-regexp": "^1.9.0",
     "pnpm": "^11.15.0",
     "proper-lockfile": "^4.1.2",
     "react": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -138,7 +138,6 @@
     "monaco-editor": "^0.55.1",
     "node-fetch": "^3.3.2",
     "node-pty": "1.2.0-beta.14",
-    "path-to-regexp": "^1.9.0",
     "pnpm": "^11.15.0",
     "proper-lockfile": "^4.1.2",
     "randomcolor": "^0.6.2",

--- a/packages/core/src/common/protocol-handler/router.ts
+++ b/packages/core/src/common/protocol-handler/router.ts
@@ -4,11 +4,10 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { matchPath } from "@freelensapp/routing";
+import { compileRoutePath, matchPath } from "@freelensapp/routing";
 import { isDefined, iter } from "@freelensapp/utilities";
 import { ipcRenderer } from "electron";
 import { when } from "mobx";
-import pathToRegexp from "path-to-regexp";
 import { RoutingError, RoutingErrorType } from "./error";
 
 import type { Logger } from "@freelensapp/logger";
@@ -275,7 +274,7 @@ export abstract class LensProtocolRouter {
     // Route schemas are authored in the `react-router` v5 dialect (`/:param?`
     // optionals and inline `/:param(regex)` patterns) — the very dialect
     // `path-to-regexp` v1 parses natively, so validate the schema as-is here.
-    pathToRegexp(urlSchema); // verify now that the schema is valid
+    compileRoutePath(urlSchema); // verify now that the schema is valid
     this.dependencies.logger.info(`${LensProtocolRouter.LoggingPrefix}: internal registering ${urlSchema}`);
     this.internalRoutes.set(urlSchema, handler);
 

--- a/packages/generate-license/src/index.ts
+++ b/packages/generate-license/src/index.ts
@@ -136,6 +136,15 @@ async function main() {
       author: "James Ide",
       licenseText: spdxLicenseList.MIT.licenseText,
     },
+    // `path-to-regexp` v1.9.0 is vendored as TypeScript into
+    // `packages/routing/src/vendor/path-to-regexp.ts` (see #2261), so it is no
+    // longer an npm dependency and must be listed here to keep its copyright in
+    // the generated license manifest.
+    "path-to-regexp:MIT": {
+      name: "path-to-regexp",
+      author: "Blake Embrey (hello@blakeembrey.com)",
+      licenseText: spdxLicenseList.MIT.licenseText,
+    },
   };
 
   const npmDependencies = await getDependenciesFromPnpmApi(prod);

--- a/packages/routing/index.ts
+++ b/packages/routing/index.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+export { compileRoutePath } from "./src/compile-route-path";
 export { routingFeature } from "./src/feature";
 export { historyInjectionToken } from "./src/history.injectable";
 export { toHistoryV4 } from "./src/history-compat";

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -25,8 +25,7 @@
     "@ogre-tools/fp": "^17.11.1",
     "@ogre-tools/injectable": "^17.11.1",
     "history": "^5.3.0",
-    "mobx": "^6.15.0",
-    "path-to-regexp": "^1.9.0"
+    "mobx": "^6.15.0"
   },
   "devDependencies": {
     "@freelensapp/typescript": "workspace:^",

--- a/packages/routing/src/compile-route-path.ts
+++ b/packages/routing/src/compile-route-path.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { pathToRegexp } from "./vendor/path-to-regexp";
+
+import type { RegExpOptions } from "./vendor/path-to-regexp";
+
+/**
+ * Compile a route-path schema (authored in the `react-router` v5 /
+ * `path-to-regexp` v1 dialect) into a matching regular expression.
+ *
+ * This is the public, purpose-named entry point over the vendored
+ * `path-to-regexp` v1 engine, so the raw engine stays encapsulated in
+ * `@freelensapp/routing`. Consumers use it to validate a schema (it throws on
+ * an invalid pattern) without depending on `path-to-regexp` directly.
+ *
+ * @param path a route-path schema in the v1 dialect (`/:param?` optionals and
+ *   inline `/:param(regex)` patterns are supported)
+ * @param options `path-to-regexp` v1 matching options
+ * @returns the compiled regular expression
+ */
+export function compileRoutePath(path: string, options?: RegExpOptions): RegExp {
+  return pathToRegexp(path, options);
+}

--- a/packages/routing/src/match-path.ts
+++ b/packages/routing/src/match-path.ts
@@ -4,7 +4,9 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import pathToRegexp from "path-to-regexp";
+import { pathToRegexp } from "./vendor/path-to-regexp";
+
+import type { Key, RegExpOptions } from "./vendor/path-to-regexp";
 
 /**
  * In-house port of `react-router` v5's `matchPath`.
@@ -48,14 +50,14 @@ export interface Match<Params extends { [K in keyof Params]?: string } = {}> {
 
 interface CompiledPath {
   regexp: RegExp;
-  keys: pathToRegexp.Key[];
+  keys: Key[];
 }
 
 const cache: Record<string, Record<string, CompiledPath>> = {};
 const cacheLimit = 10000;
 let cacheCount = 0;
 
-function compilePath(path: string, options: pathToRegexp.RegExpOptions): CompiledPath {
+function compilePath(path: string, options: RegExpOptions): CompiledPath {
   const cacheKey = `${options.end}${options.strict}${options.sensitive}`;
   const pathCache = cache[cacheKey] || (cache[cacheKey] = {});
 
@@ -65,7 +67,7 @@ function compilePath(path: string, options: pathToRegexp.RegExpOptions): Compile
     return cached;
   }
 
-  const keys: pathToRegexp.Key[] = [];
+  const keys: Key[] = [];
   const regexp = pathToRegexp(path, keys, options);
   const result: CompiledPath = { regexp, keys };
 

--- a/packages/routing/src/vendor/path-to-regexp.ts
+++ b/packages/routing/src/vendor/path-to-regexp.ts
@@ -1,0 +1,339 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+/**
+ * Vendored port of `path-to-regexp` v1.9.0 (the last release of the 1.x line,
+ * which carries the security-patched ReDoS fix GHSA-9wv6-86v2-598j).
+ *
+ * Upstream: https://github.com/pillarjs/path-to-regexp/blob/v1.9.0/index.js
+ * License:  MIT (c) 2014 Blake Embrey (hello@blakeembrey.com)
+ *
+ * `path-to-regexp` v1 is the engine `react-router` 5 bundled internally and the
+ * dialect Freelens' route schemas are authored against (`/:param?` optionals and
+ * inline `/:param(regex)` patterns, neither of which `path-to-regexp` v8 can
+ * express). Rather than depend on an unmaintained package — and to close the
+ * whole class of Vite version-collision bugs where a single bare `path-to-regexp`
+ * specifier collapsed to a v8 that then crashed on v1-dialect paths — the source
+ * is vendored here so the v1 dialect stays the routing contract and we own the
+ * code. See `docs/v2-routing-modernization.md`.
+ *
+ * Deliberately faithful to upstream so it can be diffed against v1.9.0. Only the
+ * following changes were made:
+ *   - converted to TypeScript / ESM with named exports;
+ *   - `require('isarray')` replaced by the native `Array.isArray`;
+ *   - the unused path-*building* helpers were dropped (`compile`,
+ *     `tokensToFunction`, `encodeURIComponentPretty`, `encodeAsterisk`) — this
+ *     port is only used for matching (string -> RegExp), never for compiling a
+ *     path back from params.
+ */
+
+/**
+ * The main path matching regexp utility.
+ */
+const PATH_REGEXP = new RegExp(
+  [
+    // Match escaped characters that would otherwise appear in future matches.
+    // This allows the user to escape special characters that won't transform.
+    "(\\\\.)",
+    // Match Express-style parameters and un-named parameters with a prefix
+    // and optional suffixes. Matches appear as:
+    //
+    // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?", undefined]
+    // "/route(\\d+)"  => [undefined, undefined, undefined, "\d+", undefined, undefined]
+    // "/*"            => ["/", undefined, undefined, undefined, undefined, "*"]
+    "([\\/.])?(?:(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))",
+  ].join("|"),
+  "g",
+);
+
+export interface RegExpOptions {
+  /** When `true` the route will be case sensitive. (default: `false`) */
+  sensitive?: boolean;
+  /** When `false` the trailing slash is optional. (default: `false`) */
+  strict?: boolean;
+  /** When `false` the path will match at the beginning. (default: `true`) */
+  end?: boolean;
+  /** Sets the final character for non-ending optimistic matches. (default: `/`) */
+  delimiter?: string;
+}
+
+export interface ParseOptions {
+  /** Set the default delimiter for repeat parameters. (default: `'/'`) */
+  delimiter?: string;
+}
+
+export interface Key {
+  name: string | number;
+  prefix: string | null;
+  delimiter: string | null;
+  optional: boolean;
+  repeat: boolean;
+  pattern: string | null;
+  partial: boolean;
+  asterisk: boolean;
+}
+
+export type Token = string | Key;
+export type Path = string | RegExp | Array<string | RegExp>;
+
+export interface PathRegExp extends RegExp {
+  /** The keys found in the path, populated during compilation. */
+  keys: Key[];
+}
+
+/**
+ * Parse a string for the raw tokens.
+ */
+export function parse(str: string, options?: ParseOptions): Token[] {
+  const tokens: Token[] = [];
+  let key = 0;
+  let index = 0;
+  let path = "";
+  const defaultDelimiter = (options && options.delimiter) || "/";
+  let res: RegExpExecArray | null;
+
+  while ((res = PATH_REGEXP.exec(str)) != null) {
+    const m = res[0];
+    const escaped = res[1];
+    const offset = res.index;
+    path += str.slice(index, offset);
+    index = offset + m.length;
+
+    // Ignore already escaped sequences.
+    if (escaped) {
+      path += escaped[1];
+      continue;
+    }
+
+    const next = str[index];
+    const prefix = res[2];
+    const name = res[3];
+    const capture = res[4];
+    const group = res[5];
+    const modifier = res[6];
+    const asterisk = res[7];
+
+    // Push the current path onto the tokens.
+    if (path) {
+      tokens.push(path);
+      path = "";
+    }
+
+    const partial = prefix != null && next != null && next !== prefix;
+    const repeat = modifier === "+" || modifier === "*";
+    const optional = modifier === "?" || modifier === "*";
+    const delimiter = prefix || defaultDelimiter;
+    const pattern = capture || group;
+    const prevText =
+      prefix || (typeof tokens[tokens.length - 1] === "string" ? (tokens[tokens.length - 1] as string) : "");
+
+    tokens.push({
+      name: name || key++,
+      prefix: prefix || "",
+      delimiter: delimiter,
+      optional: optional,
+      repeat: repeat,
+      partial: partial,
+      asterisk: Boolean(asterisk),
+      pattern: pattern ? escapeGroup(pattern) : asterisk ? ".*" : restrictBacktrack(delimiter, prevText),
+    });
+  }
+
+  // Match any characters still remaining.
+  if (index < str.length) {
+    path += str.substr(index);
+  }
+
+  // If the path exists, push it onto the end.
+  if (path) {
+    tokens.push(path);
+  }
+
+  return tokens;
+}
+
+function restrictBacktrack(delimiter: string, prevText: string): string {
+  if (!prevText || prevText.indexOf(delimiter) > -1) {
+    return "[^" + escapeString(delimiter) + "]+?";
+  }
+
+  return escapeString(prevText) + "|(?:(?!" + escapeString(prevText) + ")[^" + escapeString(delimiter) + "])+?";
+}
+
+/**
+ * Escape a regular expression string.
+ */
+function escapeString(str: string): string {
+  return str.replace(/([.+*?=^!:${}()[\]|\/\\])/g, "\\$1");
+}
+
+/**
+ * Escape the capturing group by escaping special characters and meaning.
+ */
+function escapeGroup(group: string): string {
+  return group.replace(/([=!:$\/()])/g, "\\$1");
+}
+
+/**
+ * Attach the keys as a property of the regexp.
+ */
+function attachKeys(re: RegExp, keys: Key[]): PathRegExp {
+  (re as PathRegExp).keys = keys;
+  return re as PathRegExp;
+}
+
+/**
+ * Get the flags for a regexp from the options.
+ */
+function flags(options?: RegExpOptions): string {
+  return options && options.sensitive ? "" : "i";
+}
+
+/**
+ * Pull out keys from a regexp.
+ */
+function regexpToRegexp(path: RegExp, keys: Key[]): PathRegExp {
+  // Use a negative lookahead to match only capturing groups.
+  const groups = path.source.match(/\((?!\?)/g);
+
+  if (groups) {
+    for (let i = 0; i < groups.length; i++) {
+      keys.push({
+        name: i,
+        prefix: null,
+        delimiter: null,
+        optional: false,
+        repeat: false,
+        partial: false,
+        asterisk: false,
+        pattern: null,
+      });
+    }
+  }
+
+  return attachKeys(path, keys);
+}
+
+/**
+ * Transform an array into a regexp.
+ */
+function arrayToRegexp(path: Array<string | RegExp>, keys: Key[], options?: RegExpOptions & ParseOptions): PathRegExp {
+  const parts: string[] = [];
+
+  for (let i = 0; i < path.length; i++) {
+    parts.push(pathToRegexp(path[i], keys, options).source);
+  }
+
+  const regexp = new RegExp("(?:" + parts.join("|") + ")", flags(options));
+
+  return attachKeys(regexp, keys);
+}
+
+/**
+ * Create a path regexp from string input.
+ */
+function stringToRegexp(path: string, keys: Key[], options?: RegExpOptions & ParseOptions): PathRegExp {
+  return tokensToRegExp(parse(path, options), keys, options);
+}
+
+/**
+ * Expose a function for taking tokens and returning a RegExp.
+ */
+export function tokensToRegExp(tokens: Token[], keys?: Key[] | RegExpOptions, options?: RegExpOptions): PathRegExp {
+  if (!Array.isArray(keys)) {
+    options = (keys || options) as RegExpOptions | undefined;
+    keys = [];
+  }
+
+  options = options || {};
+
+  const strict = options.strict;
+  const end = options.end !== false;
+  let route = "";
+
+  // Iterate over the tokens and create our regexp string.
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (typeof token === "string") {
+      route += escapeString(token);
+    } else {
+      const prefix = escapeString(token.prefix ?? "");
+      let capture = "(?:" + token.pattern + ")";
+
+      keys.push(token);
+
+      if (token.repeat) {
+        capture += "(?:" + prefix + capture + ")*";
+      }
+
+      if (token.optional) {
+        if (!token.partial) {
+          capture = "(?:" + prefix + "(" + capture + "))?";
+        } else {
+          capture = prefix + "(" + capture + ")?";
+        }
+      } else {
+        capture = prefix + "(" + capture + ")";
+      }
+
+      route += capture;
+    }
+  }
+
+  const delimiter = escapeString(options.delimiter || "/");
+  const endsWithDelimiter = route.slice(-delimiter.length) === delimiter;
+
+  // In non-strict mode we allow a slash at the end of match. If the path to
+  // match already ends with a slash, we remove it for consistency. The slash
+  // is valid at the end of a path match, not in the middle. This is important
+  // in non-ending mode, where "/test/" shouldn't match "/test//route".
+  if (!strict) {
+    route = (endsWithDelimiter ? route.slice(0, -delimiter.length) : route) + "(?:" + delimiter + "(?=$))?";
+  }
+
+  if (end) {
+    route += "$";
+  } else {
+    // In non-ending mode, we need the capturing groups to match as much as
+    // possible by using a positive lookahead to the end or next path segment.
+    route += strict && endsWithDelimiter ? "" : "(?=" + delimiter + "|$)";
+  }
+
+  return attachKeys(new RegExp("^" + route, flags(options)), keys);
+}
+
+/**
+ * Normalize the given path string, returning a regular expression.
+ *
+ * An empty array can be passed in for the keys, which will hold the
+ * placeholder key descriptions. For example, using `/user/:id`, `keys` will
+ * contain `[{ name: 'id', delimiter: '/', optional: false, repeat: false }]`.
+ */
+export function pathToRegexp(path: Path, options?: RegExpOptions & ParseOptions): PathRegExp;
+export function pathToRegexp(path: Path, keys?: Key[], options?: RegExpOptions & ParseOptions): PathRegExp;
+export function pathToRegexp(
+  path: Path,
+  keys?: Key[] | (RegExpOptions & ParseOptions),
+  options?: RegExpOptions & ParseOptions,
+): PathRegExp {
+  if (!Array.isArray(keys)) {
+    options = (keys || options) as (RegExpOptions & ParseOptions) | undefined;
+    keys = [];
+  }
+
+  options = options || {};
+
+  if (path instanceof RegExp) {
+    return regexpToRegexp(path, keys);
+  }
+
+  if (Array.isArray(path)) {
+    return arrayToRegexp(path, keys, options);
+  }
+
+  return stringToRegexp(path, keys, options);
+}

--- a/packages/utility-features/utilities/package.json
+++ b/packages/utility-features/utilities/package.json
@@ -29,7 +29,6 @@
     "mobx": "^6.15.0",
     "moment": "^2.30.1",
     "p-limit": "^7.3.0",
-    "path-to-regexp": "^1.9.0",
     "react": "catalog:",
     "semver": "^7.8.5",
     "tar": "^7.5.19",

--- a/packages/utility-features/utilities/src/buildUrl.ts
+++ b/packages/utility-features/utilities/src/buildUrl.ts
@@ -4,7 +4,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import pathToRegexp from "path-to-regexp";
 import { isDefined } from "./type-narrowing";
 
 import type { RouteProps } from "react-router";
@@ -21,38 +20,30 @@ export interface URLParams<P extends object = {}, Q extends object = {}> {
 
 /**
  * Route paths in this project are authored in the `react-router` v5 dialect
- * (`path-to-regexp` v1), where an optional parameter is written as `/:param?`.
- * The same engine matches them (`@freelensapp/routing`'s `matchPath`), so URLs
- * are built from the very same dialect here — no syntax translation needed.
+ * (`path-to-regexp` v1), where a `/`-prefixed parameter is written as `/:param`
+ * and an optional one as `/:param?`. Front-end route paths never use inline
+ * `(regex)` patterns (those live only in protocol/extension schemas, which are
+ * matched, not built), so a small regex substitution over `/:name` and
+ * `/:name?` is enough to build URLs — no `path-to-regexp` dependency needed.
  *
  * Segments are substituted verbatim (identity encoding), preserving the
- * behavior the project relied on under `path-to-regexp` v6. `pathToRegexp.compile`
- * would force `encodeURIComponent`, so the path is built from parsed tokens
- * directly to keep already-formed segments intact.
+ * behavior the project relied on: already-formed segments are kept intact
+ * instead of being `encodeURIComponent`-escaped.
  */
 function fillPath(path: string, params: Record<string, unknown>): string {
-  let result = "";
-
-  for (const token of pathToRegexp.parse(path)) {
-    if (typeof token === "string") {
-      result += token;
-      continue;
-    }
-
-    const value = params[token.name];
+  return path.replace(/\/:(\w+)(\?)?/g, (_match, name: string, optional: string | undefined) => {
+    const value = params[name];
 
     if (value == null) {
-      if (token.optional) {
-        continue;
+      if (optional) {
+        return "";
       }
 
-      throw new TypeError(`Expected "${token.name}" to be defined`);
+      throw new TypeError(`Expected "${name}" to be defined`);
     }
 
-    result += token.prefix + String(value);
-  }
-
-  return result;
+    return `/${String(value)}`;
+  });
 }
 
 export function buildURL<P extends object = {}, Q extends object = {}>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,6 @@ importers:
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
-      path-to-regexp:
-        specifier: ^1.9.0
-        version: 1.9.0
       pnpm:
         specifier: ^11.15.0
         version: 11.15.0
@@ -656,9 +653,6 @@ importers:
       node-pty:
         specifier: 1.2.0-beta.14
         version: 1.2.0-beta.14
-      path-to-regexp:
-        specifier: ^1.9.0
-        version: 1.9.0
       pnpm:
         specifier: ^11.15.0
         version: 11.15.0
@@ -1211,9 +1205,6 @@ importers:
       mobx:
         specifier: ^6.15.0
         version: 6.15.0
-      path-to-regexp:
-        specifier: ^1.9.0
-        version: 1.9.0
     devDependencies:
       '@freelensapp/typescript':
         specifier: workspace:^
@@ -2206,9 +2197,6 @@ importers:
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
-      path-to-regexp:
-        specifier: ^1.9.0
-        version: 1.9.0
       react:
         specifier: 'catalog:'
         version: 18.3.1


### PR DESCRIPTION
Vendors a faithful TS/ESM port of `path-to-regexp` v1.9.0 into `packages/routing/src/vendor/path-to-regexp.ts` so the v1 dialect stays the routing contract and the code is owned in-repo. `match-path` uses the vendored engine, a purpose-named `compileRoutePath` wrapper is exported, the protocol-handler validates via it, and `buildUrl`'s `fillPath` is rewritten as a small regex substitution. `path-to-regexp` is removed as a direct dependency of `routing`, `core`, `utilities`, and `freelens`.

This is PR 3 of the Phase 2 routing-modernization sequence.

Part of #2261.

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`