### PR TITLE
Surface the reason when Prometheus metrics are unavailable

### DIFF
--- a/packages/core/src/common/k8s-api/endpoints/metrics.api.ts
+++ b/packages/core/src/common/k8s-api/endpoints/metrics.api.ts
@@ -16,6 +16,14 @@ export interface MetricData {
   };
 }
 
+export type MetricsErrorReason = "not-found" | "access-denied" | "error";
+
+export interface MetricsErrorInfo {
+  reason: MetricsErrorReason;
+  message: string;
+  status?: number;
+}
+
 export interface MetricResult {
   metric: {
     [name: string]: string | undefined;

--- a/packages/core/src/main/cluster/prometheus-handler/prometheus-handler.ts
+++ b/packages/core/src/main/cluster/prometheus-handler/prometheus-handler.ts
@@ -16,6 +16,8 @@ import type { ClusterPrometheusPreferences } from "../../../common/cluster-types
 import type { GetPrometheusProviderByKind } from "../../prometheus/get-by-kind.injectable";
 import type { LoadProxyKubeconfig } from "../load-proxy-kubeconfig.injectable";
 
+export const NO_PROMETHEUS_SERVICE_FOUND_MESSAGE = "No Prometheus service found";
+
 export interface PrometheusDetails {
   prometheusPath: string;
   provider: PrometheusProvider;
@@ -112,7 +114,7 @@ export const createClusterPrometheusHandler = (...args: [Dependencies, Cluster])
       }
     }
 
-    throw new Error("No Prometheus service found", { cause: errors });
+    throw new Error(NO_PROMETHEUS_SERVICE_FOUND_MESSAGE, { cause: errors });
   };
 
   const getPrometheusDetails: ClusterPrometheusHandler["getPrometheusDetails"] = async () => {

--- a/packages/core/src/main/routes/metrics/add-metrics-route.injectable.test.ts
+++ b/packages/core/src/main/routes/metrics/add-metrics-route.injectable.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import asyncFn from "@async-fn/vitest";
+import { loggerInjectionToken } from "@freelensapp/logger";
+import { NO_PROMETHEUS_SERVICE_FOUND_MESSAGE } from "../../cluster/prometheus-handler/prometheus-handler";
+import prometheusHandlerInjectable from "../../cluster/prometheus-handler/prometheus-handler.injectable";
+import getMetricsInjectable from "../../get-metrics.injectable";
+import { getDiForUnitTesting } from "../../getDiForUnitTesting";
+import addMetricsRouteInjectable from "./add-metrics-route.injectable";
+
+import type { Logger } from "@freelensapp/logger";
+
+import type { AsyncFnMock } from "@async-fn/vitest";
+import type { DiContainer } from "@ogre-tools/injectable";
+import type { Mocked } from "vitest";
+
+import type { Cluster } from "../../../common/cluster/cluster";
+import type { PrometheusDetails } from "../../cluster/prometheus-handler/prometheus-handler";
+import type { GetMetrics } from "../../get-metrics.injectable";
+
+class ApiExceptionStub extends Error {
+  constructor(
+    public code: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+describe("add-metrics-route", () => {
+  let di: DiContainer;
+  let clusterStub: Cluster;
+  let loggerMock: Mocked<Logger>;
+  let getPrometheusDetailsMock: AsyncFnMock<() => Promise<PrometheusDetails>>;
+  let getMetricsMock: AsyncFnMock<GetMetrics>;
+  let callRoute: (payload: unknown) => Promise<unknown>;
+
+  beforeEach(() => {
+    di = getDiForUnitTesting();
+
+    loggerMock = {
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      silly: vi.fn(),
+    };
+    di.override(loggerInjectionToken, () => loggerMock);
+
+    getPrometheusDetailsMock = asyncFn();
+    di.override(prometheusHandlerInjectable, () => ({
+      setupPrometheus: () => {},
+      getPrometheusDetails: getPrometheusDetailsMock,
+    }));
+
+    getMetricsMock = asyncFn();
+    di.override(getMetricsInjectable, () => getMetricsMock);
+
+    clusterStub = {
+      id: "some-cluster-id",
+      preferences: {},
+      metadata: {},
+    } as unknown as Cluster;
+
+    const route = di.inject(addMetricsRouteInjectable);
+
+    callRoute = (payload: unknown) =>
+      Promise.resolve(
+        (route.handler as (request: unknown) => unknown)({
+          cluster: clusterStub,
+          params: {},
+          path: route.path,
+          payload,
+          query: new URLSearchParams(),
+          raw: { req: {}, res: {} },
+        }),
+      );
+  });
+
+  it("logs the classification reason and the serialized cause when Prometheus detection fails", async () => {
+    const resultPromise = callRoute({});
+
+    await getPrometheusDetailsMock.reject(
+      new Error(NO_PROMETHEUS_SERVICE_FOUND_MESSAGE, {
+        cause: [
+          new Error('Failed to find Prometheus provider for "lens"', { cause: new ApiExceptionStub(403, "Forbidden") }),
+          new Error('Failed to find Prometheus provider for "helm"', { cause: new ApiExceptionStub(500, "boom") }),
+        ],
+      }),
+    );
+
+    await resultPromise;
+
+    expect(loggerMock.warn).toHaveBeenCalledTimes(1);
+
+    const [message, meta] = loggerMock.warn.mock.calls[0] as [string, Record<string, unknown>];
+
+    expect(message).toBe(
+      `[METRICS-ROUTE]: failed to get metrics for clusterId=some-cluster-id: ${new Error(NO_PROMETHEUS_SERVICE_FOUND_MESSAGE)}`,
+    );
+    expect(meta.reason).toBe("not-found");
+    expect(meta.cause).not.toBeInstanceOf(Error);
+    expect(meta.cause).toMatchObject({
+      message: NO_PROMETHEUS_SERVICE_FOUND_MESSAGE,
+      cause: [
+        { message: 'Failed to find Prometheus provider for "lens"', cause: { message: "Forbidden" } },
+        { message: 'Failed to find Prometheus provider for "helm"', cause: { message: "boom" } },
+      ],
+    });
+  });
+});

--- a/packages/core/src/main/routes/metrics/add-metrics-route.injectable.test.ts
+++ b/packages/core/src/main/routes/metrics/add-metrics-route.injectable.test.ts
@@ -112,4 +112,60 @@ describe("add-metrics-route", () => {
       ],
     });
   });
+
+  it("returns a 503 with a not-found error when Prometheus detection fails", async () => {
+    const resultPromise = callRoute({});
+
+    await getPrometheusDetailsMock.reject(
+      new Error(NO_PROMETHEUS_SERVICE_FOUND_MESSAGE, {
+        cause: [
+          new Error('Failed to find Prometheus provider for "lens"', { cause: new ApiExceptionStub(500, "boom") }),
+        ],
+      }),
+    );
+
+    await expect(resultPromise).resolves.toEqual({
+      statusCode: 503,
+      error: { reason: "not-found", message: NO_PROMETHEUS_SERVICE_FOUND_MESSAGE },
+    });
+  });
+
+  it("returns a 403 with an access-denied error when detection fails due to authorization", async () => {
+    const resultPromise = callRoute({});
+
+    await getPrometheusDetailsMock.reject(
+      new Error(NO_PROMETHEUS_SERVICE_FOUND_MESSAGE, {
+        cause: [
+          new Error('Failed to find Prometheus provider for "lens"', { cause: new ApiExceptionStub(403, "Forbidden") }),
+        ],
+      }),
+    );
+
+    await expect(resultPromise).resolves.toEqual({
+      statusCode: 403,
+      error: { reason: "access-denied", message: NO_PROMETHEUS_SERVICE_FOUND_MESSAGE, status: 403 },
+    });
+  });
+
+  it("returns a 503 with a not-found error when no Prometheus service could be located", async () => {
+    const resultPromise = callRoute({});
+
+    await getPrometheusDetailsMock.resolve({ prometheusPath: "", provider: undefined as never });
+
+    await expect(resultPromise).resolves.toEqual({
+      statusCode: 503,
+      error: { reason: "not-found", message: NO_PROMETHEUS_SERVICE_FOUND_MESSAGE },
+    });
+  });
+
+  it("returns the response unchanged on success", async () => {
+    const resultPromise = callRoute("up");
+
+    await getPrometheusDetailsMock.resolve({ prometheusPath: "/api/v1/prometheus", provider: undefined as never });
+    await getMetricsMock.resolve({ status: "success", data: { resultType: "vector", result: [] } });
+
+    await expect(resultPromise).resolves.toEqual({
+      response: { status: "success", data: { resultType: "vector", result: [] } },
+    });
+  });
 });

--- a/packages/core/src/main/routes/metrics/add-metrics-route.injectable.ts
+++ b/packages/core/src/main/routes/metrics/add-metrics-route.injectable.ts
@@ -14,49 +14,20 @@ import prometheusHandlerInjectable from "../../cluster/prometheus-handler/promet
 import getMetricsInjectable from "../../get-metrics.injectable";
 import { clusterRoute } from "../../router/route";
 import { getRouteInjectable } from "../../router/router.injectable";
+import {
+  classifyMetricsRouteError,
+  describeError,
+  METRICS_NOT_AVAILABLE_MESSAGE,
+  serializeErrorForLogging,
+} from "./metrics-error-classification";
 
 import type { Cluster } from "../../../common/cluster/cluster";
 import type { ClusterPrometheusMetadata } from "../../../common/cluster-types";
 import type { GetMetrics } from "../../get-metrics.injectable";
+import type { MetricsErrorDescription } from "./metrics-error-classification";
 
 // This is used for backoff retry tracking.
 const ATTEMPTS = [false, false, false, false, true];
-
-interface MetricsErrorDescription {
-  query: string;
-  status?: number;
-  response?: string;
-  message?: string;
-}
-
-async function describeError(query: string, error: unknown): Promise<MetricsErrorDescription> {
-  if (!(error instanceof Error)) {
-    return { query, message: String(error) };
-  }
-
-  const cause = error.cause as any;
-
-  // Duck-type check for a Response
-  const looksLikeResponse = cause && typeof cause.text === "function" && typeof cause.status === "number";
-
-  if (looksLikeResponse) {
-    try {
-      const bodyText = await cause.text();
-
-      if (bodyText) {
-        return {
-          query,
-          status: cause.status,
-          response: bodyText.trim(),
-        };
-      }
-    } catch {
-      // body already consumed or unreadable — fall through
-    }
-  }
-
-  return { query, message: error.message };
-}
 
 const loadMetricsFor =
   (getMetrics: GetMetrics) =>
@@ -85,7 +56,7 @@ const loadMetricsFor =
                 error.statusCode < 500)
             ) {
               const description = await describeError(query, error);
-              throw new Error("Metrics not available", { cause: description });
+              throw new Error(METRICS_NOT_AVAILABLE_MESSAGE, { cause: description });
             }
 
             await new Promise((resolve) => setTimeout(resolve, (attempt + 1) * 1000)); // add delay before repeating request
@@ -158,12 +129,18 @@ const addMetricsRouteInjectable = getRouteInjectable({
         return { response: {} };
       } catch (error) {
         prometheusMetadata.success = false;
-        const description = error instanceof Error ? (error.cause as MetricsErrorDescription | undefined) : undefined;
 
-        if (description?.status === 422) {
+        const info = classifyMetricsRouteError(error);
+
+        if (info.status === 422) {
+          const description = error instanceof Error ? (error.cause as MetricsErrorDescription | undefined) : undefined;
+
           logger.warn(`[METRICS-ROUTE]: query failed for clusterId=${cluster.id}`, description);
         } else {
-          logger.warn(`[METRICS-ROUTE]: failed to get metrics for clusterId=${cluster.id}: ${error}`);
+          logger.warn(`[METRICS-ROUTE]: failed to get metrics for clusterId=${cluster.id}: ${error}`, {
+            reason: info.reason,
+            cause: serializeErrorForLogging(error),
+          });
         }
 
         return { response: {} };

--- a/packages/core/src/main/routes/metrics/add-metrics-route.injectable.ts
+++ b/packages/core/src/main/routes/metrics/add-metrics-route.injectable.ts
@@ -10,6 +10,7 @@ import { isObject } from "es-toolkit/compat";
 import { runInAction } from "mobx";
 import { ClusterMetadataKey, initialFilesystemMountpoints } from "../../../common/cluster-types";
 import { apiPrefix } from "../../../common/vars";
+import { NO_PROMETHEUS_SERVICE_FOUND_MESSAGE } from "../../cluster/prometheus-handler/prometheus-handler";
 import prometheusHandlerInjectable from "../../cluster/prometheus-handler/prometheus-handler.injectable";
 import getMetricsInjectable from "../../get-metrics.injectable";
 import { clusterRoute } from "../../router/route";
@@ -19,10 +20,12 @@ import {
   describeError,
   METRICS_NOT_AVAILABLE_MESSAGE,
   serializeErrorForLogging,
+  statusCodeFor,
 } from "./metrics-error-classification";
 
 import type { Cluster } from "../../../common/cluster/cluster";
 import type { ClusterPrometheusMetadata } from "../../../common/cluster-types";
+import type { MetricsErrorInfo } from "../../../common/k8s-api/endpoints/metrics.api";
 import type { GetMetrics } from "../../get-metrics.injectable";
 import type { MetricsErrorDescription } from "./metrics-error-classification";
 
@@ -96,7 +99,10 @@ const addMetricsRouteInjectable = getRouteInjectable({
         if (!prometheusPath) {
           prometheusMetadata.success = false;
 
-          return { response: {} };
+          return {
+            statusCode: 503,
+            error: { reason: "not-found", message: NO_PROMETHEUS_SERVICE_FOUND_MESSAGE } satisfies MetricsErrorInfo,
+          };
         }
 
         // return data in same structure as query
@@ -143,7 +149,7 @@ const addMetricsRouteInjectable = getRouteInjectable({
           });
         }
 
-        return { response: {} };
+        return { statusCode: statusCodeFor(info), error: info };
       } finally {
         runInAction(() => {
           cluster.metadata[ClusterMetadataKey.PROMETHEUS] = prometheusMetadata;

--- a/packages/core/src/main/routes/metrics/metrics-error-classification.test.ts
+++ b/packages/core/src/main/routes/metrics/metrics-error-classification.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { NO_PROMETHEUS_SERVICE_FOUND_MESSAGE } from "../../cluster/prometheus-handler/prometheus-handler";
+import {
+  classifyMetricsRouteError,
+  findStatusCode,
+  METRICS_NOT_AVAILABLE_MESSAGE,
+  serializeErrorForLogging,
+  statusCodeFor,
+} from "./metrics-error-classification";
+
+class ApiExceptionStub extends Error {
+  constructor(
+    public code: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+describe("classifyMetricsRouteError", () => {
+  it("reports access-denied when every provider failed to detect Prometheus with a 401/403", () => {
+    const error = new Error(NO_PROMETHEUS_SERVICE_FOUND_MESSAGE, {
+      cause: [
+        new Error('Failed to find Prometheus provider for "lens"', { cause: new ApiExceptionStub(403, "Forbidden") }),
+        new Error('Failed to find Prometheus provider for "helm"', {
+          cause: new ApiExceptionStub(401, "Unauthorized"),
+        }),
+      ],
+    });
+
+    expect(classifyMetricsRouteError(error)).toEqual({
+      reason: "access-denied",
+      message: NO_PROMETHEUS_SERVICE_FOUND_MESSAGE,
+      status: 403,
+    });
+  });
+
+  it("reports not-found when detection failures are not uniformly access-denied", () => {
+    const error = new Error(NO_PROMETHEUS_SERVICE_FOUND_MESSAGE, {
+      cause: [
+        new Error('Failed to find Prometheus provider for "lens"', { cause: new ApiExceptionStub(403, "Forbidden") }),
+        new Error('Failed to find Prometheus provider for "helm"', { cause: new ApiExceptionStub(500, "boom") }),
+      ],
+    });
+
+    expect(classifyMetricsRouteError(error)).toEqual({
+      reason: "not-found",
+      message: NO_PROMETHEUS_SERVICE_FOUND_MESSAGE,
+    });
+  });
+
+  it("reports not-found when the cause list is empty", () => {
+    const error = new Error(NO_PROMETHEUS_SERVICE_FOUND_MESSAGE, { cause: [] });
+
+    expect(classifyMetricsRouteError(error)).toEqual({
+      reason: "not-found",
+      message: NO_PROMETHEUS_SERVICE_FOUND_MESSAGE,
+    });
+  });
+
+  it("reports access-denied when a query failed with a 403", () => {
+    const error = new Error(METRICS_NOT_AVAILABLE_MESSAGE, {
+      cause: { query: "up", status: 403, response: "Forbidden" },
+    });
+
+    expect(classifyMetricsRouteError(error)).toEqual({
+      reason: "access-denied",
+      message: "Forbidden",
+      status: 403,
+    });
+  });
+
+  it("reports error with the original status when a query failed for another reason", () => {
+    const error = new Error(METRICS_NOT_AVAILABLE_MESSAGE, {
+      cause: { query: "up", status: 422, response: "Unprocessable" },
+    });
+
+    expect(classifyMetricsRouteError(error)).toEqual({
+      reason: "error",
+      message: "Unprocessable",
+      status: 422,
+    });
+  });
+
+  it("reports error for an unrelated Error", () => {
+    expect(classifyMetricsRouteError(new Error("boom"))).toEqual({
+      reason: "error",
+      message: "boom",
+    });
+  });
+
+  it("reports error for a non-Error value", () => {
+    expect(classifyMetricsRouteError("boom")).toEqual({
+      reason: "error",
+      message: "boom",
+    });
+  });
+});
+
+describe("findStatusCode", () => {
+  it("finds a status via .code", () => {
+    expect(findStatusCode({ code: 404 })).toBe(404);
+  });
+
+  it("finds a status via .status", () => {
+    expect(findStatusCode({ status: 401 })).toBe(401);
+  });
+
+  it("finds a status via .statusCode", () => {
+    expect(findStatusCode({ statusCode: 500 })).toBe(500);
+  });
+
+  it("walks nested causes to find the status", () => {
+    const outer = new Error("outer", { cause: new Error("middle", { cause: new ApiExceptionStub(403, "Forbidden") }) });
+
+    expect(findStatusCode(outer)).toBe(403);
+  });
+
+  it("ignores out-of-range numbers", () => {
+    expect(findStatusCode({ code: 9000 })).toBeUndefined();
+  });
+
+  it("does not walk past the depth limit", () => {
+    let deep: unknown = { code: 500 };
+
+    for (let i = 0; i < 6; i += 1) {
+      deep = { cause: deep };
+    }
+
+    expect(findStatusCode(deep, 4)).toBeUndefined();
+    expect(findStatusCode(deep, 10)).toBe(500);
+  });
+});
+
+describe("serializeErrorForLogging", () => {
+  it("serializes an Error and its cause", () => {
+    const error = new Error("outer", { cause: new Error("inner") });
+
+    expect(serializeErrorForLogging(error)).toEqual({
+      message: "outer",
+      cause: { message: "inner", cause: undefined },
+    });
+  });
+
+  it("serializes an Error whose cause is an array of errors", () => {
+    const error = new Error("outer", { cause: [new Error("a"), new Error("b")] });
+
+    expect(serializeErrorForLogging(error)).toEqual({
+      message: "outer",
+      cause: [
+        { message: "a", cause: undefined },
+        { message: "b", cause: undefined },
+      ],
+    });
+  });
+
+  it("passes plain objects through and stringifies primitives", () => {
+    expect(serializeErrorForLogging({ some: "value" })).toEqual({ some: "value" });
+    expect(serializeErrorForLogging("plain string")).toBe("plain string");
+    expect(serializeErrorForLogging(42)).toBe("42");
+  });
+
+  it("stops recursing once the depth limit is exhausted", () => {
+    let deepest: Error = new Error("level-0");
+
+    for (let i = 1; i <= 6; i += 1) {
+      deepest = new Error(`level-${i}`, { cause: deepest });
+    }
+
+    const serialized = serializeErrorForLogging(deepest, 2) as {
+      cause: { cause: { cause: unknown; message: string } };
+    };
+
+    expect(serialized.cause.cause.message).toBe("level-4");
+    expect(serialized.cause.cause.cause).toBeUndefined();
+  });
+});
+
+describe("statusCodeFor", () => {
+  it("prefers an explicit status when present", () => {
+    expect(statusCodeFor({ reason: "error", message: "boom", status: 422 })).toBe(422);
+  });
+
+  it("defaults not-found to 503", () => {
+    expect(statusCodeFor({ reason: "not-found", message: "boom" })).toBe(503);
+  });
+
+  it("defaults access-denied to 403", () => {
+    expect(statusCodeFor({ reason: "access-denied", message: "boom" })).toBe(403);
+  });
+
+  it("defaults error to 500", () => {
+    expect(statusCodeFor({ reason: "error", message: "boom" })).toBe(500);
+  });
+});

--- a/packages/core/src/main/routes/metrics/metrics-error-classification.ts
+++ b/packages/core/src/main/routes/metrics/metrics-error-classification.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { NO_PROMETHEUS_SERVICE_FOUND_MESSAGE } from "../../cluster/prometheus-handler/prometheus-handler";
+
+import type { MetricsErrorInfo } from "../../../common/k8s-api/endpoints/metrics.api";
+
+export const METRICS_NOT_AVAILABLE_MESSAGE = "Metrics not available";
+
+export interface MetricsErrorDescription {
+  query: string;
+  status?: number;
+  response?: string;
+  message?: string;
+}
+
+export async function describeError(query: string, error: unknown): Promise<MetricsErrorDescription> {
+  if (!(error instanceof Error)) {
+    return { query, message: String(error) };
+  }
+
+  const cause = error.cause as any;
+
+  // Duck-type check for a Response
+  const looksLikeResponse = cause && typeof cause.text === "function" && typeof cause.status === "number";
+
+  if (looksLikeResponse) {
+    try {
+      const bodyText = await cause.text();
+
+      if (bodyText) {
+        return {
+          query,
+          status: cause.status,
+          response: bodyText.trim(),
+        };
+      }
+    } catch {
+      // body already consumed or unreadable — fall through
+    }
+  }
+
+  return { query, message: error.message };
+}
+
+const HTTP_STATUS_MIN = 100;
+const HTTP_STATUS_MAX = 599;
+
+function isHttpStatusCode(value: unknown): value is number {
+  return typeof value === "number" && value >= HTTP_STATUS_MIN && value <= HTTP_STATUS_MAX;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+/**
+ * Walks the `.cause` chain of an error (descending into array causes) looking
+ * for the first numeric status-like property. `depth` bounds the walk so a
+ * cyclical cause chain cannot cause infinite recursion.
+ */
+export function findStatusCode(error: unknown, depth = 4): number | undefined {
+  if (depth < 0) {
+    return undefined;
+  }
+
+  if (Array.isArray(error)) {
+    for (const item of error) {
+      const found = findStatusCode(item, depth - 1);
+
+      if (found !== undefined) {
+        return found;
+      }
+    }
+
+    return undefined;
+  }
+
+  if (!isPlainObject(error)) {
+    return undefined;
+  }
+
+  for (const key of ["status", "statusCode", "code"]) {
+    if (isHttpStatusCode(error[key])) {
+      return error[key] as number;
+    }
+  }
+
+  return findStatusCode((error as { cause?: unknown }).cause, depth - 1);
+}
+
+/**
+ * Recursively converts an error (and its cause chain) into a JSON-safe plain
+ * structure suitable for the winston logger. `depth` bounds the recursion so
+ * a cyclical cause chain cannot cause infinite recursion.
+ */
+export function serializeErrorForLogging(error: unknown, depth = 4): unknown {
+  if (depth < 0) {
+    return undefined;
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      cause: error.cause === undefined ? undefined : serializeErrorForLogging(error.cause, depth - 1),
+    };
+  }
+
+  if (Array.isArray(error)) {
+    return error.map((item) => serializeErrorForLogging(item, depth - 1));
+  }
+
+  if (isPlainObject(error)) {
+    return error;
+  }
+
+  return String(error);
+}
+
+export function classifyMetricsRouteError(error: unknown): MetricsErrorInfo {
+  if (error instanceof Error && error.message === NO_PROMETHEUS_SERVICE_FOUND_MESSAGE) {
+    const causes = Array.isArray(error.cause) ? error.cause : [];
+    const allAccessDenied =
+      causes.length > 0 &&
+      causes.every((cause) => {
+        const status = findStatusCode(cause);
+
+        return status === 401 || status === 403;
+      });
+
+    if (allAccessDenied) {
+      return { reason: "access-denied", message: error.message, status: 403 };
+    }
+
+    return { reason: "not-found", message: error.message };
+  }
+
+  if (error instanceof Error && error.message === METRICS_NOT_AVAILABLE_MESSAGE) {
+    const description = error.cause as MetricsErrorDescription | undefined;
+    const message = description?.message ?? description?.response ?? error.message;
+
+    if (description?.status === 401 || description?.status === 403) {
+      return { reason: "access-denied", message, status: description.status };
+    }
+
+    return { reason: "error", message, status: description?.status };
+  }
+
+  return { reason: "error", message: error instanceof Error ? error.message : String(error) };
+}
+
+export function statusCodeFor(info: MetricsErrorInfo): number {
+  if (info.status !== undefined) {
+    return info.status;
+  }
+
+  switch (info.reason) {
+    case "not-found":
+      return 503;
+    case "access-denied":
+      return 403;
+    case "error":
+      return 500;
+  }
+}

--- a/packages/core/src/renderer/components/cluster/cluster-metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/cluster/cluster-metrics.injectable.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+const asyncComputedMock = vi.fn((options: unknown) => options);
+
+vi.mock("@ogre-tools/injectable-react", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+
+  return {
+    ...actual,
+    asyncComputed: (options: unknown) => asyncComputedMock(options),
+  };
+});
+
+vi.mock("mobx-utils", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+
+  return {
+    ...actual,
+    now: () => {},
+  };
+});
+
+import { loggerInjectionToken } from "@freelensapp/logger";
+import requestClusterMetricsByNodeNamesInjectable from "../../../common/k8s-api/endpoints/metrics.api/request-cluster-metrics-by-node-names.injectable";
+import { getDiForUnitTesting } from "../../getDiForUnitTesting";
+import clusterOverviewMetricsInjectable from "./cluster-metrics.injectable";
+import selectedMetricsTimeRangeInjectable from "./overview/selected-metrics-time-range.injectable";
+import selectedNodeRoleForMetricsInjectable from "./overview/selected-node-role-for-metrics.injectable";
+
+import type { Logger } from "@freelensapp/logger";
+
+import type { Mocked } from "vitest";
+
+describe("clusterOverviewMetricsInjectable", () => {
+  beforeEach(() => {
+    asyncComputedMock.mockClear();
+  });
+
+  it("resolves to an empty object instead of rejecting when the request fails", async () => {
+    const di = getDiForUnitTesting();
+    const loggerMock: Mocked<Logger> = {
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      silly: vi.fn(),
+    };
+
+    di.override(loggerInjectionToken, () => loggerMock);
+    di.override(
+      selectedNodeRoleForMetricsInjectable,
+      () =>
+        ({
+          nodes: { get: () => [] },
+        }) as never,
+    );
+    di.override(
+      selectedMetricsTimeRangeInjectable,
+      () =>
+        ({
+          timestamps: { get: () => ({ start: 2000, end: 2100, range: 100 }) },
+        }) as never,
+    );
+    di.override(requestClusterMetricsByNodeNamesInjectable, () => vi.fn().mockRejectedValue(new Error("boom")));
+
+    di.inject(clusterOverviewMetricsInjectable);
+
+    const asyncComputedConfiguration = asyncComputedMock.mock.calls[0]?.[0] as {
+      getValueFromObservedPromise: () => Promise<unknown>;
+    };
+
+    await expect(asyncComputedConfiguration.getValueFromObservedPromise()).resolves.toEqual({});
+    expect(loggerMock.debug).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/renderer/components/cluster/cluster-metrics.injectable.ts
+++ b/packages/core/src/renderer/components/cluster/cluster-metrics.injectable.ts
@@ -4,6 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import { asyncComputed } from "@ogre-tools/injectable-react";
 import { now } from "mobx-utils";
@@ -21,6 +22,7 @@ const clusterOverviewMetricsInjectable = getInjectable({
     const requestClusterMetricsByNodeNames = di.inject(requestClusterMetricsByNodeNamesInjectable);
     const selectedNodeRoleForMetrics = di.inject(selectedNodeRoleForMetricsInjectable);
     const selectedMetricsTimeRange = di.inject(selectedMetricsTimeRangeInjectable);
+    const logger = di.inject(loggerInjectionToken);
 
     return asyncComputed<Partial<ClusterMetricData> | undefined>({
       getValueFromObservedPromise: async () => {
@@ -29,11 +31,22 @@ const clusterOverviewMetricsInjectable = getInjectable({
         const nodeNames = selectedNodeRoleForMetrics.nodes.get().map((node) => node.getName());
         const { start, end, range } = selectedMetricsTimeRange.timestamps.get();
 
-        return requestClusterMetricsByNodeNames(nodeNames, {
-          start,
-          end,
-          range,
-        });
+        try {
+          return await requestClusterMetricsByNodeNames(nodeNames, {
+            start,
+            end,
+            range,
+          });
+        } catch (error) {
+          // asyncComputed's internal promise chain only attaches a `.then()`,
+          // with no rejection handler, so letting this promise reject would
+          // leave `pending` stuck at `true` forever (a permanent spinner).
+          // Fall back to the same "no metrics" shape the route used to
+          // resolve with before it started rejecting on failure.
+          logger.debug("[CLUSTER-OVERVIEW-METRICS]: failed to load cluster metrics", { error });
+
+          return {};
+        }
       },
       betweenUpdates: "show-latest-value",
     });

--- a/packages/core/src/renderer/components/nodes/route.tsx
+++ b/packages/core/src/renderer/components/nodes/route.tsx
@@ -7,6 +7,7 @@
 import "./nodes.scss";
 
 import { formatNodeTaint } from "@freelensapp/kube-object";
+import { loggerInjectionToken } from "@freelensapp/logger";
 import { Tooltip, TooltipPosition } from "@freelensapp/tooltip";
 import { bytesToUnits, cpuUnitsToNumber, interval, unitsToBytes } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
@@ -28,6 +29,7 @@ import podStoreInjectable from "../workloads-pods/store.injectable";
 import nodeStoreInjectable from "./store.injectable";
 
 import type { Node, Pod } from "@freelensapp/kube-object";
+import type { Logger } from "@freelensapp/logger";
 
 import type {
   NodeMetricData,
@@ -74,6 +76,7 @@ interface Dependencies {
   podStore: PodStore;
   subscribeStores: SubscribeStores;
   loadPodsFromAllNamespaces: () => void;
+  logger: Logger;
 }
 
 function bytesToUnitsAligned(bytes: number): string {
@@ -166,7 +169,17 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
   private metricsWatcher = interval(30, () => {
     void (async () => {
       await this.props.nodeStore.loadKubeMetrics();
-      this.metrics = await this.props.requestAllNodeMetrics();
+
+      try {
+        this.metrics = await this.props.requestAllNodeMetrics();
+      } catch (error) {
+        // `interval()` has no rejection handler of its own, so an unhandled
+        // rejection here would surface as an unhandled promise rejection.
+        // Fall back to the same "no metrics" shape the route used to resolve
+        // with before it started rejecting on failure.
+        this.props.logger.debug("[NODES-ROUTE]: failed to load node metrics", { error });
+        this.metrics = {} as NodeMetricData;
+      }
     })();
   });
 
@@ -550,5 +563,6 @@ export const NodesRoute = withInjectables<Dependencies>(NonInjectedNodesRoute, {
     podStore: di.inject(podStoreInjectable),
     subscribeStores: di.inject(subscribeStoresInjectable),
     loadPodsFromAllNamespaces: di.inject(loadPodsFromAllNamespacesInjectable),
+    logger: di.inject(loggerInjectionToken),
   }),
 });

--- a/packages/core/src/renderer/components/resource-metrics/classify-metrics-error.test.ts
+++ b/packages/core/src/renderer/components/resource-metrics/classify-metrics-error.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { JsonApiErrorParsed } from "@freelensapp/json-api";
+import { classifyMetricsError } from "./classify-metrics-error";
+
+import type { MetricsErrorInfo } from "../../../common/k8s-api/endpoints/metrics.api";
+
+describe("classifyMetricsError", () => {
+  it("passes through a well-formed MetricsErrorInfo body", () => {
+    const body: MetricsErrorInfo = { reason: "not-found", message: "No Prometheus service found", status: 503 };
+    const error = new JsonApiErrorParsed(body as never, ["No Prometheus service found"]);
+
+    expect(classifyMetricsError(error)).toBe(body);
+  });
+
+  it("falls back to a generic error for a malformed body", () => {
+    const body = { message: "not quite right" } as never;
+    const error = new JsonApiErrorParsed(body, ["not quite right"]);
+
+    expect(classifyMetricsError(error)).toEqual({ reason: "error", message: error.toString() });
+  });
+
+  it("falls back to a generic error when the reason is unrecognized", () => {
+    const body = { reason: "totally-unknown", message: "boom" } as never;
+    const error = new JsonApiErrorParsed(body, ["boom"]);
+
+    expect(classifyMetricsError(error)).toEqual({ reason: "error", message: error.toString() });
+  });
+
+  it("reports error with the message for a plain Error", () => {
+    expect(classifyMetricsError(new Error("network exploded"))).toEqual({
+      reason: "error",
+      message: "network exploded",
+    });
+  });
+
+  it("reports error with a stringified value for a non-Error", () => {
+    expect(classifyMetricsError("boom")).toEqual({ reason: "error", message: "boom" });
+  });
+});

--- a/packages/core/src/renderer/components/resource-metrics/classify-metrics-error.ts
+++ b/packages/core/src/renderer/components/resource-metrics/classify-metrics-error.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { JsonApiErrorParsed } from "@freelensapp/json-api";
+
+import type { MetricsErrorInfo, MetricsErrorReason } from "../../../common/k8s-api/endpoints/metrics.api";
+
+const reasons: readonly MetricsErrorReason[] = ["not-found", "access-denied", "error"];
+
+function isMetricsErrorInfo(value: unknown): value is MetricsErrorInfo {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  return typeof candidate.message === "string" && reasons.includes(candidate.reason as MetricsErrorReason);
+}
+
+export function classifyMetricsError(error: unknown): MetricsErrorInfo {
+  if (error instanceof JsonApiErrorParsed) {
+    const body = error.data;
+
+    return isMetricsErrorInfo(body) ? body : { reason: "error", message: error.toString() };
+  }
+
+  return { reason: "error", message: error instanceof Error ? error.message : String(error) };
+}

--- a/packages/core/src/renderer/components/resource-metrics/create-time-ranged-metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/resource-metrics/create-time-ranged-metrics.injectable.test.ts
@@ -138,4 +138,89 @@ describe("createTimeRangedMetricsInjectable", () => {
     expect(metricsForObjectAAgain).toBe(metricsForObjectA);
     expect(metricsForObjectB).not.toBe(metricsForObjectA);
   });
+
+  it("resolves to undefined and exposes a classified error when the request rejects", async () => {
+    const di = getDiForUnitTesting();
+    const object: TestObject = {
+      getId: () => "resource-id",
+    };
+
+    const injectable = createTimeRangedMetricsInjectable<{ object: TestObject }, TestObject, unknown>({
+      id: "test-time-ranged-metrics-rejection",
+      getObject: ({ object }) => object,
+      getObjectId: (resource) => resource.getId(),
+      request: async () => {
+        throw new Error("metrics request failed");
+      },
+    });
+
+    di.register(injectable);
+
+    di.override(
+      selectedMetricsTimeRangeInjectable,
+      () =>
+        ({
+          timestamps: {
+            get: () => ({ start: 2000, end: 2100, range: 100 }),
+          },
+        }) as never,
+    );
+
+    const metrics = di.inject(injectable, { object }) as unknown as {
+      error: { get: () => unknown };
+    };
+    const asyncComputedConfiguration = asyncComputedMock.mock.calls[0]?.[0] as {
+      getValueFromObservedPromise: () => Promise<unknown>;
+    };
+
+    await expect(asyncComputedConfiguration.getValueFromObservedPromise()).resolves.toBeUndefined();
+
+    expect(metrics.error.get()).toEqual({ reason: "error", message: "metrics request failed" });
+  });
+
+  it("clears a previously classified error once a subsequent request succeeds", async () => {
+    const di = getDiForUnitTesting();
+    const object: TestObject = {
+      getId: () => "resource-id",
+    };
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("metrics request failed"))
+      .mockResolvedValueOnce({ ok: true });
+
+    const injectable = createTimeRangedMetricsInjectable<{ object: TestObject }, TestObject, unknown>({
+      id: "test-time-ranged-metrics-recovery",
+      getObject: ({ object }) => object,
+      getObjectId: (resource) => resource.getId(),
+      request: async () => request(),
+    });
+
+    di.register(injectable);
+
+    di.override(
+      selectedMetricsTimeRangeInjectable,
+      () =>
+        ({
+          timestamps: {
+            get: () => ({ start: 2000, end: 2100, range: 100 }),
+          },
+        }) as never,
+    );
+
+    const metrics = di.inject(injectable, { object }) as unknown as {
+      error: { get: () => unknown };
+    };
+    const asyncComputedConfiguration = asyncComputedMock.mock.calls[0]?.[0] as {
+      getValueFromObservedPromise: () => Promise<unknown>;
+    };
+
+    await asyncComputedConfiguration.getValueFromObservedPromise();
+
+    expect(metrics.error.get()).toEqual({ reason: "error", message: "metrics request failed" });
+
+    const value = await asyncComputedConfiguration.getValueFromObservedPromise();
+
+    expect(value).toEqual({ ok: true });
+    expect(metrics.error.get()).toBeUndefined();
+  });
 });

--- a/packages/core/src/renderer/components/resource-metrics/create-time-ranged-metrics.ts
+++ b/packages/core/src/renderer/components/resource-metrics/create-time-ranged-metrics.ts
@@ -6,10 +6,15 @@
 
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import { asyncComputed } from "@ogre-tools/injectable-react";
+import { computed, observable, runInAction } from "mobx";
 import selectedMetricsTimeRangeInjectable from "../cluster/overview/selected-metrics-time-range.injectable";
+import { classifyMetricsError } from "./classify-metrics-error";
 
 import type { DiContainer, DiContainerForInjection, Injectable } from "@ogre-tools/injectable";
 import type { IAsyncComputed } from "@ogre-tools/injectable-react";
+import type { IComputedValue } from "mobx";
+
+import type { MetricsErrorInfo } from "../../../common/k8s-api/endpoints/metrics.api";
 
 interface RequestContext<ObjectType> {
   di: DiContainerForInjection;
@@ -26,11 +31,19 @@ interface TimeRangedMetricsInjectableConfig<Params, ObjectType, Value> {
   request: (context: RequestContext<ObjectType>) => Promise<Value>;
 }
 
-type TimeRangedMetricsInjectable<Params, Value> = Injectable<IAsyncComputed<Value>, IAsyncComputed<Value>, Params>;
+export type TimeRangedMetricsValue<Value> = IAsyncComputed<Value> & {
+  error: IComputedValue<MetricsErrorInfo | undefined>;
+};
+
+type TimeRangedMetricsInjectable<Params, Value> = Injectable<
+  TimeRangedMetricsValue<Value>,
+  TimeRangedMetricsValue<Value>,
+  Params
+>;
 
 const getTimeRangedMetricsInjectable = getInjectable as <Params, Value>(options: {
   id: string;
-  instantiate: (di: DiContainerForInjection, params: Params) => IAsyncComputed<Value>;
+  instantiate: (di: DiContainerForInjection, params: Params) => TimeRangedMetricsValue<Value>;
   lifecycle: {
     getInstanceKey: (di: DiContainer, params: Params) => string;
   };
@@ -47,21 +60,38 @@ export const createTimeRangedMetricsInjectable = <Params, ObjectType, Value>({
     instantiate: (di, params) => {
       const selectedMetricsTimeRange = di.inject(selectedMetricsTimeRangeInjectable);
       const object = getObject(params);
+      const errorBox = observable.box<MetricsErrorInfo | undefined>(undefined, { deep: false });
 
-      return asyncComputed<Value>({
+      const metrics = asyncComputed<Value>({
         getValueFromObservedPromise: async () => {
           const { start, end, range } = selectedMetricsTimeRange.timestamps.get();
 
-          return request({
-            di,
-            object,
-            start,
-            end,
-            range,
-          });
+          try {
+            const value = await request({
+              di,
+              object,
+              start,
+              end,
+              range,
+            });
+
+            runInAction(() => errorBox.set(undefined));
+
+            return value;
+          } catch (error) {
+            // asyncComputed's internal promise chain only attaches a `.then()`,
+            // with no rejection handler, so letting this promise reject would
+            // leave `pending` stuck at `true` forever (a permanent spinner in
+            // the chart). Always resolve and surface the failure via `error`.
+            runInAction(() => errorBox.set(classifyMetricsError(error)));
+
+            return undefined as Value;
+          }
         },
         betweenUpdates: "show-latest-value",
       });
+
+      return Object.assign(metrics, { error: computed(() => errorBox.get()) });
     },
     lifecycle: lifecycleEnum.keyedSingleton({
       getInstanceKey: (_di, params) => getObjectId(getObject(params)),

--- a/packages/core/src/renderer/components/resource-metrics/no-metrics.module.scss
+++ b/packages/core/src/renderer/components/resource-metrics/no-metrics.module.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+.link {
+  color: var(--blue);
+  cursor: pointer;
+}

--- a/packages/core/src/renderer/components/resource-metrics/no-metrics.test.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/no-metrics.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import navigateToEntitySettingsInjectable from "../../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
+import hostedClusterInjectable from "../../cluster-frame-context/hosted-cluster.injectable";
+import { getDiForUnitTesting } from "../../getDiForUnitTesting";
+import { renderFor } from "../test-utils/renderFor";
+import { NoMetrics } from "./no-metrics";
+import { ResourceMetricsContext } from "./resource-metrics";
+
+import type { DiContainer } from "@ogre-tools/injectable";
+import type { MockedFunction } from "vitest";
+
+import type { NavigateToEntitySettings } from "../../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
+import type { MetricsErrorInfo } from "../../../common/k8s-api/endpoints/metrics.api";
+
+function renderNoMetrics(di: DiContainer, metricsError?: MetricsErrorInfo) {
+  const render = renderFor(di);
+
+  return render(
+    <ResourceMetricsContext.Provider
+      value={{ object: {} as never, tab: "CPU", metrics: undefined, isPending: false, metricsError }}
+    >
+      <NoMetrics />
+    </ResourceMetricsContext.Provider>,
+  );
+}
+
+describe("NoMetrics", () => {
+  let di: DiContainer;
+  let navigateToEntitySettingsMock: MockedFunction<NavigateToEntitySettings>;
+
+  beforeEach(() => {
+    di = getDiForUnitTesting();
+
+    navigateToEntitySettingsMock = vi.fn();
+    di.override(navigateToEntitySettingsInjectable, () => navigateToEntitySettingsMock);
+    di.override(hostedClusterInjectable, () => ({ id: "some-cluster-id" }) as never);
+  });
+
+  it("renders the generic message as a single row, unchanged from before error reasons existed", () => {
+    renderNoMetrics(di);
+
+    const message = screen.getByTestId("no-metrics-message");
+
+    expect(message).toHaveTextContent("Metrics not available at the moment");
+    expect(message).toHaveClass("flex", "justify-center", "items-center");
+    expect(message).not.toHaveClass("flex-col");
+    expect(message).not.toHaveAttribute("title");
+    expect(message.querySelector("p")).not.toBeInTheDocument();
+    expect(screen.queryByText("Open cluster settings")).not.toBeInTheDocument();
+  });
+
+  it("renders the generic message when rendered outside of a ResourceMetrics context", () => {
+    const render = renderFor(di);
+
+    render(<NoMetrics />);
+
+    expect(screen.getByTestId("no-metrics-message")).toHaveTextContent("Metrics not available at the moment");
+  });
+
+  it("shows the not-found reason and a working cluster settings link", () => {
+    renderNoMetrics(di, { reason: "not-found", message: "No Prometheus service found" });
+
+    expect(screen.getByTestId("no-metrics-message")).toHaveTextContent(
+      "No Prometheus service was found for this cluster.",
+    );
+
+    const link = screen.getByText("Open cluster settings");
+
+    fireEvent.click(link);
+
+    expect(navigateToEntitySettingsMock).toHaveBeenCalledWith("some-cluster-id", "metrics");
+  });
+
+  it("shows the access-denied reason and a cluster settings link", () => {
+    renderNoMetrics(di, { reason: "access-denied", message: "Forbidden", status: 403 });
+
+    expect(screen.getByTestId("no-metrics-message")).toHaveTextContent("Access to Prometheus metrics was denied.");
+    expect(screen.getByText("Open cluster settings")).toBeInTheDocument();
+  });
+
+  it("shows the generic error reason without a link, carrying the detail in the title", () => {
+    renderNoMetrics(di, { reason: "error", message: "boom", status: 500 });
+
+    const message = screen.getByTestId("no-metrics-message");
+
+    expect(message).toHaveTextContent("Failed to load metrics.");
+    expect(message).toHaveAttribute("title", "HTTP 500: boom");
+    expect(screen.queryByText("Open cluster settings")).not.toBeInTheDocument();
+  });
+
+  it("does not show a cluster settings link when there is no known cluster id", () => {
+    di.override(hostedClusterInjectable, () => undefined);
+
+    renderNoMetrics(di, { reason: "not-found", message: "No Prometheus service found" });
+
+    expect(screen.queryByText("Open cluster settings")).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/src/renderer/components/resource-metrics/no-metrics.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/no-metrics.tsx
@@ -5,12 +5,81 @@
  */
 
 import { Icon } from "@freelensapp/icon";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import { useContext } from "react";
+import navigateToEntitySettingsInjectable from "../../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
+import hostedClusterInjectable from "../../cluster-frame-context/hosted-cluster.injectable";
+import styles from "./no-metrics.module.scss";
+import { ResourceMetricsContext } from "./resource-metrics";
 
-export function NoMetrics() {
+import type { NavigateToEntitySettings } from "../../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
+import type { MetricsErrorInfo } from "../../../common/k8s-api/endpoints/metrics.api";
+
+const GENERIC_MESSAGE = "Metrics not available at the moment";
+
+interface Dependencies {
+  navigateToEntitySettings: NavigateToEntitySettings;
+  clusterId: string | undefined;
+}
+
+function getReasonText(metricsError: MetricsErrorInfo): string {
+  switch (metricsError.reason) {
+    case "not-found":
+      return "No Prometheus service was found for this cluster.";
+    case "access-denied":
+      return "Access to Prometheus metrics was denied.";
+    case "error":
+      return "Failed to load metrics.";
+  }
+}
+
+function getDetailText(metricsError: MetricsErrorInfo): string {
+  return metricsError.status !== undefined
+    ? `HTTP ${metricsError.status}: ${metricsError.message}`
+    : metricsError.message;
+}
+
+export function NonInjectedNoMetrics({ navigateToEntitySettings, clusterId }: Dependencies) {
+  const metricsError = useContext(ResourceMetricsContext)?.metricsError;
+
+  if (!metricsError) {
+    // Unchanged from before error reasons existed: the most common empty
+    // state across every chart, kept as a single row.
+    return (
+      <div className="flex justify-center items-center" data-testid="no-metrics-message">
+        <Icon material="info" />
+        &nbsp;{GENERIC_MESSAGE}
+      </div>
+    );
+  }
+
+  const canOpenClusterSettings =
+    clusterId !== undefined && (metricsError.reason === "not-found" || metricsError.reason === "access-denied");
+
   return (
-    <div className="flex justify-center items-center">
+    <div
+      className="flex flex-col justify-center items-center gap-1"
+      title={getDetailText(metricsError)}
+      data-testid="no-metrics-message"
+    >
       <Icon material="info" />
-      &nbsp;Metrics not available at the moment
+      <p>{getReasonText(metricsError)}</p>
+      {canOpenClusterSettings && (
+        <span className={styles.link} onClick={() => navigateToEntitySettings(clusterId, "metrics")}>
+          Open cluster settings
+        </span>
+      )}
     </div>
   );
 }
+
+export const NoMetrics = withInjectables<Dependencies>(NonInjectedNoMetrics, {
+  getProps: (di) => {
+    const cluster = di.inject(hostedClusterInjectable);
+
+    return {
+      navigateToEntitySettings: di.inject(navigateToEntitySettingsInjectable),
+      clusterId: cluster?.id,
+    };
+  },
+});

--- a/packages/core/src/renderer/components/resource-metrics/resource-metrics.test.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/resource-metrics.test.tsx
@@ -13,7 +13,7 @@ import { ResourceMetrics, ResourceMetricsContext } from "./resource-metrics";
 
 import type { DiContainer } from "@ogre-tools/injectable";
 
-import type { MetricData } from "../../../common/k8s-api/endpoints/metrics.api";
+import type { MetricData, MetricsErrorInfo } from "../../../common/k8s-api/endpoints/metrics.api";
 
 const object = {
   getId: () => "resource-id",
@@ -43,6 +43,16 @@ function MetricsProbe() {
   }
 
   return <div data-testid="metrics-value">{context.metrics.cpuUsage?.data.result[0].values[0]?.[1]}</div>;
+}
+
+function MetricsErrorProbe() {
+  const context = useContext(ResourceMetricsContext);
+
+  if (!context?.metricsError) {
+    return null;
+  }
+
+  return <div data-testid="metrics-error">{context.metricsError.reason}</div>;
 }
 
 function renderResourceMetrics(di: DiContainer) {
@@ -176,5 +186,41 @@ describe("ResourceMetrics", () => {
 
     expect(screen.queryByTestId("metrics-value")).not.toBeInTheDocument();
     expect(result.container.querySelector(".graph")).toBeEmptyDOMElement();
+  });
+
+  it("passes an async metrics value's error through the context", () => {
+    const render = renderFor({} as never);
+    const error: MetricsErrorInfo = { reason: "not-found", message: "No Prometheus service found" };
+    const metrics = {
+      pending: computed(() => false),
+      value: computed(() => undefined),
+      error: computed(() => error),
+    } as never;
+
+    render(
+      <ResourceMetrics object={object} tabs={["CPU"]} metrics={metrics}>
+        <MetricsErrorProbe />
+      </ResourceMetrics>,
+    );
+
+    expect(screen.getByTestId("metrics-error")).toHaveTextContent("not-found");
+  });
+
+  it("does not blow up when an async metrics value has no error computed", () => {
+    const render = renderFor({} as never);
+    const metrics = {
+      pending: computed(() => false),
+      value: computed(() => ({ cpuUsage: metricWithValue("1") }) as Partial<Record<"cpuUsage", MetricData>>),
+    } as never;
+
+    render(
+      <ResourceMetrics object={object} tabs={["CPU"]} metrics={metrics}>
+        <MetricsProbe />
+        <MetricsErrorProbe />
+      </ResourceMetrics>,
+    );
+
+    expect(screen.getByTestId("metrics-value")).toHaveTextContent("1");
+    expect(screen.queryByTestId("metrics-error")).not.toBeInTheDocument();
   });
 });

--- a/packages/core/src/renderer/components/resource-metrics/resource-metrics.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/resource-metrics.tsx
@@ -16,25 +16,32 @@ import { Radio, RadioGroup } from "../radio";
 import type { KubeObject } from "@freelensapp/kube-object";
 
 import type { IAsyncComputed } from "@ogre-tools/injectable-react";
+import type { IComputedValue } from "mobx";
 
-import type { MetricData } from "../../../common/k8s-api/endpoints/metrics.api";
+import type { MetricData, MetricsErrorInfo } from "../../../common/k8s-api/endpoints/metrics.api";
 import type { MetricsTab } from "../chart/options";
 
 export type AtLeastOneMetricTab = [MetricsTab, ...MetricsTab[]];
+
+export type AsyncResourceMetrics<Keys extends string> = IAsyncComputed<
+  Partial<Record<Keys, MetricData>> | null | undefined
+> & {
+  error?: IComputedValue<MetricsErrorInfo | undefined>;
+};
 
 export interface ResourceMetricsProps<Keys extends string> {
   tabs: AtLeastOneMetricTab;
   object: KubeObject;
   className?: string;
   metricsKey?: string;
-  metrics: IAsyncComputed<Partial<Record<Keys, MetricData>> | null | undefined> | Partial<Record<Keys, MetricData>>;
+  metrics: AsyncResourceMetrics<Keys> | Partial<Record<Keys, MetricData>>;
   children: React.ReactChild | React.ReactChild[];
 }
 
 function isAsyncComputedMetrics<Keys extends string>(
-  metrics: IAsyncComputed<Partial<Record<Keys, MetricData>> | null | undefined> | Partial<Record<Keys, MetricData>>,
-): metrics is IAsyncComputed<Partial<Record<Keys, MetricData>> | null | undefined> {
-  return isComputed((metrics as IAsyncComputed<unknown>).value);
+  metrics: AsyncResourceMetrics<Keys> | Partial<Record<Keys, MetricData>>,
+): metrics is AsyncResourceMetrics<Keys> {
+  return isComputed((metrics as AsyncResourceMetrics<Keys>).value);
 }
 
 export interface ResourceMetricsValue {
@@ -42,6 +49,7 @@ export interface ResourceMetricsValue {
   tab: MetricsTab;
   metrics: Partial<Record<string, MetricData>> | null | undefined;
   isPending: boolean;
+  metricsError?: MetricsErrorInfo;
 }
 
 export const ResourceMetricsContext = createContext<ResourceMetricsValue | null>(null);
@@ -60,6 +68,9 @@ export const ResourceMetrics = observer(
     }
 
     const currentMetrics = isAsyncMetrics ? (shouldHideStaleMetrics ? undefined : metrics.value.get()) : metrics;
+    // Optional-chained deliberately: hand-built test fakes for `metrics` may
+    // not provide an `.error` computed, and they should keep working.
+    const metricsError = isAsyncMetrics ? metrics.error?.get() : undefined;
 
     return (
       <div className={cssNames("ResourceMetrics flex flex-col", className)}>
@@ -76,6 +87,7 @@ export const ResourceMetrics = observer(
             tab,
             metrics: currentMetrics,
             isPending,
+            metricsError,
           }}
         >
           <div className="graph">{children}</div>

--- a/packages/technical-features/prometheus/src/provider.ts
+++ b/packages/technical-features/prometheus/src/provider.ts
@@ -75,6 +75,7 @@ export async function findFirstNamespacedService(
   } catch (error) {
     throw new Error(
       `Failed to list services in all namespaces: ${isRequestError(error) ? error.response?.body.message : error}`,
+      { cause: error },
     );
   }
 
@@ -103,6 +104,7 @@ export async function findNamespacedService(
       `Failed to list services in namespace="${namespace}": ${
         isRequestError(error) ? error.response?.body.message : error
       }`,
+      { cause: error },
     );
   }
 }

--- a/packages/utility-features/json-api/package.json
+++ b/packages/utility-features/json-api/package.json
@@ -20,7 +20,8 @@
   "main": "./index.ts",
   "types": "./index.ts",
   "scripts": {
-    "clean:dist": "pnpm dlx rimraf@6.1.3 dist"
+    "clean:dist": "pnpm dlx rimraf@6.1.3 dist",
+    "test:unit": "vitest run -c ../../../vitest.config.ts --project @freelensapp/json-api"
   },
   "dependencies": {
     "@freelensapp/event-emitter": "workspace:^",
@@ -31,9 +32,11 @@
     "@freelensapp/logger": "workspace:^",
     "@freelensapp/typescript": "workspace:^",
     "@types/node": "~24.12.4",
+    "jsdom": "^29.1.1",
     "node-fetch": "^3.3.2",
     "rfc6902": "^5.2.0",
-    "type-fest": "^5.6.0"
+    "type-fest": "^5.6.0",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/utility-features/json-api/src/json-api.test.ts
+++ b/packages/utility-features/json-api/src/json-api.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { JsonApiErrorParsed } from "./json-api";
+
+import type { JsonApiError, KubeJsonApiError } from "./json-api";
+
+describe("JsonApiErrorParsed", () => {
+  it("exposes the parsed JsonApiError via the data getter", () => {
+    const parsedError: JsonApiError = { code: 404, message: "Not Found" };
+    const error = new JsonApiErrorParsed(parsedError, ["Not Found"]);
+
+    expect(error.data).toBe(parsedError);
+  });
+
+  it("exposes the parsed KubeJsonApiError via the data getter", () => {
+    const parsedError: KubeJsonApiError = {
+      kind: "Status",
+      apiVersion: "v1",
+      metadata: {},
+      status: "Failure",
+      message: "some kube error",
+      reason: "NotFound",
+      details: { name: "some-name", group: "some-group", kind: "some-kind", causes: [] },
+      code: 404,
+    };
+    const error = new JsonApiErrorParsed(parsedError, ["some kube error"]);
+
+    expect(error.data).toBe(parsedError);
+  });
+
+  it("exposes a DOMException via the data getter", () => {
+    const parsedError = new DOMException("The operation was aborted", "AbortError");
+    const error = new JsonApiErrorParsed(parsedError, ["The operation was aborted"]);
+
+    expect(error.data).toBe(parsedError);
+  });
+});

--- a/packages/utility-features/json-api/src/json-api.ts
+++ b/packages/utility-features/json-api/src/json-api.ts
@@ -106,6 +106,10 @@ export class JsonApiErrorParsed {
     return this.error.code === DOMException.ABORT_ERR;
   }
 
+  get data(): JsonApiError | DOMException | KubeJsonApiError {
+    return this.error;
+  }
+
   toString() {
     return this.messages.join("\n");
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1988,6 +1988,9 @@ importers:
       '@types/node':
         specifier: ~24.12.4
         version: 24.12.4
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -1997,6 +2000,9 @@ importers:
       type-fest:
         specifier: ^5.6.0
         version: 5.6.0
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.12.4)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.2(supports-color@8.1.1))(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.62.0(supports-color@8.1.1))(terser@5.39.0))
 
   packages/utility-features/kube-api:
     dependencies:


### PR DESCRIPTION
## Problem

When Prometheus metrics cannot be fetched, all detail-view charts show only the generic "Metrics not available at the moment". The real cause is invisible:

- The `POST /api/metrics` route swallows every failure and returns HTTP 200 with `{}`, so the renderer cannot distinguish a fetch error from an empty result.
- The main-process log line drops `error.cause`, so even the logs only say `Error: No Prometheus service found` or `Error: Metrics not available` with no HTTP status and no Kubernetes error message (e.g. the RBAC `Forbidden` body).
- If the renderer metrics request rejects unexpectedly, the chart hangs on a spinner forever: the `asyncComputed` wrapper in `create-time-ranged-metrics.ts` has no rejection handler, so `pending` never resolves.

In practice this makes RBAC-restricted clusters (users without `services list` / `services/proxy` permissions) undiagnosable from inside the app: auto-detection fails, manual configuration fails, and the UI gives no hint why.

Related: #1078, #1566.

## Changes

One commit per independent fix:

1. **Preserve the original Kubernetes API error when Prometheus service discovery fails** — the re-throws in `provider.ts` now attach `{ cause }`, so the Kubernetes client error (with its HTTP status) survives the chain instead of being flattened into a string.
2. **Log the real cause when the metrics route fails** — new `metrics-error-classification.ts` classifies failures (`not-found` / `access-denied` / `error`) by walking the cause chain, and the warn log now includes the serialized cause chain (HTTP statuses, per-provider detection errors) instead of only the outer message.
3. **Fix metrics charts hanging on a spinner forever after a failed request** — `create-time-ranged-metrics.ts` now catches request rejections (always resolving, since `asyncComputed` has no rejection handler) and exposes the failure as an observable `error` alongside `value`/`pending`.
4. **Surface the reason when Prometheus metrics are unavailable** — the route returns a structured `MetricsErrorInfo` with a proper status code (503 not-found / 403 access-denied / carried status otherwise), and `NoMetrics` shows a reason-specific message ("No Prometheus service was found for this cluster." / "Access to Prometheus metrics was denied.") with an "Open cluster settings" link and the raw detail in the tooltip. The generic no-data state renders exactly as before. All direct `requestMetrics` call sites were audited and now handle rejection (cluster overview, nodes list) by falling back to the previous empty-metrics behavior.

## Compatibility

The successful response shape of `POST /api/metrics` is unchanged. Extension callers of `Renderer.K8sApi.requestMetrics` keep resolving with the same data on success; on failure they get a rejected promise (carrying a structured error body) instead of a silently empty object.

## Testing

- New unit tests: error classification (main), metrics route error responses and logging payload, renderer error classifier, `create-time-ranged-metrics` rejection/recovery, `NoMetrics` states and settings-link navigation, `JsonApiErrorParsed.data` accessor, cluster overview metrics fallback.
- Full `@freelensapp/core` suite: 2405 passed / 27 skipped (baseline before this branch: 2385 / 27), no regressions; full monorepo type-check clean; biome/trunk clean.

## Remaining before marking ready

- [ ] Manual verification in the running app against a cluster where metrics fail (RBAC-restricted or no Prometheus): pod detail should show the reason and the settings link instead of the generic message, and `lens.log` should contain the serialized cause (e.g. the Kubernetes `Forbidden` details).
