### PR TITLE
Document true cause of the react-dom 19 override

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,9 +26,16 @@ overrides:
   http-proxy: npm:http-proxy-node16@^1.0.6
   http-proxy-middleware: ^3.0.7
   mobx-react: ^9.1.1
-  # React 19 bump: several deps still peer on react-dom ^18, which forks a
-  # second react-dom copy (18.3.1 built against react 19) in the tree. This
-  # override collapses everything onto the single react-dom 19 we ship.
+  # React 19 bump: @ogre-tools/injectable-react@17.11.1 declares a non-optional
+  # `react-dom: "^17 || ^18"` peer (no ^19), which forks a second react-dom copy
+  # (18.3.1 built against react 19) into the tree. Other deps with wide/optional
+  # react-dom peers (mobx-react, react-window, mui via react-transition-group,
+  # @testing-library/react) then dedupe onto that 18 copy. This override collapses
+  # everything onto the single react-dom 19 we ship. Note: this is NOT caused by
+  # react-window (its peer range already includes ^19); migrating react-window
+  # does not remove the need for this. The override can be dropped once
+  # @ogre-tools/injectable-react is bumped to >=19 (from v19 it drops the
+  # react-dom peer and its react peer becomes ^18 || ^19).
   react-dom: ^19.2.8
   tmp@^0.2.0: ^0.2.7
 


### PR DESCRIPTION
Part of #2278 (Phase 3 of the React upgrade, part of #2154).

While starting the `react-window 1 → v2` task, I verified the premise behind the temporary `react-dom` override from #2280 and found it is inaccurate. This PR takes the sanctioned fallback: keep react-window on v1 (already React-19-compatible), keep the override, and correct its comment to name the real cause.

## Findings

- `react-window@1.8.11` already peers on React 19 (`^15 || … || ^19`), so it is not the cause of the forked react-dom 18 copy.
- The react-dom 18.3.1 fork originates from `@ogre-tools/injectable-react@17.11.1`, whose non-optional peer is `react-dom: "^17 || ^18"` (no ^19). mobx-react, react-window, mui (via react-transition-group), and @testing-library/react then dedupe onto that copy.
- Migrating react-window to v2 does NOT remove the need for the override. The real removal path is bumping `@ogre-tools/injectable-react` to >=19 (from v19 it drops the react-dom peer) — a DI-wide major, out of scope here.

## Change

Comment-only correction to the `react-dom` override in `pnpm-workspace.yaml`. No dependency or lockfile change; `pnpm install --frozen-lockfile` passes unchanged.

## Recommended follow-ups (decoupled)

- react-window 1 → v2 as its own PR with live smoke-testing (v2 is a rewrite: ResizeObserver sizing, no onScroll-offset/resetAfterIndex/outerRef, jsdom scroll test breakage).
- `@ogre-tools/injectable-react` >=19 bump as the actual enabler for removing the react-dom override.

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`