### PR TITLE
Adopt React 19 ref-as-prop and direct context providers

### DIFF
--- a/packages/core/src/renderer/components/dock/logs/list.tsx
+++ b/packages/core/src/renderer/components/dock/logs/list.tsx
@@ -498,6 +498,6 @@ const InjectedNonForwardedLogList = withInjectables<
   }),
 });
 
-export const LogList = React.forwardRef<LogListRef, LogListProps>((props, ref) => (
-  <InjectedNonForwardedLogList {...props} innerRef={ref} />
-));
+export const LogList = ({ ref, ...props }: LogListProps & { ref?: ForwardedRef<LogListRef> }) => (
+  <InjectedNonForwardedLogList {...props} innerRef={ref ?? null} />
+);

--- a/packages/core/src/renderer/components/menu/menu.tsx
+++ b/packages/core/src/renderer/components/menu/menu.tsx
@@ -443,7 +443,7 @@ class NonInjectedMenu extends React.Component<MenuProps & Dependencies, State> {
       menu = <Animate enter={this.isOpen}>{menu}</Animate>;
     }
 
-    menu = <MenuContext.Provider value={this}>{menu}</MenuContext.Provider>;
+    menu = <MenuContext value={this}>{menu}</MenuContext>;
 
     if (!usePortal) {
       return menu;

--- a/packages/core/src/renderer/components/monaco-editor/__mocks__/monaco-editor.tsx
+++ b/packages/core/src/renderer/components/monaco-editor/__mocks__/monaco-editor.tsx
@@ -37,6 +37,6 @@ class FakeMonacoEditor extends React.Component<MonacoEditorProps> {
   }
 }
 
-export const MonacoEditor = React.forwardRef<MonacoEditorRef, MonacoEditorProps>((props, ref) => (
+export const MonacoEditor = ({ ref, ...props }: MonacoEditorProps & { ref?: React.ForwardedRef<MonacoEditorRef> }) => (
   <FakeMonacoEditor innerRef={ref} {...props} />
-));
+);

--- a/packages/core/src/renderer/components/monaco-editor/monaco-editor.tsx
+++ b/packages/core/src/renderer/components/monaco-editor/monaco-editor.tsx
@@ -347,12 +347,20 @@ class NonInjectedMonacoEditor extends React.Component<MonacoEditorProps & Depend
   }
 }
 
-const ForwardedRefMonacoEditor = React.forwardRef<MonacoEditorRef, MonacoEditorProps & Dependencies>((props, ref) => (
+const ForwardedRefMonacoEditor = ({
+  ref,
+  ...props
+}: MonacoEditorProps & Dependencies & { ref?: React.ForwardedRef<MonacoEditorRef> }) => (
   <NonInjectedMonacoEditor innerRef={ref} {...props} />
-));
+);
 
 export const MonacoEditor = withInjectables<Dependencies, MonacoEditorProps, MonacoEditorRef>(
-  ForwardedRefMonacoEditor,
+  // `withInjectables`'s ref-forwarding overload is typed for a
+  // `ForwardRefExoticComponent`; `ForwardedRefMonacoEditor` now takes `ref` as a
+  // regular prop (React 19), which the wrapper still forwards at runtime.
+  ForwardedRefMonacoEditor as unknown as React.ForwardRefExoticComponent<
+    MonacoEditorProps & Dependencies & React.RefAttributes<MonacoEditorRef>
+  >,
   {
     getProps: (di, props) => ({
       ...props,

--- a/packages/core/src/renderer/components/namespaces/namespace-tree-view.tsx
+++ b/packages/core/src/renderer/components/namespaces/namespace-tree-view.tsx
@@ -45,11 +45,10 @@ function NonInjectableNamespaceTreeView({ tree, namespaces, getDetailsUrl }: Dep
 
   const classes = { group: styles.group, label: styles.label };
 
-  const ExpandOnIconClickComponent = React.forwardRef(function ExpandOnIconClickComponent(
-    props: TreeItemContentProps,
-    ref,
-  ) {
-    const { classes, className, label, nodeId, icon: iconProp, expansionIcon, displayIcon } = props;
+  const ExpandOnIconClickComponent = function ExpandOnIconClickComponent(props: TreeItemContentProps) {
+    // React 19 passes `ref` as a regular prop; `TreeItemContentProps` already
+    // declares it (typed `Ref<unknown>`), so read it from props.
+    const { classes, className, label, nodeId, icon: iconProp, expansionIcon, displayIcon, ref } = props;
 
     const { disabled, expanded, selected, focused, handleExpansion, handleSelection, preventSelection } =
       useTreeItem(nodeId);
@@ -87,7 +86,7 @@ function NonInjectableNamespaceTreeView({ tree, namespaces, getDetailsUrl }: Dep
         </Typography>
       </div>
     );
-  });
+  };
 
   const handleToggle = (event: React.SyntheticEvent, nodeIds: string[]) => {
     setExpanded(nodeIds);

--- a/packages/core/src/renderer/components/radio/radio.tsx
+++ b/packages/core/src/renderer/components/radio/radio.tsx
@@ -26,7 +26,7 @@ interface RadioGroupContext {
   onSelect: (newValue: any) => void;
 }
 
-const radioGroupContext = React.createContext<RadioGroupContext>({
+const RadioGroupContext = React.createContext<RadioGroupContext>({
   disabled: false,
   value: undefined,
   onSelect: noop,
@@ -42,9 +42,7 @@ export function RadioGroup<T>({
 }: RadioGroupProps<T>) {
   return (
     <div className={cssNames("RadioGroup", { buttonsView: asButtons }, className)}>
-      <radioGroupContext.Provider value={{ disabled, onSelect: onChange, value }}>
-        {children}
-      </radioGroupContext.Provider>
+      <RadioGroupContext value={{ disabled, onSelect: onChange, value }}>{children}</RadioGroupContext>
     </div>
   );
 }
@@ -57,7 +55,7 @@ export interface RadioProps<T> {
 }
 
 export function Radio<T>({ className, label, value, disabled = false }: RadioProps<T>) {
-  const ctx = useContext(radioGroupContext);
+  const ctx = useContext(RadioGroupContext);
   const ref = useRef<HTMLLabelElement | null>(null);
   const checked = ctx.value === value;
 

--- a/packages/core/src/renderer/components/resource-metrics/resource-metrics.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/resource-metrics.tsx
@@ -69,7 +69,7 @@ export const ResourceMetrics = observer(
             ))}
           </RadioGroup>
         </div>
-        <ResourceMetricsContext.Provider
+        <ResourceMetricsContext
           value={{
             object,
             tab,
@@ -78,7 +78,7 @@ export const ResourceMetrics = observer(
           }}
         >
           <div className="graph">{children}</div>
-        </ResourceMetricsContext.Provider>
+        </ResourceMetricsContext>
         <div className="loader">
           <Spinner />
         </div>

--- a/packages/core/src/renderer/components/tabs/tabs.tsx
+++ b/packages/core/src/renderer/components/tabs/tabs.tsx
@@ -44,7 +44,7 @@ export class Tabs<D> extends React.PureComponent<TabsProps<D>> {
     });
 
     return (
-      <TabsContext.Provider value={{ autoFocus, value, onChange }}>
+      <TabsContext value={{ autoFocus, value, onChange }}>
         <div
           {...elemProps}
           className={className}
@@ -52,7 +52,7 @@ export class Tabs<D> extends React.PureComponent<TabsProps<D>> {
             this.elem = elem;
           }}
         />
-      </TabsContext.Provider>
+      </TabsContext>
     );
   }
 }

--- a/packages/core/src/renderer/components/virtual-list/virtual-list.tsx
+++ b/packages/core/src/renderer/components/virtual-list/virtual-list.tsx
@@ -144,9 +144,14 @@ function VirtualListInner<T extends { getId(): string } | string>({
   );
 }
 
-export const VirtualList = React.forwardRef<VirtualListRef, VirtualListProps<string>>((props, ref) => (
-  <VirtualListInner {...props} forwardedRef={ref} />
-)) as <T extends { getId(): string } | string>(
+const VirtualListWithRef = <T extends { getId(): string } | string>({
+  ref,
+  ...props
+}: VirtualListProps<T> & { ref?: ForwardedRef<VirtualListRef> }) => (
+  <VirtualListInner<T> {...props} forwardedRef={ref} />
+);
+
+export const VirtualList = VirtualListWithRef as <T extends { getId(): string } | string>(
   props: VirtualListProps<T> & { ref?: ForwardedRef<VirtualListRef> },
 ) => React.JSX.Element;
 

--- a/packages/routing/src/link.tsx
+++ b/packages/routing/src/link.tsx
@@ -7,7 +7,7 @@
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { parsePath } from "history";
 import { observer } from "mobx-react";
-import React, { forwardRef } from "react";
+import React from "react";
 import { matchPath } from "./match-path";
 import { observableHistoryInjectionToken } from "./observable-history.injectable";
 
@@ -62,33 +62,40 @@ interface LinkDependencies {
   history: ObservableHistory;
 }
 
-const NonInjectedLink = forwardRef<HTMLAnchorElement, LinkProps & LinkDependencies>(
-  ({ history, to, replace, onClick, target, ...rest }, ref) => {
-    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-      onClick?.(event);
+const NonInjectedLink = ({
+  history,
+  to,
+  replace,
+  onClick,
+  target,
+  ref,
+  ...rest
+}: LinkProps & LinkDependencies & { ref?: React.Ref<HTMLAnchorElement> }) => {
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
 
-      if (!event.defaultPrevented && event.button === 0 && (!target || target === "_self") && !isModifiedEvent(event)) {
-        event.preventDefault();
+    if (!event.defaultPrevented && event.button === 0 && (!target || target === "_self") && !isModifiedEvent(event)) {
+      event.preventDefault();
 
-        if (replace) {
-          history.replace(to);
-        } else {
-          history.push(to);
-        }
+      if (replace) {
+        history.replace(to);
+      } else {
+        history.push(to);
       }
-    };
+    }
+  };
 
-    const href = history.createHref(resolveHrefTarget(to, history.location.pathname));
+  const href = history.createHref(resolveHrefTarget(to, history.location.pathname));
 
-    return <a {...rest} ref={ref} href={href} target={target} onClick={handleClick} />;
-  },
-);
+  return <a {...rest} ref={ref} href={href} target={target} onClick={handleClick} />;
+};
 
 NonInjectedLink.displayName = "NonInjectedLink";
 
-// `withInjectables` forwards refs at runtime (see the `injectable-react`
-// `forwardRef` wrapper) but does not surface `ref` in its public props type;
-// annotate the export so call sites (e.g. `<Icon>`'s `NavLink`) can pass one.
+// `NonInjectedLink` takes `ref` as a regular prop (React 19). `withInjectables`
+// forwards it at runtime but types its result as `FunctionComponent<Props>`,
+// which omits `ref`; annotate the export so call sites (e.g. `<Icon>`'s
+// `NavLink`) can pass one.
 export const Link = withInjectables<LinkDependencies, LinkProps>(NonInjectedLink, {
   getProps: (di, props) => ({
     ...props,
@@ -118,45 +125,43 @@ interface NavLinkDependencies {
   history: ObservableHistory;
 }
 
-const NonInjectedNavLink = observer(
-  forwardRef<HTMLAnchorElement, NavLinkProps & NavLinkDependencies>((props, ref) => {
-    const {
-      history,
-      to,
-      exact = false,
-      strict = false,
-      sensitive = false,
-      isActive: getIsActive,
-      activeClassName = "active",
-      activeStyle,
-      className,
-      style,
-      "aria-current": ariaCurrent = "page",
-      ...rest
-    } = props;
+// `observer` returns the wrapped component's type verbatim, which has no
+// `displayName` expando; a named function expression names it for React DevTools
+// instead. `ref` is a regular prop under React 19, forwarded on to `<Link>`.
+const NonInjectedNavLink = observer(function NonInjectedNavLink({
+  history,
+  to,
+  exact = false,
+  strict = false,
+  sensitive = false,
+  isActive: getIsActive,
+  activeClassName = "active",
+  activeStyle,
+  className,
+  style,
+  "aria-current": ariaCurrent = "page",
+  ref,
+  ...rest
+}: NavLinkProps & NavLinkDependencies & { ref?: React.Ref<HTMLAnchorElement> }) {
+  const location = history.location;
+  const path = typeof to === "string" ? to : to.pathname;
+  // Match `react-router-dom` v5: escape the path so `matchPath` treats it as a
+  // literal pattern rather than interpreting the target as a route schema.
+  const escapedPath = path?.replace(/([.+*?=^!:${}()[\]|/\\])/g, "\\$1");
+  const match = escapedPath ? matchPath(location.pathname, { path: escapedPath, exact, strict, sensitive }) : null;
+  const isActive = Boolean(getIsActive ? getIsActive(match, location) : match);
 
-    const location = history.location;
-    const path = typeof to === "string" ? to : to.pathname;
-    // Match `react-router-dom` v5: escape the path so `matchPath` treats it as a
-    // literal pattern rather than interpreting the target as a route schema.
-    const escapedPath = path?.replace(/([.+*?=^!:${}()[\]|/\\])/g, "\\$1");
-    const match = escapedPath ? matchPath(location.pathname, { path: escapedPath, exact, strict, sensitive }) : null;
-    const isActive = Boolean(getIsActive ? getIsActive(match, location) : match);
-
-    return (
-      <Link
-        {...rest}
-        ref={ref}
-        to={to}
-        className={isActive ? [className, activeClassName].filter(Boolean).join(" ") : className}
-        style={isActive && activeStyle ? { ...style, ...activeStyle } : style}
-        aria-current={isActive ? ariaCurrent : undefined}
-      />
-    );
-  }),
-);
-
-NonInjectedNavLink.displayName = "NonInjectedNavLink";
+  return (
+    <Link
+      {...rest}
+      ref={ref}
+      to={to}
+      className={isActive ? [className, activeClassName].filter(Boolean).join(" ") : className}
+      style={isActive && activeStyle ? { ...style, ...activeStyle } : style}
+      aria-current={isActive ? ariaCurrent : undefined}
+    />
+  );
+});
 
 export const NavLink = withInjectables<NavLinkDependencies, NavLinkProps>(NonInjectedNavLink, {
   getProps: (di, props) => ({


### PR DESCRIPTION
Implements the two optional React 19 cleanups from #2278 (Phase 3 of the React upgrade), part of #2154. Both are mechanical, behavior-preserving; no runtime behavior changes.

## Commit 1 - forwardRef -> ref-as-prop

React 19 makes `ref` a regular prop for function components, so the `React.forwardRef` wrappers are dropped in favour of reading `ref` from props:

- `namespaces/namespace-tree-view.tsx` (`ExpandOnIconClickComponent`)
- `virtual-list/virtual-list.tsx` (`VirtualList`)
- `monaco-editor/monaco-editor.tsx` (`ForwardedRefMonacoEditor`) and its `__mocks__`
- `dock/logs/list.tsx` (`LogList`)
- `routing/src/link.tsx` (`Link` and `NavLink`)

`VirtualList`, `MonacoEditor` and `Link`/`NavLink` stay extension-facing: ref-as-prop is source-compatible for consumers, so their exports and public types are unchanged. `withInjectables` still forwards the ref at runtime (`MonacoEditor` keeps a cast to satisfy the wrapper's `ForwardRefExoticComponent`-typed ref overload). The `Link` comment about ref not surfacing in the public type is updated.

## Commit 2 - Context.Provider -> `<Context>`

React 19 lets a context render as its own provider:

- `tabs/tabs.tsx` (`TabsContext`)
- `radio/radio.tsx` (`radioGroupContext` renamed to `RadioGroupContext` so the lowercase name can be used as a capitalized JSX element)
- `resource-metrics/resource-metrics.tsx` (`ResourceMetricsContext`)
- `menu/menu.tsx` (`MenuContext`)

## Validation

- `pnpm type:check` - 0 errors
- `pnpm biome check` - clean; `pnpm trunk check` - no issues on all changed files
- core unit suite: 2363 passed / 0 failed (27 skipped); routing: 55 passed. No snapshot churn.

The tracking issue #2278 stays open (not `Closes`).

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`