### PR TITLE
Enable React.StrictMode (with Chart unmount fix)

### DIFF
--- a/packages/core/src/renderer/components/chart/chart.tsx
+++ b/packages/core/src/renderer/components/chart/chart.tsx
@@ -118,6 +118,14 @@ export class Chart extends React.Component<ChartProps> {
     }
   }
 
+  componentWillUnmount() {
+    // Destroy the Chart.js instance so its canvas is released. Without this the
+    // instance leaks on unmount and a remount hits "Canvas is already in use"
+    // (surfaced by React.StrictMode's mount → unmount → mount double-invoke).
+    this.chart?.destroy();
+    this.chart = null;
+  }
+
   memoizeDataProps() {
     const { data } = this.props;
 

--- a/packages/technical-features/react-application/src/render-application/react-root.injectable.ts
+++ b/packages/technical-features/react-application/src/render-application/react-root.injectable.ts
@@ -1,4 +1,5 @@
 import { getInjectable, getInjectionToken } from "@ogre-tools/injectable";
+import { createElement, StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import type React from "react";
@@ -32,7 +33,10 @@ const reactRootInjectable = getInjectable({
     };
 
     return {
-      render: (container, application) => getRoot(container).render(application),
+      // Spike: wrap the application in React.StrictMode to surface impure
+      // renders and missing effect cleanup (double render / mount-unmount-mount)
+      // in development. Dev-only behaviour; no effect in a production build.
+      render: (container, application) => getRoot(container).render(createElement(StrictMode, null, application)),
       unmount: (container) => {
         const root = roots.get(container);
 


### PR DESCRIPTION
## Summary

Enables `React.StrictMode` around the app root and fixes the one real bug it surfaced (a `Chart` instance leaked on unmount). StrictMode is **dev-only — no production effect**; it double-invokes render and mounts effects (mount → unmount → mount) in development to catch impure renders and missing cleanup, which is exactly the class of regression this React-19 phase hit (stale state on remount, crash on teardown). Refs #2278.

## What changed

- **Enable StrictMode** — wrap the rendered application in `React.StrictMode` in `react-root.injectable.ts` (covers both the top frame and the cross-origin cluster iframe).
- **Fix `Chart` unmount leak** — `Chart` created a Chart.js instance in `componentDidMount` but never destroyed it. On remount that hit `Error: Canvas is already in use`; StrictMode's double-invoke made it a hard crash of the cluster metrics view. Added `componentWillUnmount` → `chart.destroy()`. (This is a genuine leak on any unmount/remount, independent of StrictMode.)

## Triage (verified live against a real cluster)

With the `Chart` fix, **the crash is gone and no other view fails under StrictMode.** Exercised across the top frame and the cluster iframe:

| View / component class | Result |
|---|---|
| Cluster metrics (charts) | ✅ fixed (was the only crash) |
| Pods / Nodes / Config Maps lists (react-window) | ✅ |
| Pod detail drawer, pod logs (dock), edit resource (monaco) | ✅ |
| Context menu, ConfirmDialog, dock tabs, sidebar, catalog | ✅ |
| **dnd-kit hotbar reorder** (manual drag) | ✅ no errors |

## Known non-blocking follow-ups (pre-existing, not caused by this PR)

StrictMode makes a few pre-existing issues louder in the dev console; none crash:

- `[mobx-react] disposeOnUnmount is not compatible with React 18+` — migrate call sites to `useEffect` + disposer cleanup.
- Duplicate React key `k3s-Update` — a non-unique key in an always-mounted list.
- `[KubeObjectStore] loadAll … AbortError` — StrictMode aborts the throwaway-mount fetch; shows abort-on-unmount cleanup works, just log noise.

These can be cleaned up incrementally and do not block enabling StrictMode (dev-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| Model: `claude-opus-4-8`
