### PR TITLE
Replace mobx-react disposeOnUnmount with componentWillUnmount cleanup

### DIFF
--- a/packages/core/src/extensions/ipc/ipc-renderer.ts
+++ b/packages/core/src/extensions/ipc/ipc-renderer.ts
@@ -24,7 +24,8 @@ export abstract class IpcRenderer extends IpcRegistrar {
   /**
    * Listen for broadcasts within your extension.
    * If the lifetime of the listener should be tied to the mounted lifetime of
-   * a component then putting the returned value in a `disposeOnUnmount` call will suffice.
+   * a component then storing the returned disposer and calling it from the
+   * component's `componentWillUnmount` will suffice.
    * @param channel The channel to listen for broadcasts on
    * @param listener The function that will be called with the arguments of the broadcast
    * @returns An optional disposer, Lens will cleanup even if this is not called

--- a/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubeconfig-sync/kubeconfig-sync.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/kubernetes/kubeconfig-sync/kubeconfig-sync.tsx
@@ -9,7 +9,7 @@ import { Spinner } from "@freelensapp/spinner";
 import { iter, tuple } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { computed, makeObservable, observable, reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import isWindowsInjectable from "../../../../../../common/vars/is-windows.injectable";
 import { Notice } from "../../../../../../renderer/components/extensions/notice";
@@ -40,6 +40,7 @@ interface Dependencies {
 
 @observer
 class NonInjectedKubeconfigSync extends React.Component<Dependencies> {
+  private readonly disposers: (() => void)[] = [];
   readonly syncs = observable.map<string, SyncKind>();
   @observable loaded = false;
 
@@ -56,14 +57,18 @@ class NonInjectedKubeconfigSync extends React.Component<Dependencies> {
     this.syncs.replace(mapEntries);
     this.loaded = true;
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => Array.from(this.syncs.entries(), ([filePath, kind]) => tuple.from(filePath, kind)),
         (syncs) => {
           this.props.state.syncKubeconfigEntries.replace(syncs);
         },
       ),
-    ]);
+    );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   @computed get syncsList(): Entry[] | undefined {

--- a/packages/core/src/renderer/components/catalog/catalog.tsx
+++ b/packages/core/src/renderer/components/catalog/catalog.tsx
@@ -13,7 +13,7 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { showErrorNotificationInjectable } from "@freelensapp/notifications";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { action, makeObservable, observable, reaction, runInAction, when } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import emitAppEventInjectable from "../../../common/app-event-bus/emit-event.injectable";
 import catalogCategoryRegistryInjectable from "../../../common/catalog/category-registry.injectable";
@@ -84,6 +84,7 @@ interface Dependencies {
 
 @observer
 class NonInjectedCatalog extends React.Component<Dependencies> {
+  private readonly disposers: (() => void)[] = [];
   private readonly menuItems = observable.array<CatalogEntityContextMenu>();
   @observable activeTab: string | undefined = undefined;
 
@@ -127,7 +128,7 @@ class NonInjectedCatalog extends React.Component<Dependencies> {
       return catalogPreviousActiveTabStorage.get() || browseCatalogTab;
     };
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       catalogEntityStore.watch(),
       reaction(
         () => routeActiveTab(),
@@ -181,12 +182,16 @@ class NonInjectedCatalog extends React.Component<Dependencies> {
           }
         },
       ),
-    ]);
+    );
 
     this.props.emitEvent({
       name: "catalog",
       action: "open",
     });
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   addToHotbar(entity: CatalogEntity): void {

--- a/packages/core/src/renderer/components/cluster-manager/cluster-manager.tsx
+++ b/packages/core/src/renderer/components/cluster-manager/cluster-manager.tsx
@@ -9,7 +9,7 @@ import "./cluster-manager.scss";
 import { Redirect } from "@freelensapp/routing";
 import { buildURL, cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import welcomeRouteInjectable from "../../../common/front-end-routing/routes/welcome/welcome-route.injectable";
 import userPreferencesStateInjectable from "../../../features/user-preferences/common/state.injectable";
@@ -36,8 +36,14 @@ interface Dependencies {
 
 @observer
 class NonInjectedClusterManager extends React.Component<Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.watchForGeneralEntityNavigation()]);
+    this.disposers.push(this.props.watchForGeneralEntityNavigation());
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   renderMainComponent() {

--- a/packages/core/src/renderer/components/cluster-manager/cluster-status.tsx
+++ b/packages/core/src/renderer/components/cluster-manager/cluster-status.tsx
@@ -10,7 +10,7 @@ import { Spinner } from "@freelensapp/spinner";
 import { cssNames, hasTypedProperty, isObject, isString } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { computed, makeObservable, observable } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import navigateToEntitySettingsInjectable from "../../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
 import { ipcRendererOn } from "../../../common/ipc";
@@ -39,6 +39,8 @@ interface Dependencies {
 
 @observer
 class NonInjectedClusterStatus extends React.Component<ClusterStatusProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   @observable authOutput: KubeAuthUpdate[] = [];
   @observable isReconnecting = false;
 
@@ -63,7 +65,7 @@ class NonInjectedClusterStatus extends React.Component<ClusterStatusProps & Depe
   }
 
   componentDidMount() {
-    disposeOnUnmount(this, [
+    this.disposers.push(
       ipcRendererOn(`cluster:${this.cluster.id}:connection-update`, (evt, res: unknown) => {
         if (
           isObject(res) &&
@@ -77,7 +79,11 @@ class NonInjectedClusterStatus extends React.Component<ClusterStatusProps & Depe
           console.warn(`Got invalid connection update for ${this.cluster.id}`, { update: res });
         }
       }),
-    ]);
+    );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   componentDidUpdate(prevProps: Readonly<ClusterStatusProps>): void {

--- a/packages/core/src/renderer/components/cluster-manager/cluster-view.tsx
+++ b/packages/core/src/renderer/components/cluster-manager/cluster-view.tsx
@@ -8,7 +8,7 @@ import "./cluster-view.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import navigateToCatalogInjectable from "../../../common/front-end-routing/routes/catalog/navigate-to-catalog.injectable";
 import requestClusterActivationInjectable from "../../../features/cluster/activation/renderer/request-activation.injectable";
@@ -40,6 +40,8 @@ interface Dependencies {
 
 @observer
 class NonInjectedClusterView extends React.Component<Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   constructor(props: Dependencies) {
     super(props);
   }
@@ -75,6 +77,7 @@ class NonInjectedClusterView extends React.Component<Dependencies> {
   componentWillUnmount() {
     this.props.clusterFrames.clearVisibleCluster();
     this.props.entityRegistry.activeEntity = undefined;
+    this.disposers.forEach((dispose) => dispose());
   }
 
   bindEvents() {
@@ -83,7 +86,7 @@ class NonInjectedClusterView extends React.Component<Dependencies> {
     // clusterId observable directly instead of this.props.
     const { clusterId, clusterFrames, entityRegistry, navigateToCatalog, requestClusterActivation } = this.props;
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => clusterId.get(),
         async (id) => {
@@ -105,7 +108,7 @@ class NonInjectedClusterView extends React.Component<Dependencies> {
           fireImmediately: true,
         },
       ),
-    ]);
+    );
   }
 
   renderStatus(): StrictReactNode {

--- a/packages/core/src/renderer/components/cluster-settings/metrics-setting.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/metrics-setting.tsx
@@ -7,7 +7,7 @@
 import { Button } from "@freelensapp/button";
 import { Icon } from "@freelensapp/icon";
 import { makeObservable, observable, reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { SubTitle } from "../layout/sub-title";
@@ -21,6 +21,8 @@ export interface ClusterMetricsSettingProps {
 
 @observer
 export class ClusterMetricsSetting extends React.Component<ClusterMetricsSettingProps> {
+  private readonly disposers: (() => void)[] = [];
+
   @observable hiddenMetrics = observable.set<string>();
 
   constructor(props: ClusterMetricsSettingProps) {
@@ -36,14 +38,18 @@ export class ClusterMetricsSetting extends React.Component<ClusterMetricsSetting
 
     this.hiddenMetrics = observable.set<string>(cluster.preferences.hiddenMetrics ?? []);
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => cluster.preferences.hiddenMetrics,
         () => {
           this.hiddenMetrics = observable.set<string>(cluster.preferences.hiddenMetrics ?? []);
         },
       ),
-    ]);
+    );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   save = () => {

--- a/packages/core/src/renderer/components/cluster-settings/name-setting.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/name-setting.tsx
@@ -5,7 +5,7 @@
  */
 
 import { autorun, makeObservable, observable } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { Input } from "../input";
 import { isRequired } from "../input/input_validators";
@@ -21,6 +21,8 @@ export interface ClusterNameSettingProps {
 
 @observer
 export class ClusterNameSetting extends React.Component<ClusterNameSettingProps> {
+  private readonly disposers: (() => void)[] = [];
+
   @observable name = "";
 
   constructor(props: ClusterNameSettingProps) {
@@ -33,12 +35,15 @@ export class ClusterNameSetting extends React.Component<ClusterNameSettingProps>
     // inside a derivation (the autorun below).
     const { cluster, entity } = this.props;
 
-    disposeOnUnmount(
-      this,
+    this.disposers.push(
       autorun(() => {
         this.name = cluster.preferences.clusterName || entity.getName();
       }),
     );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   save = () => {

--- a/packages/core/src/renderer/components/cluster-settings/prometheus-setting.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/prometheus-setting.tsx
@@ -7,7 +7,7 @@
 import { Spinner } from "@freelensapp/spinner";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { autorun, computed, makeObservable, observable } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { initialFilesystemMountpoints } from "../../../common/cluster-types";
 import requestMetricsProvidersInjectable from "../../../common/k8s-api/endpoints/metrics.api/request-providers.injectable";
@@ -74,6 +74,8 @@ const requestMethodOptions: SelectOption<PrometheusRequestMethod>[] = [
 
 @observer
 class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometheusSettingProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   @observable mountpoints = "";
   @observable path = ""; // <namespace>/<service>:<port>
   @observable customPrefix = ""; // e.g. "/prometheus"
@@ -123,8 +125,7 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
     // this.props inside a derivation (the autorun below).
     const { cluster } = this.props;
 
-    disposeOnUnmount(
-      this,
+    this.disposers.push(
       autorun(() => {
         const { prometheus, prometheusProvider, filesystemMountpoints, prometheusRequestMethod } = cluster.preferences;
 
@@ -166,6 +167,10 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
       this.loading = false;
       this.loadedOptions.replace(values.map((provider) => [provider.id, provider]));
     });
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   private sanitizePrefix(prefix: string): string {

--- a/packages/core/src/renderer/components/cluster-settings/proxy-setting.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/proxy-setting.tsx
@@ -5,7 +5,7 @@
  */
 
 import { autorun, makeObservable, observable } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { Input, InputValidators } from "../input";
 import { SubTitle } from "../layout/sub-title";
@@ -18,6 +18,8 @@ export interface ClusterProxySettingProps {
 
 @observer
 export class ClusterProxySetting extends React.Component<ClusterProxySettingProps> {
+  private readonly disposers: (() => void)[] = [];
+
   @observable proxy = "";
 
   constructor(props: ClusterProxySettingProps) {
@@ -30,12 +32,15 @@ export class ClusterProxySetting extends React.Component<ClusterProxySettingProp
     // this.props inside a derivation (the autorun below).
     const { cluster } = this.props;
 
-    disposeOnUnmount(
-      this,
+    this.disposers.push(
       autorun(() => {
         this.proxy = cluster.preferences.httpsProxy || "";
       }),
     );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   save = () => {

--- a/packages/core/src/renderer/components/cluster-settings/show-metrics.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/show-metrics.tsx
@@ -6,7 +6,7 @@
 
 import { Icon } from "@freelensapp/icon";
 import { makeObservable, observable, reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { Badge } from "../badge/badge";
 import { Notice } from "../extensions/notice";
@@ -19,6 +19,8 @@ export interface ShowMetricsSettingProps {
 
 @observer
 export class ShowMetricsSetting extends React.Component<ShowMetricsSettingProps> {
+  private readonly disposers: (() => void)[] = [];
+
   @observable hiddenMetrics = observable.set<string>();
 
   constructor(props: ShowMetricsSettingProps) {
@@ -34,14 +36,18 @@ export class ShowMetricsSetting extends React.Component<ShowMetricsSettingProps>
 
     this.hiddenMetrics = observable.set<string>(cluster.preferences.hiddenMetrics ?? []);
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => cluster.preferences.hiddenMetrics,
         () => {
           this.hiddenMetrics = observable.set<string>(cluster.preferences.hiddenMetrics ?? []);
         },
       ),
-    ]);
+    );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   removeMetric(metric: string) {

--- a/packages/core/src/renderer/components/cluster/cluster-overview.tsx
+++ b/packages/core/src/renderer/components/cluster/cluster-overview.tsx
@@ -9,7 +9,7 @@ import { Spinner } from "@freelensapp/spinner";
 import { byOrderNumber } from "@freelensapp/utilities";
 import { computedInjectManyInjectionToken } from "@ogre-tools/injectable-extension-for-mobx";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import enabledMetricsInjectable from "../../api/catalog/entity/metrics-enabled.injectable";
@@ -41,10 +41,14 @@ interface Dependencies {
 
 @observer
 class NonInjectedClusterOverview extends React.Component<Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [
-      this.props.subscribeStores([this.props.podStore, this.props.eventStore, this.props.nodeStore]),
-    ]);
+    this.disposers.push(this.props.subscribeStores([this.props.podStore, this.props.eventStore, this.props.nodeStore]));
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   renderWithMetrics() {

--- a/packages/core/src/renderer/components/command-palette/command-container.tsx
+++ b/packages/core/src/renderer/components/command-palette/command-container.tsx
@@ -11,7 +11,7 @@
 
 import { onKeyboardShortcut } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { broadcastMessage } from "../../../common/ipc";
 import isMacInjectable from "../../../common/vars/is-mac.injectable";
@@ -42,6 +42,8 @@ interface Dependencies {
 
 @observer
 class NonInjectedCommandContainer extends React.Component<Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
     const { clusterId, addWindowEventListener, commandOverlay, matchedClusterId, isMac } = this.props;
 
@@ -58,7 +60,7 @@ class NonInjectedCommandContainer extends React.Component<Dependencies> {
         };
     const ipcChannel = clusterId ? `command-palette:${clusterId}:open` : "command-palette:open";
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       this.props.legacyOnChannelListen(ipcChannel, action),
       addWindowEventListener("keydown", onKeyboardShortcut(isMac ? "Shift+Cmd+P" : "Shift+Ctrl+P", action)),
       addWindowEventListener("keydown", (event) => {
@@ -67,7 +69,11 @@ class NonInjectedCommandContainer extends React.Component<Dependencies> {
           this.props.commandOverlay.close();
         }
       }),
-    ]);
+    );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/core/src/renderer/components/config-maps/config-map-details.tsx
+++ b/packages/core/src/renderer/components/config-maps/config-map-details.tsx
@@ -12,7 +12,7 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { showErrorNotificationInjectable, showSuccessNotificationInjectable } from "@freelensapp/notifications";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { autorun, makeObservable, observable } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { DrawerTitle } from "../drawer";
 import { MonacoEditor } from "../monaco-editor";
@@ -35,6 +35,7 @@ interface Dependencies {
 
 @observer
 class NonInjectedConfigMapDetails extends React.Component<ConfigMapDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
   @observable isSaving = false;
   @observable data = observable.map<string, string | undefined>();
 
@@ -48,13 +49,17 @@ class NonInjectedConfigMapDetails extends React.Component<ConfigMapDetailsProps 
     // this.props inside a derivation (the autorun below).
     const { object: configMap } = this.props;
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       autorun(() => {
         if (configMap) {
           this.data.replace(configMap.data); // refresh
         }
       }),
-    ]);
+    );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   save = () => {

--- a/packages/core/src/renderer/components/config-secrets/secret-details.tsx
+++ b/packages/core/src/renderer/components/config-secrets/secret-details.tsx
@@ -14,7 +14,7 @@ import { showCheckedErrorNotificationInjectable, showSuccessNotificationInjectab
 import { base64, toggle } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { autorun, makeObservable, observable } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { DrawerItem, DrawerTitle } from "../drawer";
 import { Input } from "../input";
@@ -37,6 +37,7 @@ interface Dependencies {
 
 @observer
 class NonInjectedSecretDetails extends React.Component<SecretDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
   @observable isSaving = false;
   @observable data: Partial<Record<string, string>> = {};
   @observable revealSecret = observable.set<string>();
@@ -51,14 +52,18 @@ class NonInjectedSecretDetails extends React.Component<SecretDetailsProps & Depe
     // this.props inside a derivation (the autorun below).
     const { object: secret } = this.props;
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       autorun(() => {
         if (secret) {
           this.data = secret.data;
           this.revealSecret.clear();
         }
       }),
-    ]);
+    );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   saveSecret = () => {

--- a/packages/core/src/renderer/components/dialog/dialog.tsx
+++ b/packages/core/src/renderer/components/dialog/dialog.tsx
@@ -11,7 +11,7 @@ import { observableHistoryInjectionToken } from "@freelensapp/routing";
 import { cssNames, noop, stopPropagation } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { createPortal } from "react-dom";
 
@@ -48,6 +48,7 @@ class NonInjectedDialog extends React.PureComponent<
   DialogProps & Dependencies & typeof NonInjectedDialog.defaultProps,
   DialogState
 > {
+  private readonly disposers: (() => void)[] = [];
   private readonly contentElem = React.createRef<HTMLDivElement>();
   private readonly ref = React.createRef<HTMLDivElement>();
 
@@ -83,12 +84,12 @@ class NonInjectedDialog extends React.PureComponent<
     // inside a derivation (the reaction's data function below).
     const { navigation } = this.props;
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => navigation.toString(),
         () => this.close(),
       ),
-    ]);
+    );
   }
 
   componentDidUpdate(prevProps: DialogProps) {
@@ -101,6 +102,7 @@ class NonInjectedDialog extends React.PureComponent<
 
   componentWillUnmount() {
     if (this.isOpen) this.onClose();
+    this.disposers.forEach((dispose) => dispose());
   }
 
   toggle(isOpen: boolean) {

--- a/packages/core/src/renderer/components/dock/logs/list.tsx
+++ b/packages/core/src/renderer/components/dock/logs/list.tsx
@@ -14,7 +14,7 @@ import autoBindReact from "auto-bind/react";
 import DOMPurify from "dompurify";
 import { debounce } from "es-toolkit/compat";
 import { action, makeObservable, observable, reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import moment from "moment-timezone";
 import React from "react";
 import userPreferencesStateInjectable from "../../../../features/user-preferences/common/state.injectable";
@@ -49,6 +49,7 @@ interface Dependencies {
 class NonForwardedLogList extends React.Component<
   Dependencies & LogListProps & { innerRef: ForwardedRef<LogListRef> }
 > {
+  private readonly disposers: (() => void)[] = [];
   @observable isJumpButtonVisible = false;
   @observable isLastLineVisible = true;
   @observable.ref private containerWidth = 0;
@@ -142,7 +143,7 @@ class NonForwardedLogList extends React.Component<
     // this.props inside a derivation (the reaction data functions below).
     const { model } = this.props;
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => model.logs.get(),
         (logs, prevLogs) => {
@@ -167,7 +168,7 @@ class NonForwardedLogList extends React.Component<
           this.virtualListRef.current?.resetAfterIndex(0);
         },
       ),
-    ]);
+    );
     this.bindInnerRef({
       scrollToItem: this.scrollToItem,
     });
@@ -218,6 +219,7 @@ class NonForwardedLogList extends React.Component<
     this.resizeObserver = null;
     window.removeEventListener("resize", this.updateContainerMetrics);
     this.bindInnerRef(null);
+    this.disposers.forEach((dispose) => dispose());
   }
 
   private onRowRendered = (rowIndex: number) => (element: HTMLDivElement | null) => {

--- a/packages/core/src/renderer/components/dock/terminal/dock-tab.tsx
+++ b/packages/core/src/renderer/components/dock/terminal/dock-tab.tsx
@@ -11,7 +11,7 @@ import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import autoBindReact from "auto-bind/react";
 import { reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import dockStoreInjectable from "../dock/store.injectable";
 import { DockTab } from "../dock-tab";
@@ -30,6 +30,8 @@ interface Dependencies {
 
 @observer
 class NonInjectedTerminalTab<Props extends TerminalTabProps & Dependencies> extends React.Component<Props> {
+  private readonly disposers: (() => void)[] = [];
+
   constructor(props: Props) {
     super(props);
     autoBindReact(this);
@@ -41,7 +43,11 @@ class NonInjectedTerminalTab<Props extends TerminalTabProps & Dependencies> exte
     // this.props, so track the underlying observable through captured props instead.
     const { value, terminalStore } = this.props;
 
-    disposeOnUnmount(this, [reaction(() => (value?.id ? terminalStore.isDisconnected(value.id) : false), this.close)]);
+    this.disposers.push(reaction(() => (value?.id ? terminalStore.isDisconnected(value.id) : false), this.close));
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   private close() {

--- a/packages/core/src/renderer/components/dock/terminal/view.tsx
+++ b/packages/core/src/renderer/components/dock/terminal/view.tsx
@@ -9,7 +9,7 @@ import "./terminal-window.scss";
 import assert from "node:assert";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import activeThemeInjectable from "../../../themes/active.injectable";
 import dockStoreInjectable from "../dock/store.injectable";
@@ -34,6 +34,7 @@ interface Dependencies {
 
 @observer
 class NonInjectedTerminalWindow extends React.Component<TerminalWindowProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
   public elem: HTMLElement | null = null;
   public terminal!: Terminal;
 
@@ -45,12 +46,12 @@ class NonInjectedTerminalWindow extends React.Component<TerminalWindowProps & De
     this.terminal = terminal;
     this.terminal.attachTo(this.elem!);
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       // refresh terminal available space (cols/rows) when <Dock/> resized
       this.props.dockStore.onResize(() => this.terminal.onResize(), {
         fireImmediately: true,
       }),
-    ]);
+    );
   }
 
   componentDidUpdate(): void {
@@ -65,6 +66,7 @@ class NonInjectedTerminalWindow extends React.Component<TerminalWindowProps & De
 
   componentWillUnmount(): void {
     this.terminal.detach();
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/core/src/renderer/components/events/kube-event-details.tsx
+++ b/packages/core/src/renderer/components/events/kube-event-details.tsx
@@ -13,7 +13,7 @@ import { type KubeEvent, KubeObject } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import moment from "moment-timezone";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
@@ -48,8 +48,14 @@ export function sortEvents(events: KubeEvent[]): KubeEvent[] | undefined {
 
 @observer
 class NonInjectedKubeEventDetails extends React.Component<KubeEventDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.eventStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.eventStore]));
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/core/src/renderer/components/input/search-input-url.tsx
+++ b/packages/core/src/renderer/components/input/search-input-url.tsx
@@ -9,7 +9,7 @@ import { storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-s
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { debounce } from "es-toolkit/compat";
 import { comparer, makeObservable, observable, reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import namespaceStoreInjectable from "../namespaces/store.injectable";
 import persistentSearchStoreInjectable from "./persistent-search-store.injectable";
@@ -31,6 +31,8 @@ interface Dependencies {
 
 @observer
 class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   @observable inputVal = ""; // fix: use empty string on init to avoid react warnings
   @observable private lastNamespaceKey = "";
   @observable private lastPlaceholder = "";
@@ -113,7 +115,7 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
     }
 
     // Sync inputVal with either persistent store or URL param
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => ({
           isEnabled: persistentSearchStore.isEnabled,
@@ -159,10 +161,10 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
         },
         { equals: comparer.structural },
       ),
-    ]);
+    );
 
     // When persistence is enabled and there's a persistent value, sync it to URL
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => ({
           isEnabled: persistentSearchStore.isEnabled,
@@ -178,7 +180,11 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
         },
         { fireImmediately: true, equals: comparer.structural },
       ),
-    ]);
+    );
+  }
+
+  componentWillUnmount(): void {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   setValue = (value: string) => {

--- a/packages/core/src/renderer/components/kube-object-list-layout/kube-object-list-layout.tsx
+++ b/packages/core/src/renderer/components/kube-object-list-layout/kube-object-list-layout.tsx
@@ -13,7 +13,7 @@ import { cssNames, hasTypedProperty, isDefined, isObject, isString } from "@free
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { sortBy } from "es-toolkit/compat";
 import { observable, reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
@@ -99,6 +99,7 @@ class NonInjectedKubeObjectListLayout<
     subscribeStores: true,
   };
 
+  private readonly disposers: (() => void)[] = [];
   private readonly loadErrors = observable.array<string>();
   private readonly menuControls = new Map<string, MenuControls>();
 
@@ -134,7 +135,11 @@ class NonInjectedKubeObjectListLayout<
       );
     }
 
-    disposeOnUnmount(this, reactions);
+    this.disposers.push(...reactions);
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   renderLoadErrors() {

--- a/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.tsx
+++ b/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.tsx
@@ -10,7 +10,7 @@ import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { identity } from "es-toolkit";
 import { observable, reaction, runInAction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import apiManagerInjectable from "../../../common/k8s-api/api-manager/manager.injectable";
 import navigateInjectable from "../../navigation/navigate.injectable";
@@ -60,6 +60,7 @@ interface Dependencies {
 class NonInjectedKubeObjectMenu<Kube extends KubeObject> extends React.Component<
   KubeObjectMenuProps<Kube> & Dependencies
 > {
+  private readonly disposers: (() => void)[] = [];
   private menuItems = observable.array<KubeObjectContextMenuItem>();
 
   componentDidUpdate(prevProps: Readonly<KubeObjectMenuProps<Kube> & Dependencies>): void {
@@ -74,7 +75,7 @@ class NonInjectedKubeObjectMenu<Kube extends KubeObject> extends React.Component
     // in place, so tracking the captured instance keeps its observable fields live.
     const { object } = this.props;
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => object?.metadata?.deletionTimestamp,
         () => {
@@ -91,7 +92,11 @@ class NonInjectedKubeObjectMenu<Kube extends KubeObject> extends React.Component
           }
         },
       ),
-    ]);
+    );
+  }
+
+  componentWillUnmount(): void {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   private renderDeleteMessage(object: KubeObject, title: string) {

--- a/packages/core/src/renderer/components/menu/menu-actions.tsx
+++ b/packages/core/src/renderer/components/menu/menu-actions.tsx
@@ -12,7 +12,7 @@ import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import autoBindReact from "auto-bind/react";
 import { makeObservable, observable, reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React, { isValidElement } from "react";
 import openConfirmDialogInjectable from "../confirm-dialog/open.injectable";
 import { Menu, MenuItem } from "./menu";
@@ -65,6 +65,8 @@ class NonInjectedMenuActions extends React.Component<MenuActionsProps & Dependen
     removeConfirmationMessage: "Remove item?",
   };
 
+  private readonly disposers: (() => void)[] = [];
+
   @observable isOpen = !!this.props.toolbar;
   @observable openedViaCursor = false;
   @observable cursorPosition: { x: number; y: number } | null = null;
@@ -82,7 +84,7 @@ class NonInjectedMenuActions extends React.Component<MenuActionsProps & Dependen
       close: this.close,
     });
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => this.isOpen,
         (isOpen) => {
@@ -94,7 +96,7 @@ class NonInjectedMenuActions extends React.Component<MenuActionsProps & Dependen
           fireImmediately: true,
         },
       ),
-    ]);
+    );
   }
 
   componentWillUnmount(): void {
@@ -102,6 +104,7 @@ class NonInjectedMenuActions extends React.Component<MenuActionsProps & Dependen
       open: () => {},
       close: () => {},
     });
+    this.disposers.forEach((dispose) => dispose());
   }
 
   open = (options?: MenuOpenOptions) => {

--- a/packages/core/src/renderer/components/namespaces/namespace-details.tsx
+++ b/packages/core/src/renderer/components/namespaces/namespace-details.tsx
@@ -12,7 +12,7 @@ import { Link } from "@freelensapp/routing";
 import { Spinner } from "@freelensapp/spinner";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import limitRangeStoreInjectable from "../config-limit-ranges/store.injectable";
@@ -40,12 +40,18 @@ interface Dependencies {
 
 @observer
 class NonInjectedNamespaceDetails extends React.Component<NamespaceDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   constructor(props: NamespaceDetailsProps & Dependencies) {
     super(props);
   }
 
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.resourceQuotaStore, this.props.limitRangeStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.resourceQuotaStore, this.props.limitRangeStore]));
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   // Plain getters (not @computed): they read this.props, which mobx-react 9

--- a/packages/core/src/renderer/components/network-port-forwards/port-forwards.tsx
+++ b/packages/core/src/renderer/components/network-port-forwards/port-forwards.tsx
@@ -8,7 +8,7 @@ import "./port-forwards.scss";
 
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { makeObservable, observable } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import navigateToPortForwardsInjectable from "../../../common/front-end-routing/routes/cluster/network/port-forwards/navigate-to-port-forwards.injectable";
 import portForwardStoreInjectable from "../../port-forward/port-forward-store/port-forward-store.injectable";
@@ -44,6 +44,8 @@ interface Dependencies {
 
 @observer
 class NonInjectedPortForwards extends React.Component<Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   // mobx-react 9 forbids reading this.props inside a derivation. getItems is invoked
   // from ItemListLayout's render (a derivation other than this component's own render),
   // so it reads props from this observable snapshot, refreshed on every update, instead
@@ -57,7 +59,11 @@ class NonInjectedPortForwards extends React.Component<Dependencies> {
   }
 
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.portForwardStore.watch()]);
+    this.disposers.push(this.props.portForwardStore.watch());
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   componentDidUpdate() {

--- a/packages/core/src/renderer/components/network-services/service-details.tsx
+++ b/packages/core/src/renderer/components/network-services/service-details.tsx
@@ -11,7 +11,7 @@ import { type PortStatus, Service } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { formatDuration } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import portForwardStoreInjectable from "../../port-forward/port-forward-store/port-forward-store.injectable";
@@ -51,10 +51,16 @@ function getExternalProtocol(service: Service): string | undefined {
 
 @observer
 class NonInjectedServiceDetails extends React.Component<ServiceDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
     const { subscribeStores, endpointSliceStore, portForwardStore } = this.props;
 
-    disposeOnUnmount(this, [subscribeStores([endpointSliceStore], {}), portForwardStore.watch()]);
+    this.disposers.push(subscribeStores([endpointSliceStore], {}), portForwardStore.watch());
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/core/src/renderer/components/nodes/details.tsx
+++ b/packages/core/src/renderer/components/nodes/details.tsx
@@ -9,7 +9,7 @@ import "./details.scss";
 import { formatNodeTaint, Node } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import { Badge } from "../badge";
@@ -38,10 +38,16 @@ interface Dependencies {
 
 @observer
 class NonInjectedNodeDetails extends React.Component<NodeDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.podStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.podStore]));
 
     this.props.loadPodsFromAllNamespaces();
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/core/src/renderer/components/nodes/route.tsx
+++ b/packages/core/src/renderer/components/nodes/route.tsx
@@ -11,7 +11,7 @@ import { Tooltip, TooltipPosition } from "@freelensapp/tooltip";
 import { bytesToUnits, cpuUnitsToNumber, interval, unitsToBytes } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { makeObservable, observable } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import requestAllNodeMetricsInjectable from "../../../common/k8s-api/endpoints/metrics.api/request-metrics-for-all-nodes.injectable";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
@@ -153,6 +153,8 @@ function formatCores(cores: number): string {
 
 @observer
 class NonInjectedNodesRoute extends React.Component<Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   @observable metrics: NodeMetricData | null = null;
 
   // mobx-react 9 forbids reading this.props inside a derivation. The row/cell
@@ -179,13 +181,14 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
   componentDidMount() {
     this.metricsWatcher.start(true);
 
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.podStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.podStore]));
 
     this.props.loadPodsFromAllNamespaces();
   }
 
   componentWillUnmount() {
     this.metricsWatcher.stop();
+    this.disposers.forEach((dispose) => dispose());
   }
 
   componentDidUpdate() {

--- a/packages/core/src/renderer/components/storage-classes/storage-class-details.tsx
+++ b/packages/core/src/renderer/components/storage-classes/storage-class-details.tsx
@@ -10,7 +10,7 @@ import { StorageClass } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { startCase } from "es-toolkit";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import { Badge } from "../badge";
@@ -37,8 +37,14 @@ interface Dependencies {
 
 @observer
 class NonInjectedStorageClassDetails extends React.Component<StorageClassDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.persistentVolumeStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.persistentVolumeStore]));
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/core/src/renderer/components/user-management/service-accounts/details.tsx
+++ b/packages/core/src/renderer/components/user-management/service-accounts/details.tsx
@@ -11,7 +11,7 @@ import { Link } from "@freelensapp/routing";
 import { Spinner } from "@freelensapp/spinner";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { autorun, observable, runInAction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import secretStoreInjectable from "../../config-secrets/store.injectable";
 import { DrawerItem, DrawerTitle } from "../../drawer";
@@ -33,6 +33,7 @@ interface Dependencies {
 
 @observer
 class NonInjectedServiceAccountsDetails extends React.Component<ServiceAccountsDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
   readonly secrets = observable.array<Secret | string>();
   readonly imagePullSecrets = observable.array<Secret | string>();
 
@@ -48,7 +49,7 @@ class NonInjectedServiceAccountsDetails extends React.Component<ServiceAccountsD
     // invokes before the first await).
     const { object: serviceAccount, secretStore } = this.props;
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       autorun(async () => {
         runInAction(() => {
           this.secrets.clear();
@@ -72,7 +73,11 @@ class NonInjectedServiceAccountsDetails extends React.Component<ServiceAccountsD
           this.imagePullSecrets.replace(imagePullSecrets);
         });
       }),
-    ]);
+    );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   renderSecrets() {

--- a/packages/core/src/renderer/components/workloads-cronjobs/cronjob-details.tsx
+++ b/packages/core/src/renderer/components/workloads-cronjobs/cronjob-details.tsx
@@ -12,7 +12,7 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { formatDuration } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { kebabCase } from "es-toolkit";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import { BadgeBoolean } from "../badge";
@@ -43,8 +43,14 @@ interface Dependencies {
 
 @observer
 class NonInjectedCronJobDetails extends React.Component<CronJobDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.jobStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.jobStore]));
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/core/src/renderer/components/workloads-daemonsets/daemonset-details.tsx
+++ b/packages/core/src/renderer/components/workloads-daemonsets/daemonset-details.tsx
@@ -9,7 +9,7 @@ import "./daemonset-details.scss";
 import { DaemonSet } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import { Badge } from "../badge";
@@ -39,8 +39,14 @@ interface Dependencies {
 
 @observer
 class NonInjectedDaemonSetDetails extends React.Component<DaemonSetDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.podStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.podStore]));
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/core/src/renderer/components/workloads-deployments/deployment-details.tsx
+++ b/packages/core/src/renderer/components/workloads-deployments/deployment-details.tsx
@@ -9,7 +9,7 @@ import "./deployment-details.scss";
 import { Deployment } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import { Badge } from "../badge";
@@ -40,8 +40,14 @@ interface Dependencies {
 
 @observer
 class NonInjectedDeploymentDetails extends React.Component<DeploymentDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.replicaSetStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.replicaSetStore]));
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/core/src/renderer/components/workloads-jobs/job-details.tsx
+++ b/packages/core/src/renderer/components/workloads-jobs/job-details.tsx
@@ -10,7 +10,7 @@ import { Job } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { formatDuration } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import { Badge, BadgeBoolean } from "../badge";
@@ -43,8 +43,14 @@ interface Dependencies {
 
 @observer
 class NonInjectedJobDetails extends React.Component<JobDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.podStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.podStore]));
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/core/src/renderer/components/workloads-overview/overview.tsx
+++ b/packages/core/src/renderer/components/workloads-overview/overview.tsx
@@ -10,7 +10,7 @@ import { Icon } from "@freelensapp/icon";
 import { TooltipPosition } from "@freelensapp/tooltip";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { makeObservable, observable, reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import clusterFrameContextForNamespacedResourcesInjectable from "../../cluster-frame-context/for-namespaced-resources.injectable";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
@@ -55,6 +55,7 @@ interface Dependencies {
 
 @observer
 class NonInjectedWorkloadsOverview extends React.Component<Dependencies> {
+  private readonly disposers: (() => void)[] = [];
   @observable loadErrors: string[] = [];
 
   constructor(props: Dependencies) {
@@ -67,7 +68,7 @@ class NonInjectedWorkloadsOverview extends React.Component<Dependencies> {
     // inside a derivation (the reaction's data function below).
     const { clusterFrameContext } = this.props;
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       this.props.subscribeStores(
         [
           this.props.cronJobStore,
@@ -90,7 +91,11 @@ class NonInjectedWorkloadsOverview extends React.Component<Dependencies> {
           this.loadErrors.length = 0;
         },
       ),
-    ]);
+    );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   renderLoadErrors() {

--- a/packages/core/src/renderer/components/workloads-pods/pod-details-container.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details-container.tsx
@@ -9,7 +9,7 @@ import "./pod-details-container.scss";
 import { podDetailsContainerMetricsInjectionToken } from "@freelensapp/metrics";
 import { cssNames, isDefined } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import enabledMetricsInjectable from "../../api/catalog/entity/metrics-enabled.injectable";
@@ -42,8 +42,14 @@ interface Dependencies {
 
 @observer
 class NonInjectedPodDetailsContainer extends React.Component<PodDetailsContainerProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.portForwardStore.watch()]);
+    this.disposers.push(this.props.portForwardStore.watch());
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   renderStatus(container: ContainerWithType | EphemeralContainerWithType, status?: PodContainerStatus) {

--- a/packages/core/src/renderer/components/workloads-replicasets/replicaset-details.tsx
+++ b/packages/core/src/renderer/components/workloads-replicasets/replicaset-details.tsx
@@ -9,7 +9,7 @@ import "./replicaset-details.scss";
 import { ReplicaSet } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import { Badge } from "../badge";
@@ -39,9 +39,16 @@ interface Dependencies {
 
 @observer
 class NonInjectedReplicaSetDetails extends React.Component<ReplicaSetDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.podStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.podStore]));
   }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
+  }
+
   render() {
     const { object: replicaSet, replicaSetStore, logger } = this.props;
 

--- a/packages/core/src/renderer/components/workloads-statefulsets/statefulset-details.tsx
+++ b/packages/core/src/renderer/components/workloads-statefulsets/statefulset-details.tsx
@@ -9,7 +9,7 @@ import "./statefulset-details.scss";
 import { StatefulSet } from "@freelensapp/kube-object";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
 import { Badge } from "../badge";
@@ -39,8 +39,14 @@ interface Dependencies {
 
 @observer
 class NonInjectedStatefulSetDetails extends React.Component<StatefulSetDetailsProps & Dependencies> {
+  private readonly disposers: (() => void)[] = [];
+
   componentDidMount() {
-    disposeOnUnmount(this, [this.props.subscribeStores([this.props.podStore])]);
+    this.disposers.push(this.props.subscribeStores([this.props.podStore]));
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   render() {

--- a/packages/ui-components/notifications/src/notifications.tsx
+++ b/packages/ui-components/notifications/src/notifications.tsx
@@ -12,7 +12,7 @@ import { JsonApiErrorParsed } from "@freelensapp/json-api";
 import { cssNames, prevDefault } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { notificationsStoreInjectable } from "./notifications-store.injectable";
 
@@ -33,6 +33,7 @@ interface Dependencies {
 
 @observer
 class NonInjectedNotifications extends React.Component<Dependencies> {
+  private readonly disposers: (() => void)[] = [];
   public elem: HTMLDivElement | null = null;
 
   componentDidMount() {
@@ -40,7 +41,7 @@ class NonInjectedNotifications extends React.Component<Dependencies> {
     // inside a derivation (the reaction's data function below).
     const { store } = this.props;
 
-    disposeOnUnmount(this, [
+    this.disposers.push(
       reaction(
         () => store.notifications.length,
         () => {
@@ -48,7 +49,11 @@ class NonInjectedNotifications extends React.Component<Dependencies> {
         },
         { delay: 250 },
       ),
-    ]);
+    );
+  }
+
+  componentWillUnmount() {
+    this.disposers.forEach((dispose) => dispose());
   }
 
   scrollToLastNotification() {


### PR DESCRIPTION
Replaces every mobx-react `disposeOnUnmount` call site (39 class components across `packages/core` and `packages/ui-components/notifications`) with an explicit `disposers` array cleaned up in `componentWillUnmount`. Part of #2278 (Phase 3 of the React upgrade), part of #2154.

## Why

`disposeOnUnmount` logs "[mobx-react] disposeOnUnmount is not compatible with React 18 and higher. Don't use it." at runtime and does not reliably clean up under React 18/19 (incl. StrictMode's mount -> unmount -> mount). Surfaced by the StrictMode work (#2289).

## Change

Each component now declares `private readonly disposers: (() => void)[] = [];`, captures each disposer where it was created, and disposes them all in `componentWillUnmount` (merged into the existing method where one already existed). `disposeOnUnmount` was dropped from every `mobx-react` import. The `ipc-renderer.ts` doc comment (the only remaining mention) was rewritten to describe the new pattern. Behavior is unchanged.

## Validation

- `grep disposeOnUnmount packages` - no call sites remain
- `pnpm type:check` - 0 errors
- `pnpm test:unit` - 3391 passed / 44 skipped / 0 failed (no snapshot churn)
- `pnpm biome check` + `pnpm trunk check` - clean

The tracking issue #2278 stays open (not `Closes`).

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`