### PR TITLE
Fix duplicate and unstable React keys in details views

### DIFF
--- a/packages/core/src/renderer/components/config-runtime-classes/runtime-classes-tolerations.tsx
+++ b/packages/core/src/renderer/components/config-runtime-classes/runtime-classes-tolerations.tsx
@@ -6,7 +6,6 @@
 
 import "./runtime-classes-tolerations.scss";
 
-import { uniqueId } from "es-toolkit/compat";
 import { Table, TableCell, TableHead, TableRow } from "../table";
 
 import type { Toleration } from "@freelensapp/kube-object";
@@ -23,11 +22,13 @@ enum sortBy {
   Value = "value",
 }
 
-const getTableRow = (toleration: Toleration) => {
+const getTableRow = (toleration: Toleration, index: number) => {
   const { key, operator, effect, tolerationSeconds, value } = toleration;
 
   return (
-    <TableRow key={uniqueId("toleration-")} sortItem={toleration} nowrap>
+    // Tolerations have no unique identifier, so key by position — a generated id would
+    // change on every render and force React to remount every row.
+    <TableRow key={`toleration-${index}`} sortItem={toleration} nowrap>
       <TableCell className="key">{key}</TableCell>
       <TableCell className="operator">{operator}</TableCell>
       <TableCell className="value">{value}</TableCell>

--- a/packages/core/src/renderer/components/kube-object-meta/kube-object-meta.tsx
+++ b/packages/core/src/renderer/components/kube-object-meta/kube-object-meta.tsx
@@ -54,6 +54,7 @@ function ManagedFieldEntryLabel({ entry }: { entry: ManagedFieldsEntry }) {
       {entry.manager}
       {": "}
       {entry.operation}
+      {entry.subresource && ` (${entry.subresource})`}
     </WithTooltip>
   );
 }
@@ -140,9 +141,13 @@ const NonInjectedKubeObjectMeta = observer((props: Dependencies & KubeObjectMeta
       {managedFields && managedFields.length > 0 && (
         <DrawerItem name="Managed Fields" hidden={isHidden("managedFields")}>
           {managedFields.filter(isManagedFieldsEntry).map((entry) => (
+            // The apiserver identifies a managed-fields entry by manager, operation,
+            // apiVersion and subresource, so that tuple is the entry's key. Manager and
+            // operation alone are not unique — a manager typically owns both a plain
+            // Update and an Update of the status subresource.
             <DrawerParamToggler
               label={<ManagedFieldEntryLabel entry={entry} />}
-              key={`${entry.manager}-${entry.operation}`}
+              key={`${entry.manager}-${entry.operation}-${entry.apiVersion ?? ""}-${entry.subresource ?? ""}`}
             >
               <MonacoEditor
                 readOnly

--- a/packages/core/src/renderer/components/network-endpoint-slices/endpoint-slice-details.tsx
+++ b/packages/core/src/renderer/components/network-endpoint-slices/endpoint-slice-details.tsx
@@ -127,7 +127,9 @@ class NonInjectedEndpointSliceDetails extends React.Component<EndpointSliceDetai
                   <TableCell className="protocol">Protocol</TableCell>
                 </TableHead>
                 {endpointSlice.ports?.map((port) => (
-                  <TableRow key={port.port} nowrap>
+                  // The same port number may be exposed under several protocols, so the
+                  // number alone is not a unique key.
+                  <TableRow key={`${port.port}-${port.protocol}`} nowrap>
                     <TableCell className="name">{port.port}</TableCell>
                     <TableCell className="name">{port.name}</TableCell>
                     <TableCell className="node">{port.protocol}</TableCell>

--- a/packages/core/src/renderer/components/network-endpoints/endpoint-subset-list.tsx
+++ b/packages/core/src/renderer/components/network-endpoints/endpoint-subset-list.tsx
@@ -168,7 +168,9 @@ class NonInjectedEndpointSubsetList extends React.Component<EndpointSubsetListPr
             <TableCell className="protocol">Protocol</TableCell>
           </TableHead>
           {ports.map((port) => (
-            <TableRow key={port.port} nowrap>
+            // The same port number may be exposed under several protocols, so the number
+            // alone is not a unique key.
+            <TableRow key={`${port.port}-${port.protocol}`} nowrap>
               <TableCell className="name">{port.port}</TableCell>
               <TableCell className="name">{port.name}</TableCell>
               <TableCell className="node">{port.protocol}</TableCell>

--- a/packages/core/src/renderer/components/nodes/details.tsx
+++ b/packages/core/src/renderer/components/nodes/details.tsx
@@ -72,8 +72,10 @@ class NonInjectedNodeDetails extends React.Component<NodeDetailsProps & Dependen
       <div className="NodeDetails">
         {addresses && (
           <DrawerItem name="Addresses">
+            {/* A node may expose several addresses of the same type (e.g. an IPv4 and an
+                IPv6 InternalIP), so the type alone is not a unique key. */}
             {addresses.map(({ type, address }) => (
-              <p key={type}>{`${type}: ${address}`}</p>
+              <p key={`${type}-${address}`}>{`${type}: ${address}`}</p>
             ))}
           </DrawerItem>
         )}

--- a/packages/core/src/renderer/components/table/table.tsx
+++ b/packages/core/src/renderer/components/table/table.tsx
@@ -116,7 +116,7 @@ export interface TableProps<Item> extends React.DOMAttributes<HTMLDivElement> {
   rowLineHeight?: number;
   customRowHeights?: (item: Item, lineHeight: number, paddings: number) => number;
   getTableRow?: (uid: string) => React.ReactElement<TableRowProps<Item>> | undefined | null;
-  renderRow?: (item: Item) => React.ReactElement<TableRowProps<Item>> | undefined | null;
+  renderRow?: (item: Item, index: number) => React.ReactElement<TableRowProps<Item>> | undefined | null;
 }
 
 interface Dependencies {

--- a/packages/core/src/renderer/components/workloads-pods/pod-tolerations.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-tolerations.tsx
@@ -6,7 +6,6 @@
 
 import "./pod-tolerations.scss";
 
-import { uniqueId } from "es-toolkit/compat";
 import { Table, TableCell, TableHead, TableRow } from "../table";
 
 import type { Toleration } from "@freelensapp/kube-object";
@@ -23,11 +22,13 @@ enum sortBy {
   Value = "value",
 }
 
-const getTableRow = (toleration: Toleration) => {
+const getTableRow = (toleration: Toleration, index: number) => {
   const { key, operator, effect, tolerationSeconds, value } = toleration;
 
   return (
-    <TableRow key={uniqueId("toleration-")} sortItem={toleration} nowrap>
+    // Tolerations have no unique identifier, so key by position — a generated id would
+    // change on every render and force React to remount every row.
+    <TableRow key={`toleration-${index}`} sortItem={toleration} nowrap>
       <TableCell className="key">{key}</TableCell>
       <TableCell className="operator">{operator}</TableCell>
       <TableCell className="value">{value}</TableCell>


### PR DESCRIPTION
Fixes the duplicate React key follow-up from #2278 (surfaced during the StrictMode triage in #2289), plus three more key defects found while sweeping the rest of the `key={…}` call sites.

## What and why

**1. Managed fields — `k3s-Update`** (`kube-object-meta.tsx`)

The reported one. Entries were keyed by `manager-operation`, but a single manager routinely owns several entries that differ only by `subresource` — every k3s node carries both `k3s: Update` and `k3s: Update` on `status`. Besides the console error, the two rows were visually identical in the drawer. The apiserver identifies an entry by manager, operation, apiVersion and subresource, so that tuple is now the key, and the label renders the subresource so the entries are distinguishable in the UI and not just to React.

**2. Node addresses — `InternalIP`** (`nodes/details.tsx`)

Not previously on the list; it showed up in the same live session. Addresses were keyed by `address.type`, and a dual-stack node has two `InternalIP` entries (IPv4 + IPv6). Keyed by type + value now.

**3. Endpoint ports** (`endpoint-subset-list.tsx`, `endpoint-slice-details.tsx`)

`key={port.port}` — the same port number exposed under both TCP and UDP is a legal configuration. Keyed by number + protocol.

**4. Toleration rows** (`pod-tolerations.tsx`, `runtime-classes-tolerations.tsx`)

The inverse defect: `key={uniqueId("toleration-")}` returns a **fresh value on every render**, so React saw every row as new and remounted the whole table each time. `Table`'s `renderRow` prop now declares the `index` parameter that `Array.prototype.map` already passed to it at runtime; the `es-toolkit/compat` `uniqueId` import is gone from both files.

On keying by index here: a toleration has no identifier, and the API permits two byte-identical tolerations on one pod, so a composite of every field is not guaranteed unique either and would reintroduce the duplicate-key error on exactly the input that motivated this PR. The usual hazard of index keys — the key tracking a display position rather than an item — does not apply to `Table`: `getContent()` keys the rows in the **source** order of `items`, and sorting reorders those already-keyed elements (`renderRows()`), so the key stays bound to its item across a sort.

## Validation

- `pnpm type:check` — clean.
- `pnpm biome check` — clean (per-commit pre-commit hook as well).
- Unit tests for the touched components — green.
- **Live** on a dev cluster (orbstack, k3s distribution, dual-stack node): after the change the renderer console shows **no** `Encountered two children with the same key`, and the node drawer renders the full set — three Managed Fields rows (`k3s-supervisor@orbstack: Update`, `k3s: Update`, `k3s: Update (status)`) and both `InternalIP` addresses. Remaining console output is the known benign noise (`AbortError` on unmount, `loadKubeMetrics`, Electron security warnings).

Part of #2278.
