### PR TITLE
Do not treat an aborted list load as a failed load

### DIFF
--- a/packages/core/src/common/k8s-api/__tests__/kube-object.store.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/kube-object.store.test.ts
@@ -10,6 +10,8 @@ import { KubeObjectStore } from "../kube-object.store";
 
 import type { KubeApi } from "@freelensapp/kube-api";
 
+import type { RequestInit } from "node-fetch";
+
 import type { KubeObjectStoreLoadingParams } from "../kube-object.store";
 
 class FakeKubeObjectStore extends KubeObjectStore<KubeObject> {
@@ -161,5 +163,124 @@ describe("KubeObjectStore", () => {
     await store.loadAll({});
 
     expect(store.items).not.toContain(clusterScopedObject1);
+  });
+
+  it("should not treat an aborted load as a failed load", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
+    const loadItems = vi.fn();
+    const obj = new KubeObject({
+      apiVersion: "v1",
+      kind: "Foo",
+      metadata: {
+        name: "some-obj-name",
+        resourceVersion: "1",
+        uid: "some-uid",
+        selfLink: "/some/self/link",
+      },
+    });
+    const store = new FakeKubeObjectStore(loadItems, {
+      isNamespaced: false,
+    });
+
+    loadItems.mockImplementationOnce(() => [obj]);
+
+    await store.loadAll({});
+
+    expect(store.items).toContain(obj);
+
+    loadItems.mockImplementationOnce(() => {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    });
+
+    const result = await store.loadAll({});
+
+    expect(result).toBeUndefined();
+    // the freshly loaded items and the loading flags must be left untouched
+    expect(store.items).toContain(obj);
+    expect(store.failedLoading).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("should not treat a load with an already-aborted signal as a failed load", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
+    const loadItems = vi.fn();
+    const obj = new KubeObject({
+      apiVersion: "v1",
+      kind: "Foo",
+      metadata: {
+        name: "some-obj-name",
+        resourceVersion: "1",
+        uid: "some-uid",
+        selfLink: "/some/self/link",
+      },
+    });
+    const store = new FakeKubeObjectStore(loadItems, {
+      isNamespaced: false,
+    });
+
+    loadItems.mockImplementationOnce(() => [obj]);
+
+    await store.loadAll({});
+
+    expect(store.items).toContain(obj);
+
+    const controller = new AbortController();
+
+    controller.abort();
+
+    loadItems.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+
+    const result = await store.loadAll({
+      reqInit: { signal: controller.signal } as RequestInit,
+    });
+
+    expect(result).toBeUndefined();
+    expect(store.items).toContain(obj);
+    expect(store.failedLoading).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("should treat a genuine load failure as a failed load", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
+    const loadItems = vi.fn();
+    const obj = new KubeObject({
+      apiVersion: "v1",
+      kind: "Foo",
+      metadata: {
+        name: "some-obj-name",
+        resourceVersion: "1",
+        uid: "some-uid",
+        selfLink: "/some/self/link",
+      },
+    });
+    const store = new FakeKubeObjectStore(loadItems, {
+      isNamespaced: false,
+    });
+
+    loadItems.mockImplementationOnce(() => [obj]);
+
+    await store.loadAll({});
+
+    expect(store.items).toContain(obj);
+
+    loadItems.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+
+    const result = await store.loadAll({});
+
+    expect(result).toBeUndefined();
+    // a real failure still resets the store and flags the failure
+    expect(store.items).not.toContain(obj);
+    expect(store.failedLoading).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 });

--- a/packages/core/src/common/k8s-api/kube-object.store.ts
+++ b/packages/core/src/common/k8s-api/kube-object.store.ts
@@ -7,7 +7,7 @@
 import assert from "node:assert";
 import { parseKubeApi } from "@freelensapp/kube-api";
 import { KubeStatus } from "@freelensapp/kube-object";
-import { includes, object, rejectPromiseBy, waitUntilDefined } from "@freelensapp/utilities";
+import { includes, isAbortError, object, rejectPromiseBy, waitUntilDefined } from "@freelensapp/utilities";
 import autoBind from "auto-bind";
 import { action, computed, makeObservable, observable, reaction } from "mobx";
 import { ItemStore } from "../item.store";
@@ -276,6 +276,16 @@ export class KubeObjectStore<
 
       return items;
     } catch (error) {
+      // A load aborted via its `reqInit.signal` (e.g. the view unmounted before
+      // the list arrived, which happens on essentially every view under
+      // `React.StrictMode`) is not a real failure. Nothing is waiting on the
+      // result, so bail out without logging, resetting, or flipping
+      // `failedLoading` — otherwise a late abort from an unmounted view could
+      // wipe items freshly loaded by a remounted one.
+      if (isAbortError(error) || reqInit?.signal?.aborted) {
+        return undefined;
+      }
+
       console.warn("[KubeObjectStore] loadAll failed", this.api.apiBase, error);
       this.resetOnError(error);
       this.failedLoading = true;

--- a/packages/core/src/renderer/kube-watch-api/kube-watch-api.ts
+++ b/packages/core/src/renderer/kube-watch-api/kube-watch-api.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { disposer, getOrInsert, noop, WrappedAbortController } from "@freelensapp/utilities";
+import { disposer, getOrInsert, isAbortError, noop, WrappedAbortController } from "@freelensapp/utilities";
 import { once } from "es-toolkit";
 import { comparer, reaction } from "mobx";
 
@@ -122,7 +122,7 @@ export class KubeWatchApi {
         await store.loadAll({ namespaces, reqInit: { signal: childController.signal }, onLoadFailure });
         unsubscribe.push(store.subscribe({ onLoadFailure, abortController: childController }));
       } catch (error) {
-        if (!(error instanceof DOMException)) {
+        if (!isAbortError(error)) {
           this.log(new Error("Loading stores has failed", { cause: error }), {
             meta: { store, namespaces },
           });

--- a/packages/utility-features/utilities/src/abort-controller.test.ts
+++ b/packages/utility-features/utilities/src/abort-controller.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { isAbortError } from "./abort-controller";
+
+describe("isAbortError", () => {
+  it("matches a DOMException named AbortError", () => {
+    expect(isAbortError(new DOMException("The operation was aborted.", "AbortError"))).toBe(true);
+  });
+
+  it("matches the AbortSignal.reason of an aborted controller", () => {
+    const controller = new AbortController();
+
+    controller.abort();
+
+    expect(isAbortError(controller.signal.reason)).toBe(true);
+  });
+
+  it("matches an error-like object named AbortError", () => {
+    expect(isAbortError({ name: "AbortError" })).toBe(true);
+  });
+
+  it("matches the kube watch aborted shape", () => {
+    expect(isAbortError({ type: "aborted" })).toBe(true);
+  });
+
+  it("does not match a genuine error", () => {
+    expect(isAbortError(new Error("boom"))).toBe(false);
+  });
+
+  it("does not match non-error values", () => {
+    expect(isAbortError(undefined)).toBe(false);
+    expect(isAbortError(null)).toBe(false);
+    expect(isAbortError("aborted")).toBe(false);
+  });
+});

--- a/packages/utility-features/utilities/src/abort-controller.ts
+++ b/packages/utility-features/utilities/src/abort-controller.ts
@@ -31,3 +31,24 @@ export function chainSignal(target: AbortController, signal: AbortSignal) {
     signal.addEventListener("abort", (event) => target.abort(event));
   }
 }
+
+/**
+ * Returns `true` if `error` represents an aborted operation rather than a real
+ * failure. Aborting a `fetch` rejects with a `DOMException` named `AbortError`,
+ * but the kube watch/list paths surface more than one abort shape, so this also
+ * matches any error-like object whose `name` is `AbortError` or whose `type` is
+ * `"aborted"`.
+ */
+export function isAbortError(error: unknown): boolean {
+  if (error instanceof DOMException) {
+    return error.name === "AbortError" || error.code === DOMException.ABORT_ERR;
+  }
+
+  if (typeof error === "object" && error !== null) {
+    const { name, type } = error as { name?: unknown; type?: unknown };
+
+    return name === "AbortError" || type === "aborted";
+  }
+
+  return false;
+}


### PR DESCRIPTION
Implements the aborted `loadAll` follow-up from #2278 (Phase 3 of the React upgrade), part of #2154.

## Why

Under `React.StrictMode`'s mount -> unmount -> mount, a view that unmounts before its list arrives aborts the in-flight `loadAll` via its `reqInit` signal. `loadAll` treated the resulting `AbortError` as a real failure: it logged, called `resetOnError` (clearing `items`) and set `failedLoading`. The store is a per-cluster singleton and overlapping loads have no guaranteed resolution order, so a late abort from an unmounted view could wipe items freshly loaded by a remounted one and leave `failedLoading` true.

## Change

- New shared `isAbortError` predicate in `@freelensapp/utilities` (detects `DOMException` `AbortError`, plus error-like objects with `name === "AbortError"` or `type === "aborted"`).
- `loadAll` bails out of the error path on an abort (or when `reqInit.signal` is aborted): no log, no reset, no `failedLoading`. Genuine failures are unchanged.
- `kube-watch-api` `loadThenSubscribe` reuses the predicate (was `instanceof DOMException`).
- Unit tests for the abort/real-failure paths and the predicate.

## Validation

- `pnpm type:check` - 0 errors
- `pnpm biome check` + `pnpm trunk check` - clean
- New + existing store/predicate unit tests green

The tracking issue #2278 stays open (not `Closes`).

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-4-8`