### PR TITLE
Update v2 extension and routing docs for React 19

### DIFF
--- a/docs/v2-extension-migration.md
+++ b/docs/v2-extension-migration.md
@@ -75,7 +75,7 @@ runtime.
 
 ## React version (host-provided, must match majors)
 
-Freelens v2 ships **React 18.3**. React is **host-provided**: the running app
+Freelens v2 ships **React 19**. React is **host-provided**: the running app
 injects a single React instance and re-exports it to extensions through the
 extension API (`Renderer.React` / `Renderer.ReactDOM`). Extensions must render
 through that shared instance.
@@ -86,12 +86,36 @@ through that shared instance.
   "invalid hook call" at runtime. This fails only at runtime, not at build
   time, so it is easy to miss.
 - Declare `react` / `react-dom` (and `@types/react*`) as **peer dependencies**
-  matching the host major — `^18` for this release — and keep them out of your
+  matching the host major — `^19` for this release — and keep them out of your
   bundle (mark them external). The `@freelensapp/extensions` types already pin
-  the React 18 major, so authoring against them keeps type-checking honest.
-- When Freelens later bumps to React 19 (a future phase), extensions relying on
-  host-provided React move with it automatically; extensions that bundled their
-  own React would need a matching bump to avoid the mismatch above.
+  the React 19 major, so authoring against them keeps type-checking honest.
+- **This is a breaking change from the earlier React 18 preview.** Extensions
+  built against React 18 types must move to React 19, because host-provided
+  React and any React the extension bundles must share the same major (see the
+  invalid-hook-call trap above). Extensions relying on host-provided React move
+  with the host automatically once their peer range is `^19`; extensions that
+  bundled their own React need a matching bump. React 19 removed long-deprecated
+  APIs (for example `ReactDOM.render` / `findDOMNode` and legacy string refs),
+  so audit for those while upgrading.
+
+## `@ogre-tools/*` 23 (dependency-injection major)
+
+Freelens v2 bumps the `@ogre-tools/*` dependency-injection packages
+(`injectable`, `injectable-react`, …) from **17 to 23**. This is
+extension-facing because the `@ogre-tools/*` types leak through the
+`@freelensapp/*` packages and the extension API (injection tokens, `getInjectable`,
+the React injection helpers). Re-check any code that constructs or consumes
+injectables against the `@ogre-tools/*` 23 type surface after upgrading.
+
+- **Namespaced runtime-registered ids.** `@ogre-tools/*` 23 namespaces the id of
+  an injectable registered at runtime through a namespaced `di` (for example an
+  extension-scoped registration) as `"<namespace>:<declaredId>"`. The host
+  already strips this namespace where it surfaces ids for its own registries
+  (see `packages/cluster-sidebar/src/sidebar-items.injectable.ts`), so
+  extensions that only register injectables against the documented tokens need
+  no change. If your extension does its **own** `injectManyWithMeta` and keys off
+  `meta.id`, be aware the id may now carry a `"<namespace>:"` prefix — strip it
+  (take the segment after the last `:`) if you compare against a bare declared id.
 
 ## `tsconfig.json` for an extension
 

--- a/docs/v2-routing-modernization.md
+++ b/docs/v2-routing-modernization.md
@@ -16,15 +16,16 @@ included so the follow-up PRs can act on them directly.
 
 ## 1. Why this phase exists
 
-`react-router` 5 + `mobx-observable-history` are the one subsystem that cannot
-follow the rest of the workspace to React 19:
+`react-router` 5 + `mobx-observable-history` were the one subsystem that could
+not follow the rest of the workspace to React 19:
 
 - `react-router` 5.3.4 is unmaintained.
 - `mobx-observable-history` 2.0.3 is abandoned upstream and was written against
   the `history` v4 API.
 
-Phase 2 removes that blocker. It is independent of the React version and can
-proceed on React 18; it is the real gate for Phase 3 (React 19).
+Phase 2 removed that blocker. It was independent of the React version and
+proceeded on React 18; it was the real gate for Phase 3 (React 19), which has
+since shipped — the workspace now runs on **React 19**.
 
 ## 2. Verified current state
 
@@ -173,7 +174,9 @@ Each is its own PR to keep history bisectable:
    deep links, and extension-registered routes; confirm the extension-facing
    routing API still works.
 
-## 6. Out of scope (deferred to Phase 3)
+## 6. Out of scope (was deferred to Phase 3, now shipped)
+
+These were deferred to Phase 3, which has since landed:
 
 - Bumping to React 19, `@testing-library/react` 16, `react-window` v2.
 - Enabling `StrictMode`.

--- a/docs/v2-routing-smoke-test.md
+++ b/docs/v2-routing-smoke-test.md
@@ -18,7 +18,8 @@ entirely on the in-house pieces in `@freelensapp/routing`
 (`Link`/`NavLink`, `Route`/`Switch`/`Redirect`, `matchPath`, the observable
 history wrapper, and the vendored `path-to-regexp` v1 engine). These flows are
 not fully covered by unit tests, so this scenario drives the **running app**
-to confirm no behavioral regression before Phase 3 (React 19) proceeds.
+to confirm no behavioral regression. It was the gate before Phase 3 (React 19),
+which has since shipped — the workspace now runs on **React 19**.
 
 The scenario is written to be executed by an AI agent through
 [Playwright MCP](https://github.com/microsoft/playwright-mcp) attached to the


### PR DESCRIPTION
Updates the extension-author-facing v2 docs to match the shipped React 19 (#2280) and `@ogre-tools/*` 23 (#2282) state. Intended as the base for the upcoming Extension API v2 work.

- `docs/v2-extension-migration.md`: React 18.3 → React 19, peer range `^18` → `^19`, reframed as a breaking change, and a new `@ogre-tools/*` 23 section.
- `docs/v2-routing-modernization.md` / `docs/v2-routing-smoke-test.md`: realign the "React 19 = future / Phase 3" framing to present tense.

Part of #2154, follows up #2278. Closes #2301.

Generated with [Claude Code](https://claude.ai/code)