### PR TITLE
Remove dead http-proxy-middleware override from pnpm-workspace.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,6 @@ overrides:
   compression: ^1.8.1
   form-data: ^4.0.6
   http-proxy: npm:http-proxy-node16@^1.0.6
-  http-proxy-middleware: ^3.0.7
   mobx-react: ^9.1.1
   tmp@^0.2.0: ^0.2.7
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,7 @@ catalogs:
       version: 19.2.8
 
 overrides:
-  '@types/http-proxy': '-'
   brace-expansion@^2.0.1: ^5.0.7
-  compression: ^1.8.1
   form-data: ^4.0.6
   http-proxy: npm:http-proxy-node16@^1.0.6
   mobx-react: ^9.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,9 +19,7 @@ allowBuilds:
 engineStrict: true
 
 overrides:
-  '@types/http-proxy': '-'
   brace-expansion@^2.0.1: ^5.0.7
-  compression: ^1.8.1
   form-data: ^4.0.6
   http-proxy: npm:http-proxy-node16@^1.0.6
   mobx-react: ^9.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,6 @@ overrides:
   compression: ^1.8.1
   form-data: ^4.0.6
   http-proxy: npm:http-proxy-node16@^1.0.6
-  http-proxy-middleware: ^3.0.7
   mobx-react: ^9.1.1
   tmp@^0.2.0: ^0.2.7
 


### PR DESCRIPTION
Removes three inert overrides from `pnpm-workspace.yaml` (and their mirrored entries in `pnpm-lock.yaml`), all leftovers from the removed Webpack / webpack-dev-server layer (#2118):

- `http-proxy-middleware: ^3.0.7` — not a direct dependency, not imported anywhere in the source (the proxy code uses `http-proxy-node16`), and not pulled in transitively.
- `compression: ^1.8.1` — not in the dependency tree at all (no `pnpm-lock.yaml` entry; `pnpm why -r compression` returns nothing). It came from the old express / webpack-dev-server stack.
- `@types/http-proxy: '-'` — now inert: nothing pulls `@types/http-proxy` anymore (the proxy code uses `http-proxy-node16`, which ships its own types), so the `'-'` removal directive no longer matches anything.

The remaining overrides are still doing work and are kept: `http-proxy: npm:http-proxy-node16@^1.0.6`, `brace-expansion@^2.0.1: ^5.0.7`, `form-data: ^4.0.6`, `tmp@^0.2.0: ^0.2.7`, and `mobx-react: ^9.1.1`.

The lockfile diff drops only the override lines (no package-graph changes); `pnpm install --frozen-lockfile`, `pnpm type:check`, `pnpm biome check`, and `pnpm build` all pass.

Closes #2322

Generated with [Claude Code](https://claude.ai/code)
