### PR TITLE
Remove the unused config block from packages/core/package.json

### DIFF
--- a/.github/workflows/kubectl-versions.yaml
+++ b/.github/workflows/kubectl-versions.yaml
@@ -75,7 +75,6 @@ jobs:
           cat packages/kubectl-versions/build/versions.json | yq -pj -oy '.[-1][-1]' > .github/version.log
           version=$(cat .github/version.log)
           yq -pj -oj -i '.config.bundledKubectlVersion="'"$version"'"' freelens/package.json
-          yq -pj -oj -i '.config.bundledKubectlVersion="'"$version"'"' packages/core/package.json
           echo "Bundled kubectl version $version" > .github/pr_body.log
 
       - name: Check for changes

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -129,8 +129,7 @@
       "customType": "regex",
       "extractVersionTemplate": "^(?<version>.*)$",
       "managerFilePatterns": [
-        "/^freelens/package\\.json$/",
-        "/^packages/core/package\\.json$/"
+        "/^freelens/package\\.json$/"
       ],
       "matchStrings": [
         "\"k8sProxyVersion\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
@@ -144,8 +143,7 @@
       "customType": "regex",
       "extractVersionTemplate": "^(?<version>.*)$",
       "managerFilePatterns": [
-        "/^freelens/package\\.json$/",
-        "/^packages/core/package\\.json$/"
+        "/^freelens/package\\.json$/"
       ],
       "matchStrings": [
         "\"bundledHelmVersion\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,13 +52,6 @@
     "test:unit": "TZ=UTC vitest run -c ../../vitest.config.ts --project @freelensapp/core",
     "test:watch": "TZ=UTC vitest -c ../../vitest.config.ts --project @freelensapp/core"
   },
-  "config": {
-    "bundledHelmVersion": "4.2.3",
-    "bundledKubectlVersion": "1.36.3",
-    "contentSecurityPolicy": "script-src 'unsafe-eval' 'self'; frame-src https://*.renderer.freelens.app:*/; img-src * data:",
-    "k8sProxyVersion": "1.8.3",
-    "welcomeRoute": "/welcome"
-  },
   "dependencies": {
     "@dnd-kit/core": "catalog:",
     "@dnd-kit/sortable": "catalog:",


### PR DESCRIPTION
Closes #2343

`packages/core/package.json` carried a `config` block duplicating the one in `freelens/package.json`. Nothing reads it, yet a nightly workflow and two Renovate custom managers kept it up to date — the previous commit on main, #2341, had to bump `k8sProxyVersion` there as well as in `freelens/package.json`.

## What changed

- **`packages/core/package.json`** — the whole `config` block is gone, all five keys (`bundledHelmVersion`, `bundledKubectlVersion`, `contentSecurityPolicy`, `k8sProxyVersion`, `welcomeRoute`), not just the versions.
- **`.github/workflows/kubectl-versions.yaml`** — dropped the `yq` line that wrote `bundledKubectlVersion` into core. This has to land in the same commit: `yq` creates a missing path, so leaving it would recreate a partial `config` block at the next kubectl bump.
- **`.renovaterc.json5`** — removed the now-unmatched `packages/core/package.json` pattern from the `managerFilePatterns` of both bundled-binary custom managers.

## Why nothing breaks

`packages/core/package.json` is imported in exactly two places under `packages/core/src`, and both read only `.version`:

- `common/vars/extension-api-version.injectable.ts` — `new SemVer(packageJson.version)`
- `common/k8s-api/create-kube-json-api.injectable.ts` — `User-Agent: Freelens/${packageJson.version}`

Every consumer of the removed keys resolves them through `applicationInformationToken`, which `freelens/src/common/application-information.injectable.ts` populates from **`freelens/package.json`**:

| key | consumer |
| --- | --- |
| `bundledKubectlVersion` | `common/vars/bundled-kubectl-version.injectable.ts` |
| `bundledHelmVersion`, `k8sProxyVersion` | read off the token by their callers |
| `contentSecurityPolicy` | `common/vars/content-security-policy.injectable.ts` |
| `welcomeRoute` | `common/front-end-routing/routes/welcome/welcome-route-config.injectable.ts` |

`ensure-binaries` is only ever given `freelens/package.json` (`build:resources:client` runs `ensure-binaries --package package.json` from `freelens/`), unit tests use `packages/core/src/test-env/application-information-fake.injectable.ts`, and `@freelensapp/core` is `private: true`, so there is no external consumer either.

## Verification

- `pnpm type:check` passes. That is the load-bearing check here: `resolveJsonModule` types the import, so any surviving reference to `.config` would now be a compile error.
- `trunk check` clean on the three changed files.
- Unit and integration tests left to CI.

| Model: `claude-opus-5[1m]`
