### PR TITLE
Remove stale OpenLens copyright line from Freelens-only files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,60 @@ When a tool insists on writing inside the repo, keep it out of git:
 Never `git add -A` / `git add .` blindly: review `git status` first and stage
 only the files your change actually touches, never these artifacts.
 
+## Copyright Headers
+
+Source files carry one of two header variants. Which one a file gets depends
+on whether it continues code from the original OpenLens fork, not on what its
+neighbours in the same directory look like.
+
+**New files** — anything created from scratch, including rewrites,
+translations, and reimplementations of removed or legacy logic — get the
+single-line variant:
+
+```ts
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+```
+
+This holds even when the new file's logic is inspired by, or replaces, old
+OpenLens code: inspiration is not continuation. `freelens/electron.vite.config.ts`,
+written as a translation of the removed webpack config, is a new file.
+
+**Files that continue code from the fork** keep the two-line variant:
+
+```ts
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+```
+
+A file continues fork code when its path was present in the fork-import commit
+`0a5798c9` ("First commit - Open Lens fork from master branch"):
+
+```sh
+git ls-tree -r --name-only 0a5798c9 | grep -x <path>
+```
+
+or when `git log --follow -- <path>` traces it back to a path that was — that
+is, git itself detects the file as a rename, move, or copy of fork-era code:
+
+```sh
+git log --follow --format= --name-only -- <path> | sort -u
+```
+
+Never add the `OpenLens Authors` line to a file that does not already have it
+just because neighbouring files do. Do not touch legal or license text
+(`LICENSE`, `README.md`, `freelens/license-header.txt`,
+`freelens/static/build/license.txt`) or the upstream copyright notices of
+vendored third-party code, which are unrelated to either header variant.
+
+See [#2352](https://github.com/freelensapp/freelens/issues/2352) for the
+cleanup that established this rule.
+
 ## Build System
 
 ### Commands

--- a/freelens/electron.vite.config.ts
+++ b/freelens/electron.vite.config.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/freelens/integration/__tests__/extensions.tests.ts
+++ b/freelens/integration/__tests__/extensions.tests.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/freelens/src/freelens-extension-api.ts
+++ b/freelens/src/freelens-extension-api.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/__mocks__/selfsigned.ts
+++ b/packages/core/__mocks__/selfsigned.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/common/app-paths/path-to-pnpm-cli.injectable.ts
+++ b/packages/core/src/common/app-paths/path-to-pnpm-cli.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/common/certificate/certificate.ts
+++ b/packages/core/src/common/certificate/certificate.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/common/dependency-injection/dependency-injection-container.injectable.ts
+++ b/packages/core/src/common/dependency-injection/dependency-injection-container.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/common/fetch/node-fetch.injectable.ts
+++ b/packages/core/src/common/fetch/node-fetch.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/common/k8s-api/endpoints/metrics.api.test.ts
+++ b/packages/core/src/common/k8s-api/endpoints/metrics.api.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/common/k8s-api/endpoints/metrics.api/request-metrics.injectable.test.ts
+++ b/packages/core/src/common/k8s-api/endpoints/metrics.api/request-metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/common/utils/async-computed.ts
+++ b/packages/core/src/common/utils/async-computed.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/common/utils/await-lock.ts
+++ b/packages/core/src/common/utils/await-lock.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/common/utils/get-latest-version.injectable.ts
+++ b/packages/core/src/common/utils/get-latest-version.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/common/vars/default-shell.injectable.ts
+++ b/packages/core/src/common/vars/default-shell.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/extensions/extension-api-di/as-lazy-injected-function.ts
+++ b/packages/core/src/extensions/extension-api-di/as-lazy-injected-function.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/extensions/extension-api-di/extension-api-di.ts
+++ b/packages/core/src/extensions/extension-api-di/extension-api-di.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/extensions/extension-loader/file-system-provisioner-store/get-hash.test.ts
+++ b/packages/core/src/extensions/extension-loader/file-system-provisioner-store/get-hash.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/extensions/install-extension/fork-pnpm.injectable.ts
+++ b/packages/core/src/extensions/install-extension/fork-pnpm.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/extensions/install-extension/install-extension.test.ts
+++ b/packages/core/src/extensions/install-extension/install-extension.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/features/application-menu/main/menu-items/help/open-licenses/show-licenses-window.injectable.ts
+++ b/packages/core/src/features/application-menu/main/menu-items/help/open-licenses/show-licenses-window.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/features/favorites/common/storage.injectable.ts
+++ b/packages/core/src/features/favorites/common/storage.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/features/favorites/storage-technical.test.ts
+++ b/packages/core/src/features/favorites/storage-technical.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/features/licenses/main/license-content-request-channel-listener.injectable.ts
+++ b/packages/core/src/features/licenses/main/license-content-request-channel-listener.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/features/licenses/renderer/license-content.injectable.ts
+++ b/packages/core/src/features/licenses/renderer/license-content.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/features/licenses/renderer/licenses.tsx
+++ b/packages/core/src/features/licenses/renderer/licenses.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/features/preferences/navigation-to-extension-preferences-using-extension-api.test.tsx
+++ b/packages/core/src/features/preferences/navigation-to-extension-preferences-using-extension-api.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/main/__test__/kube-api-upgrade-request.test.ts
+++ b/packages/core/src/main/__test__/kube-api-upgrade-request.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/main/catalog-sources/kubeconfig-sync/watch-file-changes.test.ts
+++ b/packages/core/src/main/catalog-sources/kubeconfig-sync/watch-file-changes.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/main/electron-app/runnables/setup-paste-handler.injectable.ts
+++ b/packages/core/src/main/electron-app/runnables/setup-paste-handler.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/main/fetch/download-binary-channel-listener.injectable.ts
+++ b/packages/core/src/main/fetch/download-binary-channel-listener.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/main/fetch/download-json-channel-listener-copy.injectable.ts
+++ b/packages/core/src/main/fetch/download-json-channel-listener-copy.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/main/fetch/download-json.injectable.ts
+++ b/packages/core/src/main/fetch/download-json.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/main/fetch/https-agent.injectable.ts
+++ b/packages/core/src/main/fetch/https-agent.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/main/kubectl/kubectl-checksums.injectable.ts
+++ b/packages/core/src/main/kubectl/kubectl-checksums.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/main/kubectl/kubectl.test.ts
+++ b/packages/core/src/main/kubectl/kubectl.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/main/versions/get-latest-version-channel-listener.injectable.ts
+++ b/packages/core/src/main/versions/get-latest-version-channel-listener.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/chart/bar-chart.test.tsx
+++ b/packages/core/src/renderer/components/chart/bar-chart.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/chart/chartjs-adapter-native.test.ts
+++ b/packages/core/src/renderer/components/chart/chartjs-adapter-native.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/chart/chartjs-adapter-native.ts
+++ b/packages/core/src/renderer/components/chart/chartjs-adapter-native.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/cluster-metrics.test.tsx
+++ b/packages/core/src/renderer/components/cluster/cluster-metrics.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/cluster-pie-charts.test.tsx
+++ b/packages/core/src/renderer/components/cluster/cluster-pie-charts.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/metrics-time-range-selector.module.scss
+++ b/packages/core/src/renderer/components/cluster/metrics-time-range-selector.module.scss
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/metrics-time-range-selector.test.tsx
+++ b/packages/core/src/renderer/components/cluster/metrics-time-range-selector.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/metrics-time-range-selector.tsx
+++ b/packages/core/src/renderer/components/cluster/metrics-time-range-selector.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/metrics-time-range.test.ts
+++ b/packages/core/src/renderer/components/cluster/metrics-time-range.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/metrics-time-range.ts
+++ b/packages/core/src/renderer/components/cluster/metrics-time-range.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/overview/metrics-time-range-storage.injectable.ts
+++ b/packages/core/src/renderer/components/cluster/overview/metrics-time-range-storage.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/overview/selected-metrics-time-range.injectable.test.ts
+++ b/packages/core/src/renderer/components/cluster/overview/selected-metrics-time-range.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/overview/selected-metrics-time-range.injectable.ts
+++ b/packages/core/src/renderer/components/cluster/overview/selected-metrics-time-range.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/overview/time-range-key.test.ts
+++ b/packages/core/src/renderer/components/cluster/overview/time-range-key.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/cluster/overview/time-range-key.ts
+++ b/packages/core/src/renderer/components/cluster/overview/time-range-key.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/command-palette/registered-commands/sidebar-navigation-commands.injectable.ts
+++ b/packages/core/src/renderer/components/command-palette/registered-commands/sidebar-navigation-commands.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/command-palette/registered-commands/sidebar-navigation-commands.test.tsx
+++ b/packages/core/src/renderer/components/command-palette/registered-commands/sidebar-navigation-commands.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/config-validating-admission-policies/details.test.tsx
+++ b/packages/core/src/renderer/components/config-validating-admission-policies/details.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/config-validating-admission-policies/validating-admission-policies-details.tsx
+++ b/packages/core/src/renderer/components/config-validating-admission-policies/validating-admission-policies-details.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/config-validating-admission-policies/validating-admission-policies-route-component.injectable.ts
+++ b/packages/core/src/renderer/components/config-validating-admission-policies/validating-admission-policies-route-component.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/config-validating-admission-policies/validating-admission-policies-sidebar-items.injectable.ts
+++ b/packages/core/src/renderer/components/config-validating-admission-policies/validating-admission-policies-sidebar-items.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/config-validating-admission-policy-bindings/details.test.tsx
+++ b/packages/core/src/renderer/components/config-validating-admission-policy-bindings/details.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/config-validating-admission-policy-bindings/validating-admission-policy-bindings-details.tsx
+++ b/packages/core/src/renderer/components/config-validating-admission-policy-bindings/validating-admission-policy-bindings-details.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/config-validating-admission-policy-bindings/validating-admission-policy-bindings-route-component.injectable.ts
+++ b/packages/core/src/renderer/components/config-validating-admission-policy-bindings/validating-admission-policy-bindings-route-component.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/config-validating-admission-policy-bindings/validating-admission-policy-bindings-sidebar-items.injectable.ts
+++ b/packages/core/src/renderer/components/config-validating-admission-policy-bindings/validating-admission-policy-bindings-sidebar-items.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.test.tsx
+++ b/packages/core/src/renderer/components/dock/edit-resource/edit-resource-model/edit-resource-model.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/dock/logs/__test__/create-logs-tab.injectable.test.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/create-logs-tab.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/dock/logs/__test__/list.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/list.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/dock/logs/__test__/logs-view-model.test.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/logs-view-model.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
+++ b/packages/core/src/renderer/components/dock/logs/__test__/test-utils.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/dock/logs/default-container-helper.ts
+++ b/packages/core/src/renderer/components/dock/logs/default-container-helper.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/dock/terminal/store.test.ts
+++ b/packages/core/src/renderer/components/dock/terminal/store.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/favorites/overview/overview.tsx
+++ b/packages/core/src/renderer/components/favorites/overview/overview.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/favorites/overview/sidebar-item.injectable.tsx
+++ b/packages/core/src/renderer/components/favorites/overview/sidebar-item.injectable.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/favorites/sidebar-items-computed.injectable.ts
+++ b/packages/core/src/renderer/components/favorites/sidebar-items-computed.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { SidebarItemDeclaration, sidebarItemsInjectable } from "@freelensapp/cluster-sidebar";

--- a/packages/core/src/renderer/components/favorites/sidebar-items-computed.test.ts
+++ b/packages/core/src/renderer/components/favorites/sidebar-items-computed.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/favorites/store.injectable.ts
+++ b/packages/core/src/renderer/components/favorites/store.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/favorites/store.test.ts
+++ b/packages/core/src/renderer/components/favorites/store.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/hotbar/__tests__/hotbar-menu-auto-hide.test.tsx
+++ b/packages/core/src/renderer/components/hotbar/__tests__/hotbar-menu-auto-hide.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/item-object-list/__tests__/column-resize.test.tsx
+++ b/packages/core/src/renderer/components/item-object-list/__tests__/column-resize.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-detail-params/get-maybe-details-url.injectable.ts
+++ b/packages/core/src/renderer/components/kube-detail-params/get-maybe-details-url.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-conditions/kube-object-conditions-drawer.tsx
+++ b/packages/core/src/renderer/components/kube-object-conditions/kube-object-conditions-drawer.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-conditions/kube-object-conditions-list.tsx
+++ b/packages/core/src/renderer/components/kube-object-conditions/kube-object-conditions-list.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/index.ts
+++ b/packages/core/src/renderer/components/kube-object-link/index.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-cluster-role.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-cluster-role.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-config-map.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-config-map.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-job.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-job.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-namespace.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-namespace.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-node.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-node.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-object.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-object.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-pod.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-pod.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-priority-class.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-priority-class.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-replica-set.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-replica-set.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-role.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-role.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-runtime-class.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-runtime-class.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-secret.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-secret.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-service-account.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-service-account.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-link/link-to-storage-class.tsx
+++ b/packages/core/src/renderer/components/kube-object-link/link-to-storage-class.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-menu/kube-object-delete-service.injectable.ts
+++ b/packages/core/src/renderer/components/kube-object-menu/kube-object-delete-service.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/kube-object-menu/smart-delete-menu-item.tsx
+++ b/packages/core/src/renderer/components/kube-object-menu/smart-delete-menu-item.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/namespaces/metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/namespaces/metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/network-endpoint-slices/endpoint-slice-details.scss
+++ b/packages/core/src/renderer/components/network-endpoint-slices/endpoint-slice-details.scss
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/network-endpoint-slices/endpoint-slice-details.tsx
+++ b/packages/core/src/renderer/components/network-endpoint-slices/endpoint-slice-details.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/network-endpoint-slices/endpoint-slices.tsx
+++ b/packages/core/src/renderer/components/network-endpoint-slices/endpoint-slices.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/network-ingresses/ingress-charts.test.tsx
+++ b/packages/core/src/renderer/components/network-ingresses/ingress-charts.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/network-ingresses/metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/network-ingresses/metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/network-services/service-details-endpoint-slices.tsx
+++ b/packages/core/src/renderer/components/network-services/service-details-endpoint-slices.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/node-pod-menu/node-menu.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/node-menu.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/node-pod-menu/pod-attach-menu.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/pod-attach-menu.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/node-pod-menu/pod-logs-menu.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/pod-logs-menu.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/node-pod-menu/pod-menu-item.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/pod-menu-item.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/node-pod-menu/pod-shell-menu.tsx
+++ b/packages/core/src/renderer/components/node-pod-menu/pod-shell-menu.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/nodes/metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/nodes/metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/nodes/node-charts.test.tsx
+++ b/packages/core/src/renderer/components/nodes/node-charts.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/resource-metrics/create-time-ranged-metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/resource-metrics/create-time-ranged-metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/resource-metrics/create-time-ranged-metrics.ts
+++ b/packages/core/src/renderer/components/resource-metrics/create-time-ranged-metrics.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/resource-metrics/metrics-details-component-adapters.test.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/metrics-details-component-adapters.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/resource-metrics/resource-metrics.test.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/resource-metrics.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/resource-metrics/time-ranged-resource-metrics.test.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/time-ranged-resource-metrics.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/resource-metrics/time-ranged-resource-metrics.tsx
+++ b/packages/core/src/renderer/components/resource-metrics/time-ranged-resource-metrics.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/storage-volume-claims/metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/storage-volume-claims/metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/storage-volume-claims/volume-claim-disk-chart.test.tsx
+++ b/packages/core/src/renderer/components/storage-volume-claims/volume-claim-disk-chart.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/welcome/new-version-notification.injectable.test.tsx
+++ b/packages/core/src/renderer/components/welcome/new-version-notification.injectable.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/welcome/new-version-notification.injectable.tsx
+++ b/packages/core/src/renderer/components/welcome/new-version-notification.injectable.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/with-tooltip/with-tooltip.tsx
+++ b/packages/core/src/renderer/components/with-tooltip/with-tooltip.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-cronjobs/utils.ts
+++ b/packages/core/src/renderer/components/workloads-cronjobs/utils.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-daemonsets/metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/workloads-daemonsets/metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-deployments/metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/workloads-deployments/metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-jobs/metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/workloads-jobs/metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-pods/__tests__/pod-details-container.test.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/__tests__/pod-details-container.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-cpu-usage-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-cpu-usage-column.injectable.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-logs-button-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-logs-button-column.injectable.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-memory-usage-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-memory-usage-column.injectable.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-pods/columns/pods-warning-column.injectable.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/columns/pods-warning-column.injectable.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-pods/container-metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/workloads-pods/container-metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-pods/metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/workloads-pods/metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-replicasets/metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/workloads-replicasets/metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/components/workloads-statefulsets/metrics.injectable.test.ts
+++ b/packages/core/src/renderer/components/workloads-statefulsets/metrics.injectable.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/fetch/download-binary-via-channel.injectable.ts
+++ b/packages/core/src/renderer/fetch/download-binary-via-channel.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/fetch/download-json-via-channel-copy.injectable.ts
+++ b/packages/core/src/renderer/fetch/download-json-via-channel-copy.injectable.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/core/src/renderer/monaco/setup-monaco-environment.ts
+++ b/packages/core/src/renderer/monaco/setup-monaco-environment.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/ensure-binaries/src/artifacts.ts
+++ b/packages/ensure-binaries/src/artifacts.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/ensure-binaries/src/download.ts
+++ b/packages/ensure-binaries/src/download.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/ensure-binaries/src/kubectl-checksums.ts
+++ b/packages/ensure-binaries/src/kubectl-checksums.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/ensure-binaries/src/lock.ts
+++ b/packages/ensure-binaries/src/lock.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/ensure-binaries/src/pin.ts
+++ b/packages/ensure-binaries/src/pin.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/ensure-binaries/src/update-kubectl-checksums.ts
+++ b/packages/ensure-binaries/src/update-kubectl-checksums.ts
@@ -2,7 +2,6 @@
 
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/ensure-binaries/src/update-lock.ts
+++ b/packages/ensure-binaries/src/update-lock.ts
@@ -2,7 +2,6 @@
 
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/ensure-binaries/src/verify.ts
+++ b/packages/ensure-binaries/src/verify.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/extensions/src/runtime-shim.ts
+++ b/packages/extensions/src/runtime-shim.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/generate-license/src/index.ts
+++ b/packages/generate-license/src/index.ts
@@ -2,7 +2,6 @@
 
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/kube-object/src/specifics/endpoint-slice.ts
+++ b/packages/kube-object/src/specifics/endpoint-slice.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/kube-object/src/specifics/events.test.ts
+++ b/packages/kube-object/src/specifics/events.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/kube-object/src/specifics/node-metrics.ts
+++ b/packages/kube-object/src/specifics/node-metrics.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/kube-object/src/specifics/validating-admission-policy-binding.ts
+++ b/packages/kube-object/src/specifics/validating-admission-policy-binding.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/kube-object/src/specifics/validating-admission-policy.ts
+++ b/packages/kube-object/src/specifics/validating-admission-policy.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/compile-route-path.ts
+++ b/packages/routing/src/compile-route-path.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/link.test.tsx
+++ b/packages/routing/src/link.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/link.tsx
+++ b/packages/routing/src/link.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/match-path.test.ts
+++ b/packages/routing/src/match-path.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/match-path.ts
+++ b/packages/routing/src/match-path.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/observable-history.test.ts
+++ b/packages/routing/src/observable-history.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/observable-history.ts
+++ b/packages/routing/src/observable-history.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/observable-search-params.ts
+++ b/packages/routing/src/observable-search-params.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/route.test.tsx
+++ b/packages/routing/src/route.test.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/route.tsx
+++ b/packages/routing/src/route.tsx
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/routing/src/vendor/path-to-regexp.ts
+++ b/packages/routing/src/vendor/path-to-regexp.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/utility-features/test-utils/src/act-async-fn.ts
+++ b/packages/utility-features/test-utils/src/act-async-fn.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/utility-features/utilities/src/abort-controller.test.ts
+++ b/packages/utility-features/utilities/src/abort-controller.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/utility-features/utilities/src/base64.test.ts
+++ b/packages/utility-features/utilities/src/base64.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/utility-features/utilities/src/buildUrl.test.ts
+++ b/packages/utility-features/utilities/src/buildUrl.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/utility-features/utilities/src/date.test.ts
+++ b/packages/utility-features/utilities/src/date.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/utility-features/utilities/src/date.ts
+++ b/packages/utility-features/utilities/src/date.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/utility-features/utilities/src/lowerAndPluralize.test.ts
+++ b/packages/utility-features/utilities/src/lowerAndPluralize.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 

--- a/packages/utility-features/utilities/src/lowerAndPluralize.ts
+++ b/packages/utility-features/utilities/src/lowerAndPluralize.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Freelens Authors. All rights reserved.
- * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 


### PR DESCRIPTION
Fixes #2352.

Removes the `Copyright (c) OpenLens Authors. All rights reserved.` line from 171 files that were created after the fork import and never carried OpenLens code, and documents the rule in AGENTS.md so new files start out correct.

## Classification

Baseline: every path in `git ls-tree -r --name-only 0a5798c9` (the squashed fork-import commit).

Of the 3361 tracked files carrying the OpenLens line:

- 3054 have a path present in the fork tree - kept
- 307 do not; of those, 136 have git-detected lineage (`git log --follow`) back to a path that was - kept
- the remaining 171 have neither - line removed

`LICENSE`, `README.md`, `freelens/license-header.txt` and `freelens/static/build/license.txt` are untouched.

## Notes for review

- `packages/routing/src/vendor/path-to-regexp.ts` is on the cleaned list. Its top-of-file header is the ordinary repo header (new Freelens-era file, so the OpenLens line goes); the separate upstream `MIT (c) 2014 Blake Embrey` notice below it is untouched.
- 89 of the 136 kept files are not moves but git-detected *copies* of fork-era files (e.g. `config-validating-admission-policies/validating-admission-policies.tsx` derived from `config-mutating-webhook-configurations/mutating-webhook-configurations.tsx`). Keeping the line there is both the literal rule from the issue and the legally safe reading. A handful are header-only similarity artifacts on trivial barrel files (e.g. `components/countdown/index.ts` matched to `components/checkbox/index.ts`, which still exists); say the word and I will clean those too.

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-5`