### PR TITLE
Complete macOS natural text editing mappings in the terminal

### DIFF
--- a/packages/core/src/renderer/components/dock/terminal/terminal-key-mapping.ts
+++ b/packages/core/src/renderer/components/dock/terminal/terminal-key-mapping.ts
@@ -10,25 +10,57 @@ interface TerminalKeyMapping {
 
 export type SendTerminalData = (data: string) => void;
 
+const Modifier = {
+  Alt: 1 << 0,
+  Ctrl: 1 << 1,
+  Meta: 1 << 2,
+  Shift: 1 << 3,
+} as const;
+
+const modifiersOf = (evt: KeyboardEvent): number =>
+  (evt.altKey ? Modifier.Alt : 0) |
+  (evt.ctrlKey ? Modifier.Ctrl : 0) |
+  (evt.metaKey ? Modifier.Meta : 0) |
+  (evt.shiftKey ? Modifier.Shift : 0);
+
+const mappingKey = (modifiers: number, code: string): string => `${modifiers}:${code}`;
+
+/**
+ * iTerm2's "Natural Text Editing" preset, limited to sequences that zsh and
+ * readline bind by default in emacs mode, so that no user configuration is
+ * required.
+ *
+ * The modifiers are matched exactly: shifted variants such as
+ * Option+Shift+ArrowLeft are selection gestures that a shell line editor cannot
+ * express, so they are left to xterm.js.
+ *
+ * Option+Backspace is intentionally absent. xterm.js already prefixes Backspace
+ * with ESC when Alt is held, and zsh binds `\e^?` to `backward-kill-word` by
+ * default, so mapping it here would be a no-op at best.
+ *
+ * Command+ArrowLeft sends Ctrl-A, which is also the default tmux prefix, so a
+ * tmux session running inside the terminal will swallow it instead of moving
+ * the cursor. iTerm2 behaves identically, so this is accepted rather than
+ * worked around.
+ */
+const macNaturalTextEditingMappings = new Map<string, string>([
+  [mappingKey(Modifier.Alt, "ArrowLeft"), "\x1bb"], // backward-word
+  [mappingKey(Modifier.Alt, "ArrowRight"), "\x1bf"], // forward-word
+  [mappingKey(Modifier.Alt, "Delete"), "\x1bd"], // kill-word (forward)
+  [mappingKey(Modifier.Meta, "ArrowLeft"), "\x01"], // beginning-of-line
+  [mappingKey(Modifier.Meta, "ArrowRight"), "\x05"], // end-of-line
+  [mappingKey(Modifier.Meta, "Backspace"), "\x15"], // backward-kill-line
+  [mappingKey(Modifier.Meta, "Delete"), "\x0b"], // kill-line (forward)
+]);
+
 export const getMacNaturalTextEditingMapping = (evt: KeyboardEvent): TerminalKeyMapping | undefined => {
   if (evt.type !== "keydown") {
     return undefined;
   }
 
-  if (evt.altKey && !evt.ctrlKey && !evt.metaKey && !evt.shiftKey) {
-    switch (evt.code) {
-      case "ArrowLeft":
-        return { data: "\x1bb" };
-      case "ArrowRight":
-        return { data: "\x1bf" };
-    }
-  }
+  const data = macNaturalTextEditingMappings.get(mappingKey(modifiersOf(evt), evt.code));
 
-  if (evt.metaKey && !evt.altKey && !evt.ctrlKey && !evt.shiftKey && evt.code === "Backspace") {
-    return { data: "\x15" };
-  }
-
-  return undefined;
+  return data ? { data } : undefined;
 };
 
 export const handleMacNaturalTextEditingKey = (evt: KeyboardEvent, sendData: SendTerminalData): boolean => {

--- a/packages/core/src/renderer/components/dock/terminal/terminal.test.ts
+++ b/packages/core/src/renderer/components/dock/terminal/terminal.test.ts
@@ -22,18 +22,59 @@ describe("getMacNaturalTextEditingMapping", () => {
     });
   });
 
+  it("maps Option+Delete to forward kill-word", () => {
+    expect(getMacNaturalTextEditingMapping(keyDown({ altKey: true, code: "Delete" }))).toEqual({
+      data: "\x1bd",
+    });
+  });
+
+  it("maps Command+ArrowLeft to beginning-of-line", () => {
+    expect(getMacNaturalTextEditingMapping(keyDown({ metaKey: true, code: "ArrowLeft" }))).toEqual({
+      data: "\x01",
+    });
+  });
+
+  it("maps Command+ArrowRight to end-of-line", () => {
+    expect(getMacNaturalTextEditingMapping(keyDown({ metaKey: true, code: "ArrowRight" }))).toEqual({
+      data: "\x05",
+    });
+  });
+
   it("maps Command+Backspace to line kill", () => {
     expect(getMacNaturalTextEditingMapping(keyDown({ metaKey: true, code: "Backspace" }))).toEqual({
       data: "\x15",
     });
   });
 
+  it("maps Command+Delete to forward kill-line", () => {
+    expect(getMacNaturalTextEditingMapping(keyDown({ metaKey: true, code: "Delete" }))).toEqual({
+      data: "\x0b",
+    });
+  });
+
+  it("does not map Option+Backspace, which xterm already prefixes with ESC for backward-kill-word", () => {
+    expect(getMacNaturalTextEditingMapping(keyDown({ altKey: true, code: "Backspace" }))).toBeUndefined();
+  });
+
   it("does not map unrelated key events", () => {
     expect(getMacNaturalTextEditingMapping(keyUp({ altKey: true, code: "ArrowLeft" }))).toBeUndefined();
     expect(getMacNaturalTextEditingMapping(keyDown({ altKey: true, code: "ArrowUp" }))).toBeUndefined();
+    expect(getMacNaturalTextEditingMapping(keyDown({ metaKey: true, code: "ArrowUp" }))).toBeUndefined();
+    expect(getMacNaturalTextEditingMapping(keyDown({ code: "ArrowLeft" }))).toBeUndefined();
+    expect(getMacNaturalTextEditingMapping(keyDown({ metaKey: true, code: "KeyK" }))).toBeUndefined();
+  });
+
+  it("requires an exact modifier match", () => {
     expect(
       getMacNaturalTextEditingMapping(keyDown({ altKey: true, code: "ArrowLeft", shiftKey: true })),
     ).toBeUndefined();
+    expect(
+      getMacNaturalTextEditingMapping(keyDown({ metaKey: true, code: "ArrowLeft", shiftKey: true })),
+    ).toBeUndefined();
+    expect(
+      getMacNaturalTextEditingMapping(keyDown({ metaKey: true, code: "ArrowRight", ctrlKey: true })),
+    ).toBeUndefined();
+    expect(getMacNaturalTextEditingMapping(keyDown({ altKey: true, code: "Delete", metaKey: true }))).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Extends the macOS terminal key mapping helper added in #2338 with the remaining shortcuts of iTerm2's "Natural Text Editing" preset:

| Shortcut | Sequence | Shell action |
| --- | --- | --- |
| Command+ArrowLeft | `\x01` | `beginning-of-line` |
| Command+ArrowRight | `\x05` | `end-of-line` |
| Command+Delete | `\x0b` | `kill-line` (forward) |
| Option+Delete | `\x1bd` | `kill-word` (forward) |

Command+arrow keys were entirely dead before, because xterm.js bails out on `metaKey` for arrow keys and sends nothing; Option/Command+Delete echoed unbound escape sequences.

The if/switch chain is flattened into a lookup table keyed on a normalized modifier mask, which keeps the exact-match requirement in one place. Handling stays on `keydown` only and behind the existing `isMac` gate.

Option+Backspace is intentionally left unmapped (xterm.js already ESC-prefixes it, which zsh binds to `backward-kill-word`); this is documented in a comment and pinned by a test. The tmux Ctrl-A prefix collision with Command+ArrowLeft is noted in a comment, matching iTerm2 behavior.

Unit tests cover every mapping, the Option+Backspace non-mapping, unrelated events and exact-modifier-match negatives. `pnpm type:check`, biome and trunk are clean.

Smoke tested by hand on macOS in the dock terminal against a real zsh session: all seven mappings and the Option+Backspace non-mapping behave as described, and Command+K, copy/paste, Shift+Option+ArrowLeft and Ctrl+A/Ctrl+E are unaffected. A note for whoever repeats this: `cat -v` cannot confirm `\x15` and `\x7f`, because the tty line discipline consumes KILL and ERASE in canonical mode before the process sees them, so those two need zsh itself or `stty -icanon -echo`.

Closes #2354

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-5`