### PR TITLE
Fix virtualized lists growing to their content instead of scrolling

### DIFF
--- a/packages/core/src/renderer/components/cluster/cluster-issues.module.scss
+++ b/packages/core/src/renderer/components/cluster/cluster-issues.module.scss
@@ -23,6 +23,15 @@
     }
   }
 
+  /* The virtualized table fills this panel with height: 100%, so the flex
+     items above it must be able to shrink below their content. Without this
+     the table grows to the height of every issue and pushes the overview
+     page instead of scrolling inside the panel. */
+  :global(.Table),
+  :global(.VirtualList) {
+    min-height: 0;
+  }
+
   .SubHeader {
     padding-top: 0;
     padding-bottom: 0;

--- a/packages/core/src/renderer/components/dock/logs/controls.module.scss
+++ b/packages/core/src/renderer/components/dock/logs/controls.module.scss
@@ -4,6 +4,10 @@
   @include mixins.hidden-scrollbar;
 
   display: flex;
+  /* The mixin above makes this a scroll container, which drops its automatic
+     minimum size to zero and lets the flex column squeeze the bar to a sliver.
+     Keep it at its natural height and let the log list take the rest. */
+  flex-shrink: 0;
   gap: var(--padding);
   align-items: center;
   justify-content: space-between;

--- a/packages/core/src/renderer/components/dock/logs/list.scss
+++ b/packages/core/src/renderer/components/dock/logs/list.scss
@@ -12,6 +12,9 @@
   color: var(--logsForeground);
   background: var(--logsBackground);
   flex-grow: 1;
+  /* Let the flex item shrink below its content, so the nested list gets a
+     definite height to fill instead of growing to the height of every row. */
+  min-height: 0;
 
   .VirtualList {
     height: 100%;

--- a/packages/core/src/renderer/components/item-object-list/item-list-layout.scss
+++ b/packages/core/src/renderer/components/item-object-list/item-list-layout.scss
@@ -35,6 +35,16 @@
     position: relative;
     min-height: 130px;
 
+    /* The virtualized list fills its parent with height: 100%, so every flex
+       item between here and it must be able to shrink below its content.
+       Without this the automatic min-height of a flex item sizes the list to
+       all of its rows at once, the percentage height resolves against that,
+       and the list never scrolls. */
+    .Table,
+    .VirtualList {
+      min-height: 0;
+    }
+
     .resize-guide {
       position: absolute;
       top: 0;


### PR DESCRIPTION
## Problem

In every virtualized list only the first screenful of rows was reachable - a pods view with 144
items showed about 18 of them and would not scroll. The same defect hit three places:

| Place | Symptom |
| --- | --- |
| Resource lists (`ItemListLayout`) - pods, events, ... | list grew to the height of all rows, `<main>` clipped the rest, no scrollbar, every row rendered |
| Pod logs in the dock | `.LogList` was 2577px inside a 300px tab; all 66 lines in the DOM, nothing scrolled |
| `Warnings` panel on the Cluster page | table 560px inside the 350px panel, pushing the overview page instead of scrolling inside it |

Measured on a live cluster through the dev app's CDP endpoint, the pods view looked like this:

| element | height | scrollHeight |
| --- | --- | --- |
| `.ItemListLayout > .items` | 625px (correct) | 4791 |
| `.Table` | 4791px | 4791 |
| `.VirtualList` | 4752px | 4752 |
| `.list` (the scroll container) | 4752px | 4756 |

The scroll container had grown to the full height of its content, so it had nothing left to scroll,
and virtualization was defeated as well - all 144 rows were in the DOM at once.

**Root cause.** This is a regression from the react-window v1 -> v2 migration (#2283). v1 measured
the parent through `react-virtualized-auto-sizer`, whose wrapper has zero height, so the list's own
size never fed back into the parent. v2 has no auto-sizer: the list is given `height: 100%` and
needs a parent with a definite height. A flex item keeps `min-height: auto` and therefore cannot
shrink below its content, so the parent's height was decided by the list, the percentage resolved
against that, and the two grew together.

A second, unrelated defect became visible once the log list could shrink: the controls bar under
the logs (`Show timestamps`, `Word wrap`, ...) was squeezed to 19px of the 43px it needs, cutting
the checkboxes in half. `hidden-scrollbar` makes that bar a scroll container, which drops its
automatic minimum size to zero, so the flex column shrinks it instead of the list. Before this PR
the bar was pushed off-screen entirely, so the damage was there either way.

## What changed

Four stylesheets, no TSX - so no snapshot churn.

**1. `item-object-list/item-list-layout.scss`** - `min-height: 0` on `.Table` / `.VirtualList`
inside `> .items`. Scoped to the layout rather than applied to `.VirtualList` globally on purpose:
`PodDetailsList` passes `virtualHeight={660}`, and a global rule collapses that fixed-height list
to zero.

**2. `dock/logs/list.scss`** - `min-height: 0` on `.LogList`.

**3. `cluster/cluster-issues.module.scss`** - the same pair of selectors, via `:global()`.

**4. `dock/logs/controls.module.scss`** - `flex-shrink: 0`, matching the guard `.InfoPanel` already
carries next to the same mixin.

I audited the other six `hidden-scrollbar` call sites: `.InfoPanel` and the dock tab strip are
already protected, `.TableCell.scrollable` and the tab strip want the shrinking, and
`code.block`, the `Input` textarea and `.Notifications` are not flex items under pressure. The
controls bar was the only one missing the guard, so the mixin itself is left alone - two of its
users rely on exactly the behaviour that bit us here.

## Verification

Measured in the running dev app against a live cluster, after a full reload so the compiled CSS was
exercised rather than an injected style:

| view | scroll viewport | content | rows in DOM |
| --- | --- | --- | --- |
| Pods, 144 items | 286px | 4752 | 19, scrolls to the end |
| Events, 552 items | 324px | 18216 | 20 |
| Pod logs | 236px | 2399 | 16 |
| Cluster `Warnings` | 264px | 561 | overview page `scrollHeight` 898 -> 650 |
| Pod list in node details (`virtualHeight={660}`) | 660px | 1584 | unchanged, still honours its fixed height |

Logs controls bar: 43px at the bottom of the dock (745 -> 788 in a 788px window), nothing
overflowing.

`trunk check` on the four files: no issues. Unit tests were not run locally - CI covers them, and no
component markup changed.

Not covered here: `VolumeDetailsList` and `EndpointSubsetList` only turn virtual above 100 items and
have no definite-height parent either, so in that case they render every row and let the drawer
scroll. Nothing is cut off, only virtualization is lost, and I could not reproduce it on this
cluster - worth a follow-up.

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-5[1m]`
