### PR TITLE
Drop -i from the login-shell env sync

### DIFF
--- a/packages/core/src/features/shell-sync/main/compute-unix-shell-environment.injectable.ts
+++ b/packages/core/src/features/shell-sync/main/compute-unix-shell-environment.injectable.ts
@@ -92,8 +92,6 @@ const computeUnixShellEnvironmentInjectable = getInjectable({
         shellArgs.push("-c", command);
         command = "";
       } else if (!cshLikeShellName.test(shellName)) {
-        // zsh (at least, maybe others) don't load RC files when in non-interactive mode, even when using -l (login) option
-        shellArgs.push("-i");
         command = ` ${command}`; // This prevents the command from being added to the history
       } else {
         // Some shells don't support any other options when providing the -l (login) shell option

--- a/packages/core/src/features/shell-sync/main/compute-unix-shell-environment.test.ts
+++ b/packages/core/src/features/shell-sync/main/compute-unix-shell-environment.test.ts
@@ -212,7 +212,7 @@ describe("computeUnixShellEnvironment technical tests", () => {
     it("should spawn a process with the correct arguments", () => {
       expect(spawnMock).toBeCalledWith(
         shellPath,
-        ["-l", "-i"],
+        ["-l"],
         expect.objectContaining({
           env: expectedEnv,
         }),


### PR DESCRIPTION
Drop -i from the login-shell env sync to avoid sourcing interactive-only rc files