### PR TITLE
Replace typed-emitter with a local type in @freelensapp/utilities

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -137,7 +137,6 @@
         "react-window",
         "rfc6902",
         "type-fest",
-        "typed-emitter",
         "undici"
       ],
       "typescript": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -182,7 +182,6 @@
     "react-select-event": "catalog:",
     "tailwindcss": "catalog:",
     "type-fest": "catalog:",
-    "typed-emitter": "catalog:",
     "typescript": "catalog:",
     "typescript-plugin-css-modules": "catalog:",
     "vitest": "catalog:",

--- a/packages/core/src/common/catalog/catalog-entity.ts
+++ b/packages/core/src/common/catalog/catalog-entity.ts
@@ -9,9 +9,7 @@ import { iter } from "@freelensapp/utilities";
 import { once } from "es-toolkit";
 import { makeObservable, observable } from "mobx";
 
-import type { Disposer, StrictReactNode } from "@freelensapp/utilities";
-
-import type TypedEmitter from "typed-emitter";
+import type { Disposer, StrictReactNode, TypedEventEmitter } from "@freelensapp/utilities";
 
 import type {
   CategoryColumnRegistration,
@@ -140,7 +138,7 @@ export function categoryVersion<
   };
 }
 
-export abstract class CatalogCategory extends (EventEmitter as new () => TypedEmitter<CatalogCategoryEvents>) {
+export abstract class CatalogCategory extends (EventEmitter as new () => TypedEventEmitter<CatalogCategoryEvents>) {
   /**
    * The version of category that you are wanting to declare.
    *

--- a/packages/core/src/common/fs/watch/watch.injectable.ts
+++ b/packages/core/src/common/fs/watch/watch.injectable.ts
@@ -8,9 +8,7 @@ import { getInjectable } from "@ogre-tools/injectable";
 import { watch } from "chokidar";
 import type { Stats } from "node:fs";
 
-import type { SingleOrMany } from "@freelensapp/utilities";
-
-import type TypedEventEmitter from "typed-emitter";
+import type { SingleOrMany, TypedEventEmitter } from "@freelensapp/utilities";
 
 export type AlwaysStatWatcherEvents = {
   add: (path: string, stats: Stats) => void;

--- a/packages/core/src/common/k8s-api/api-manager/auto-registration-emitter.injectable.ts
+++ b/packages/core/src/common/k8s-api/api-manager/auto-registration-emitter.injectable.ts
@@ -8,8 +8,7 @@ import EventEmitter from "node:events";
 import { getInjectable } from "@ogre-tools/injectable";
 
 import type { KubeApi } from "@freelensapp/kube-api";
-
-import type TypedEventEmitter from "typed-emitter";
+import type { TypedEventEmitter } from "@freelensapp/utilities";
 
 export type LegacyAutoRegistration = {
   kubeApi: (api: KubeApi<any, any>) => void;

--- a/packages/core/src/extensions/extension-discovery/extension-discovery.ts
+++ b/packages/core/src/extensions/extension-discovery/extension-discovery.ts
@@ -16,8 +16,7 @@ import { requestInitialExtensionDiscovery } from "../../renderer/ipc";
 import type { Stats } from "node:fs";
 
 import type { Logger } from "@freelensapp/logger";
-
-import type TypedEventEmitter from "typed-emitter";
+import type { TypedEventEmitter } from "@freelensapp/utilities";
 
 import type { AccessPath } from "../../common/fs/access-path.injectable";
 import type { Copy } from "../../common/fs/copy.injectable";

--- a/packages/core/src/renderer/api/websocket-api.ts
+++ b/packages/core/src/renderer/api/websocket-api.ts
@@ -7,9 +7,7 @@
 import EventEmitter from "node:events";
 import { makeObservable, observable } from "mobx";
 
-import type { Defaulted } from "@freelensapp/utilities";
-
-import type TypedEventEmitter from "typed-emitter";
+import type { Defaulted, TypedEventEmitter } from "@freelensapp/utilities";
 
 import type { DefaultWebsocketApiParams } from "./default-websocket-api-params.injectable";
 

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -51,7 +51,6 @@
     "react-window": "catalog:extensions",
     "rfc6902": "catalog:extensions",
     "type-fest": "catalog:extensions",
-    "typed-emitter": "catalog:extensions",
     "undici": "catalog:extensions"
   },
   "devDependencies": {

--- a/packages/utility-features/run-many/package.json
+++ b/packages/utility-features/run-many/package.json
@@ -37,7 +37,6 @@
     "jsdom": "catalog:",
     "mobx": "catalog:",
     "type-fest": "catalog:",
-    "typed-emitter": "catalog:",
     "vitest": "catalog:"
   },
   "publishConfig": {

--- a/packages/utility-features/run-many/src/run-many-for.ts
+++ b/packages/utility-features/run-many/src/run-many-for.ts
@@ -8,9 +8,10 @@ import EventEmitter from "node:events";
 import { getOrInsert } from "@freelensapp/utilities";
 import { convertToWithIdWith, verifyRunnablesAreDAG } from "./helpers";
 
+import type { TypedEventEmitter } from "@freelensapp/utilities";
+
 import type { DiContainerForInjection, InjectionToken } from "@ogre-tools/injectable";
 import type { Asyncify } from "type-fest";
-import type TypedEventEmitter from "typed-emitter";
 
 import type { Run, Runnable, RunnableWithId } from "./types";
 

--- a/packages/utility-features/run-many/src/run-many-sync-for.ts
+++ b/packages/utility-features/run-many/src/run-many-sync-for.ts
@@ -7,10 +7,9 @@
 import EventEmitter from "node:events";
 import { convertToWithIdWith, verifyRunnablesAreDAG } from "./helpers";
 
-import type { Disposer } from "@freelensapp/utilities";
+import type { Disposer, TypedEventEmitter } from "@freelensapp/utilities";
 
 import type { DiContainerForInjection, InjectionToken } from "@ogre-tools/injectable";
-import type TypedEventEmitter from "typed-emitter";
 
 import type { RunnableSync, RunnableSyncWithId, RunSync } from "./types";
 

--- a/packages/utility-features/utilities/index.ts
+++ b/packages/utility-features/utilities/index.ts
@@ -40,6 +40,7 @@ export * from "./src/sort-function";
 export * from "./src/tar";
 export * from "./src/tuple";
 export * from "./src/type-narrowing";
+export * from "./src/typed-event-emitter";
 export * from "./src/types";
 export * from "./src/union-env-path";
 export * from "./src/wait";

--- a/packages/utility-features/utilities/src/typed-event-emitter.ts
+++ b/packages/utility-features/utilities/src/typed-event-emitter.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+/**
+ * A map of event names to the signatures of their listeners.
+ */
+export type EventMap = Record<string, (...args: never[]) => void>;
+
+/**
+ * A type-safe view of `node:events`' `EventEmitter`, in which the event names
+ * are restricted to the keys of `Events` and each listener is typed by the
+ * corresponding entry.
+ *
+ * This is a purely structural type; it does not provide an implementation. Use
+ * it by casting an `EventEmitter`:
+ *
+ * ```typescript
+ * type MyEvents = {
+ *   error: (error: Error) => void;
+ *   message: (from: string, content: string) => void;
+ * };
+ *
+ * const emitter = new EventEmitter() as unknown as TypedEventEmitter<MyEvents>;
+ *
+ * emitter.emit("error", "not an Error"); // <- type error
+ * ```
+ *
+ * The cast is needed because `EventEmitter` declares the same method names with
+ * wider signatures, which are not assignable to the narrowed ones.
+ *
+ * Replaces the `typed-emitter` package, which was last released in 2022-01 and
+ * only ever contained declarations.
+ */
+export interface TypedEventEmitter<Events extends EventMap> {
+  addListener<E extends keyof Events>(event: E, listener: Events[E]): this;
+  on<E extends keyof Events>(event: E, listener: Events[E]): this;
+  once<E extends keyof Events>(event: E, listener: Events[E]): this;
+  prependListener<E extends keyof Events>(event: E, listener: Events[E]): this;
+  prependOnceListener<E extends keyof Events>(event: E, listener: Events[E]): this;
+
+  off<E extends keyof Events>(event: E, listener: Events[E]): this;
+  removeListener<E extends keyof Events>(event: E, listener: Events[E]): this;
+  removeAllListeners<E extends keyof Events>(event?: E): this;
+
+  emit<E extends keyof Events>(event: E, ...args: Parameters<Events[E]>): boolean;
+
+  /**
+   * The return type is deliberately wider than `(keyof Events)[]` so that this
+   * interface stays compatible with `EventEmitter.eventNames()`.
+   */
+  eventNames(): (keyof Events | string | symbol)[];
+  listeners<E extends keyof Events>(event: E): Events[E][];
+  rawListeners<E extends keyof Events>(event: E): Events[E][];
+  listenerCount<E extends keyof Events>(event: E): number;
+
+  getMaxListeners(): number;
+  setMaxListeners(maxListeners: number): this;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,9 +354,6 @@ catalogs:
     type-fest:
       specifier: 5.6.0
       version: 5.6.0
-    typed-emitter:
-      specifier: 2.1.0
-      version: 2.1.0
     typed-regex:
       specifier: 0.0.8
       version: 0.0.8
@@ -460,9 +457,6 @@ catalogs:
     type-fest:
       specifier: ^5.6.0
       version: 5.6.0
-    typed-emitter:
-      specifier: ^2.1.0
-      version: 2.1.0
     undici:
       specifier: ^8.9.0
       version: 8.9.0
@@ -1227,9 +1221,6 @@ importers:
       type-fest:
         specifier: 'catalog:'
         version: 5.6.0
-      typed-emitter:
-        specifier: 'catalog:'
-        version: 2.1.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1357,9 +1348,6 @@ importers:
       type-fest:
         specifier: catalog:extensions
         version: 5.6.0
-      typed-emitter:
-        specifier: catalog:extensions
-        version: 2.1.0
       undici:
         specifier: catalog:extensions
         version: 8.9.0
@@ -2508,9 +2496,6 @@ importers:
       type-fest:
         specifier: 'catalog:'
         version: 5.6.0
-      typed-emitter:
-        specifier: 'catalog:'
-        version: 2.1.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@24.12.4)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.2(supports-color@8.1.1))(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.62.0(supports-color@8.1.1))(terser@5.39.0))
@@ -7291,9 +7276,6 @@ packages:
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
-
-  typed-emitter@2.1.0:
-    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
 
   typed-regex@0.0.8:
     resolution: {integrity: sha512-1XkGm1T/rUngbFROIOw9wPnMAKeMsRoc+c9O6GwOHz6aH/FrJFtcyd2sHASbT0OXeGLot5N1shPNpwHGTv9RdQ==}
@@ -12245,10 +12227,6 @@ snapshots:
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
-
-  typed-emitter@2.1.0:
-    optionalDependencies:
-      rxjs: 7.8.2
 
   typed-regex@0.0.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -138,7 +138,6 @@ catalog:
   tcp-port-used: 1.0.3
   tempy: 3.2.0
   triple-beam: 1.4.1
-  typed-emitter: 2.1.0
   typed-regex: 0.0.8
   typescript-plugin-css-modules: 5.2.0
   undici: 8.9.0
@@ -178,7 +177,6 @@ catalogs:
     react-window: ^2.3.0
     rfc6902: ^5.2.0
     type-fest: ^5.6.0
-    typed-emitter: ^2.1.0
     undici: ^8.9.0
 
 allowBuilds:


### PR DESCRIPTION
<!-- markdownlint-disable -->
Part of #2360 (second item of task list A1).

**Description of changes:**

- Add a `TypedEventEmitter` interface to `@freelensapp/utilities` and use it at all six `typed-emitter` sites.
- Drop `typed-emitter` from `packages/core`, `packages/extensions`, `packages/utility-features/run-many`, both catalogs, `knip.jsonc` and the lockfile.

`typed-emitter` was last released in 2022-01 and contains nothing but declarations. It still sat in `catalogs.extensions`, so every extension author had to resolve an abandoned package in order to compile against the API — it leaks through `common/catalog/catalog-entity.ts` into `Common.Catalog`.

This takes `catalogs.extensions` from 21 entries to 20.

**The replacement**

The new interface reproduces the package's full method surface rather than only the methods used today, so the change is a substitution and not a narrowing. That includes the deliberately wide `eventNames(): (keyof Events | string | symbol)[]`, which is what keeps the type compatible with `EventEmitter.eventNames()` — upstream carried a comment about this and the reason still applies.

Two of the six sites do more than annotate a variable, and both keep working unchanged:

- `renderer/api/websocket-api.ts` casts through a generic construct signature, `EventEmitter as { new <T extends WebSocketEvents>(): TypedEventEmitter<T> }`
- `common/catalog/catalog-entity.ts` uses it as a base class, `extends (EventEmitter as new () => TypedEventEmitter<CatalogCategoryEvents>)`

`common/fs/watch/watch.injectable.ts` is the third notable one: `Watcher<AlwaysStat>` extends the interface with a conditional type argument, which still satisfies the `EventMap` constraint.

`@freelensapp/run-many` already depended on `@freelensapp/utilities`, so no new package dependency was introduced anywhere.

**Validation**

- `pnpm type:check` — clean, first try, including the three sites above
- `biome check` on the nine touched files — clean
- `trunk check` on the changed config files — clean
- `@freelensapp/run-many` unit tests — 40 passed

`pnpm knip:check` was run but is not usable as evidence on a working tree: it runs with `--no-gitignore`, and a local checkout that has been built carries `packages/extensions/dist-types/` and `freelens/static/build/`, which account for every one of its findings. Worth noting that `typed-emitter` appears nowhere in its output. CI runs on a clean checkout, so the knip job there is the real check.
