### PR TITLE
Narrow SliderProps so @mui/material leaves the extension API

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -118,7 +118,6 @@
         // extension projects resolve these packages for types through
         // @freelensapp/extensions, so they must stay declared even though no
         // runtime code in this package imports them
-        "@mui/material",
         "@ogre-tools/injectable",
         "@ogre-tools/injectable-react",
         "@types/react",

--- a/packages/core/src/renderer/components/slider/slider.tsx
+++ b/packages/core/src/renderer/components/slider/slider.tsx
@@ -5,7 +5,7 @@
  */
 
 // Wrapper for <Slider/> component
-// API docs: https://material-ui.com/lab/api/slider/
+// API docs: https://mui.com/material-ui/api/slider/
 import "./slider.scss";
 
 import assert from "node:assert";
@@ -13,11 +13,54 @@ import { cssNames } from "@freelensapp/utilities";
 import MaterialSlider from "@mui/material/Slider";
 import { Component } from "react";
 
-import type { SliderProps as MaterialSliderProps, SliderClassKey } from "@mui/material/Slider";
+import type { SyntheticEvent } from "react";
 
-export interface SliderProps extends Omit<MaterialSliderProps, "onChange"> {
+/**
+ * The props of {@link Slider}.
+ *
+ * These are written out by hand instead of being derived from the props of the
+ * underlying `@mui/material` slider, because this component is part of the
+ * published extension API and deriving them would force every extension author
+ * to resolve `@mui/material` in order to compile against it.
+ *
+ * The surface is deliberately limited to the single-value slider: `value` is a
+ * `number` and never a range.
+ */
+export interface SliderProps {
   className?: string;
+
+  /** @default 0 */
+  min?: number;
+
+  /** @default 100 */
+  max?: number;
+
+  /** @default 1 */
+  step?: number;
+
+  value?: number;
+
+  disabled?: boolean;
+
+  /** @default "horizontal" */
+  orientation?: "horizontal" | "vertical";
+
+  /**
+   * Whether the value is shown in a label above the thumb.
+   *
+   * @default "off"
+   */
+  valueLabelDisplay?: "auto" | "on" | "off";
+
+  /**
+   * Called continuously while the thumb is being dragged.
+   */
   onChange(evt: Event, value: number): void;
+
+  /**
+   * Called once the thumb is released, or after a click on the track.
+   */
+  onChangeCommitted?(evt: Event | SyntheticEvent, value: number): void;
 }
 
 const defaultProps: Partial<SliderProps> = {
@@ -29,7 +72,7 @@ const defaultProps: Partial<SliderProps> = {
 export class Slider extends Component<SliderProps> {
   static defaultProps = defaultProps as object;
 
-  private classNames: Partial<{ [P in SliderClassKey]: string }> = {
+  private classNames = {
     track: "track",
     thumb: "thumb",
     disabled: "disabled",
@@ -37,7 +80,7 @@ export class Slider extends Component<SliderProps> {
   };
 
   render() {
-    const { className, onChange, ...sliderProps } = this.props;
+    const { className, onChange, onChangeCommitted, ...sliderProps } = this.props;
 
     return (
       <MaterialSlider
@@ -46,6 +89,13 @@ export class Slider extends Component<SliderProps> {
           assert(!Array.isArray(value));
           onChange?.(event, value);
         }}
+        onChangeCommitted={
+          onChangeCommitted &&
+          ((event, value) => {
+            assert(!Array.isArray(value));
+            onChangeCommitted(event, value);
+          })
+        }
         classes={{
           root: cssNames("Slider", className),
           ...this.classNames,

--- a/packages/core/src/renderer/components/workloads-replication-controllers/replication-controller-details.tsx
+++ b/packages/core/src/renderer/components/workloads-replication-controllers/replication-controller-details.tsx
@@ -82,7 +82,7 @@ class NonInjectedReplicationControllerDetails<
               disabled={this.sliderReplicasDisabled}
               value={this.sliderReplicasValue}
               onChange={(evt, value) => (this.sliderReplicasValue = value)}
-              onChangeCommitted={(event, value) => this.onScaleSliderChangeCommitted(event, value as number)}
+              onChangeCommitted={(event, value) => this.onScaleSliderChangeCommitted(event, value)}
             />
           </div>
         </DrawerItem>

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -32,7 +32,6 @@
     "prepack": "pnpm build:dist"
   },
   "dependencies": {
-    "@mui/material": "catalog:extensions",
     "@ogre-tools/injectable": "catalog:extensions",
     "@ogre-tools/injectable-react": "catalog:extensions",
     "@types/node": "catalog:extensions",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,9 +400,6 @@ catalogs:
       specifier: 4.4.3
       version: 4.4.3
   extensions:
-    '@mui/material':
-      specifier: ^9.2.0
-      version: 9.2.0
     '@ogre-tools/injectable':
       specifier: ^23.2.0
       version: 23.2.0
@@ -1288,9 +1285,6 @@ importers:
 
   packages/extensions:
     dependencies:
-      '@mui/material':
-        specifier: catalog:extensions
-        version: 9.2.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@8.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.8)(supports-color@8.1.1))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@ogre-tools/injectable':
         specifier: catalog:extensions
         version: 23.2.0(@ogre-tools/fp@23.2.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -158,7 +158,6 @@ catalogs:
   # relies on. Versions here intentionally duplicate the default catalog and
   # must be kept in sync with it.
   extensions:
-    '@mui/material': ^9.2.0
     '@ogre-tools/injectable': ^23.2.0
     '@ogre-tools/injectable-react': ^23.2.0
     '@types/node': ~24.12.4


### PR DESCRIPTION
<!-- markdownlint-disable -->
Part of #2360 (third item of task list A1).

**Description of changes:**

- Write `SliderProps` out by hand instead of deriving it from `@mui/material`'s own slider props.
- Drop `@mui/material` from `packages/extensions`, `catalogs.extensions` and `knip.jsonc`.

`SliderProps extends Omit<MaterialSliderProps, "onChange">` was the sole reason `@mui/material` sat in `catalogs.extensions`. `Slider` is re-exported through `Renderer.Component`, so that one `extends` clause made every extension author resolve MUI in order to compile against the API.

This takes `catalogs.extensions` from 20 entries to 19.

**MUI is not going away, only leaving the public contract**

It stays a runtime dependency of `@freelensapp/core` — the wrapper still renders `MaterialSlider`. The other three MUI usages in core are value imports that no API file re-exports, which I checked rather than assumed:

- `renderer/mui-base-theme.tsx` is imported only by `theme-provider-react-application-hoc.injectable.tsx` and one test
- `components/helm-charts/helm-chart-details.tsx` (`styled`, `Tooltip`)
- `components/catalog/catalog-add-button.tsx` (`SpeedDial`, `SpeedDialAction`)

**The narrowed surface**

Deliberately limited to the single-value slider — `value` is a `number`, never a range — and covers what the four call sites in this repository use: `className`, `min`, `max`, `step`, `value`, `disabled`, `orientation`, `valueLabelDisplay`, `onChange`, `onChangeCommitted`. Extensions using a prop outside that set will need it added; this rides the already-breaking `@freelensapp/extensions` major in #2301 and should be mentioned in the migration guide.

`onChangeCommitted` is now wrapped with the same `assert(!Array.isArray(value))` that `onChange` already had. Without that, narrowing MUI's `number | number[]` to `number` would only compile because method-style declarations are bivariant — the wrapper makes it hold structurally instead. It also lets the `value as number` cast at the replication controller call site go.

`SliderClassKey` was the second MUI type import; the `classes` object is now inferred and still checked against MUI's type at the call site.

**Validation**

- `pnpm type:check` — clean
- `biome check` on both touched files — clean
- `trunk check` on the changed config files — clean
- `extensions/__tests__/extension-api.test.ts` — 43 passed (it asserts `Renderer.Component.Slider` is exported)

As in #2387, `pnpm knip:check` is not usable locally: it runs with `--no-gitignore` and a built checkout carries `packages/extensions/dist-types/` and `freelens/static/build/`, which produce all of its findings. The knip job in CI runs on a clean checkout.
