### PR TITLE
Replace winston-transport-browserconsole with an in-house transport

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -144,7 +144,6 @@
     "uuid": "catalog:",
     "winston": "catalog:",
     "winston-transport": "catalog:",
-    "winston-transport-browserconsole": "catalog:",
     "ws": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/core/src/renderer/logger/browser-console-transport.test.ts
+++ b/packages/core/src/renderer/logger/browser-console-transport.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { createLogger, format } from "winston";
+import { BrowserConsoleTransport } from "./browser-console-transport";
+
+import type { MockInstance } from "vitest";
+import type { Logger } from "winston";
+
+describe("BrowserConsoleTransport", () => {
+  let logger: Logger;
+  let consoleMethods: Record<"debug" | "error" | "info" | "warn", MockInstance>;
+
+  beforeEach(() => {
+    consoleMethods = {
+      debug: vi.spyOn(console, "debug").mockImplementation(() => {}),
+      error: vi.spyOn(console, "error").mockImplementation(() => {}),
+      info: vi.spyOn(console, "info").mockImplementation(() => {}),
+      warn: vi.spyOn(console, "warn").mockImplementation(() => {}),
+    };
+
+    // The same format the application's winston logger is created with, so
+    // that the entries reaching the transport are shaped the same way
+    logger = createLogger({
+      level: "silly",
+      format: format.combine(format.splat(), format.simple(), format.timestamp({ format: "DD/MM/YYYY HH:mm:ss" })),
+      transports: [new BrowserConsoleTransport()],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes a message with no metadata as just the message", () => {
+    logger.info("plain message");
+
+    expect(consoleMethods.info).toHaveBeenCalledWith("plain message");
+  });
+
+  it("passes a single metadata argument through unchanged", () => {
+    const meta = { filePath: "/tmp/kubeconfig" };
+
+    logger.warn("something happened", meta);
+
+    expect(consoleMethods.warn).toHaveBeenCalledWith("something happened", meta);
+  });
+
+  it("keeps an Error inspectable rather than flattening it", () => {
+    const error = new Error("boom");
+
+    logger.error("request failed", error);
+
+    // winston appends the error's own message to the message string; what
+    // matters here is that the second argument is still the Error itself and
+    // not a plain object built out of its fields
+    expect(consoleMethods.error).toHaveBeenCalledWith("request failed boom", error);
+  });
+
+  it("reports the metadata of an entry logged with several arguments", () => {
+    // winston's splat format moves two or more arguments onto the entry itself,
+    // leaving nothing behind under the splat symbol. The previous transport,
+    // winston-transport-browserconsole, printed an empty array here.
+    logger.error("scaling failed", { replicas: 3 }, { namespace: "default" });
+
+    expect(consoleMethods.error).toHaveBeenCalledWith("scaling failed", { replicas: 3, namespace: "default" });
+  });
+
+  it("interpolates placeholders into the message", () => {
+    logger.info("connected to %s", "cluster-a");
+
+    expect(consoleMethods.info).toHaveBeenCalledWith("connected to cluster-a", "cluster-a");
+  });
+
+  it.each([
+    ["error", "error"],
+    ["warn", "warn"],
+    ["info", "info"],
+    ["debug", "debug"],
+    ["verbose", "debug"],
+    ["silly", "debug"],
+  ] as const)("maps the %s level onto console.%s", (level, method) => {
+    logger.log(level, "a message");
+
+    expect(consoleMethods[method]).toHaveBeenCalledWith("a message");
+  });
+});

--- a/packages/core/src/renderer/logger/browser-console-transport.ts
+++ b/packages/core/src/renderer/logger/browser-console-transport.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { setImmediate } from "node:timers";
+import TransportStream from "winston-transport";
+
+import type { LogEntry } from "winston";
+
+/**
+ * The symbol under which winston keeps the arguments that followed the message.
+ *
+ * This is the same symbol as `triple-beam`'s `SPLAT`, spelled out so that the
+ * renderer does not have to import a CommonJS package for one well-known
+ * symbol.
+ */
+const SPLAT = Symbol.for("splat");
+
+/**
+ * Fields that winston puts on every entry, and which the printed message
+ * already accounts for.
+ */
+const builtinFields = new Set(["level", "message", "timestamp"]);
+
+const consoleMethodFor = (level: string): "debug" | "error" | "info" | "warn" => {
+  switch (level) {
+    case "error":
+      return "error";
+    case "warn":
+      return "warn";
+    case "debug":
+    case "verbose":
+    case "silly":
+      return "debug";
+    default:
+      return "info";
+  }
+};
+
+/**
+ * The metadata to show next to the message.
+ *
+ * `format.splat()` leaves a single trailing argument in place, but moves two or
+ * more of them onto the entry itself as own properties. Prefer the former,
+ * because it preserves object identity and so keeps an `Error` inspectable in
+ * the devtools console; fall back to the latter, which is the only place the
+ * data exists in the multiple-argument case.
+ */
+const metadataOf = (entry: LogEntry): unknown[] => {
+  const splat = (entry as unknown as Record<symbol, unknown>)[SPLAT];
+
+  if (Array.isArray(splat) && splat.length > 0) {
+    return splat;
+  }
+
+  const fields = Object.entries(entry).filter(([field]) => !builtinFields.has(field));
+
+  return fields.length > 0 ? [Object.fromEntries(fields)] : [];
+};
+
+/**
+ * Writes log entries to the browser console, mapping the winston level onto the
+ * matching `console` method so that the devtools level filter works.
+ *
+ * Replaces `winston-transport-browserconsole`, which was last released in
+ * 2020-03, is CommonJS-only -- which needed an interop workaround in the
+ * renderer bundle -- and dropped the metadata of any entry logged with more
+ * than one argument.
+ */
+export class BrowserConsoleTransport extends TransportStream {
+  name = "browser-console-transport";
+
+  log(entry: LogEntry, next: () => void) {
+    setImmediate(() => {
+      this.emit("logged", entry);
+    });
+
+    console[consoleMethodFor(entry.level)](entry.message, ...metadataOf(entry));
+
+    next();
+  }
+}

--- a/packages/core/src/renderer/logger/browser-transport.injectable.ts
+++ b/packages/core/src/renderer/logger/browser-transport.injectable.ts
@@ -6,22 +6,11 @@
 
 import { loggerTransportInjectionToken } from "@freelensapp/logger";
 import { getInjectable } from "@ogre-tools/injectable";
-import BrowserConsoleImport from "winston-transport-browserconsole";
-
-// `winston-transport-browserconsole` is a CommonJS module that exports its class
-// via `exports.default` (`{ __esModule: true, default: BrowserConsole }`). Under
-// the Node-mode ESM interop that electron-vite v6 + Vite 8 (rolldown) emit for
-// the renderer, a default import — and even `import { default as ... }` — binds
-// to the whole `module.exports` object, leaving the class one `.default` deeper,
-// so `new BrowserConsole()` throws "BrowserConsole is not a constructor". Unwrap
-// the extra `.default` when present. (ansi_up 6.x avoids this by being native
-// ESM; this transport is CommonJS-only, so the unwrap is unavoidable here.)
-const BrowserConsole = ((BrowserConsoleImport as unknown as { default?: typeof BrowserConsoleImport }).default ??
-  BrowserConsoleImport) as typeof BrowserConsoleImport;
+import { BrowserConsoleTransport } from "./browser-console-transport";
 
 const browserLoggerTransportInjectable = getInjectable({
   id: "browser-logger-transport",
-  instantiate: () => new BrowserConsole(),
+  instantiate: () => new BrowserConsoleTransport(),
   injectionToken: loggerTransportInjectionToken,
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,9 +387,6 @@ catalogs:
     winston-transport:
       specifier: 4.9.0
       version: 4.9.0
-    winston-transport-browserconsole:
-      specifier: 1.0.5
-      version: 1.0.5
     ws:
       specifier: 8.21.0
       version: 8.21.0
@@ -1109,9 +1106,6 @@ importers:
       winston-transport:
         specifier: 'catalog:'
         version: 4.9.0
-      winston-transport-browserconsole:
-        specifier: 'catalog:'
-        version: 1.0.5
       ws:
         specifier: 'catalog:'
         version: 8.21.0
@@ -7512,9 +7506,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  winston-transport-browserconsole@1.0.5:
-    resolution: {integrity: sha512-BFZDvknATAmsqaRY3WatB2S0eEb0ziwqBYIv+H0Fnu9oe7GnPUVQzEJC1frmLdNsfEkfnyR1PCNDBAFtZE3SuQ==}
-
   winston-transport@4.9.0:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
     engines: {node: '>= 12.0.0'}
@@ -12445,11 +12436,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  winston-transport-browserconsole@1.0.5:
-    dependencies:
-      winston: 3.19.0
-      winston-transport: 4.9.0
 
   winston-transport@4.9.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -144,7 +144,6 @@ catalog:
   uuid: 14.0.1
   winston: 3.19.0
   winston-transport: 4.9.0
-  winston-transport-browserconsole: 1.0.5
   ws: 8.21.0
   yauzl-promise: 4.0.0
   zod: 4.4.3


### PR DESCRIPTION
<!-- markdownlint-disable -->
Part of #2360 (first item of task list A2, listed there as the highest priority of the internal removals).

**Description of changes:**

- Add `renderer/logger/browser-console-transport.ts`, a `winston-transport` subclass, and use it from the injectable.
- Drop `winston-transport-browserconsole` from `packages/core`, the catalog and the lockfile, along with the interop workaround it required.
- Add tests, which the old transport had none of.

This is the entry #2360 called a textbook misfit for an ESM-first stack: last released 2020-03, CommonJS-only, and the only dependency in the audit that had *already* forced a workaround. Under the ESM interop electron-vite 6 / Vite 8 emit for the renderer, a default import binds to the whole `module.exports` object and leaves the class one `.default` deeper, so the injectable carried ten lines of comment plus an unwrap to stop `new BrowserConsole()` from throwing. `winston-transport` was already a direct dependency, so the replacement is about forty lines.

**One behaviour change, and it is a bug fix**

I probed the old transport against the application's actual logger format (`combine(splat(), simple(), timestamp())`) rather than reading it, because its metadata handling is not obvious — it indexes the entry's symbols:

```js
var args = logEntry[Object.getOwnPropertySymbols(logEntry)[1]];
args = args.length >= 1 ? args[0] : args;
```

That index lands on `Symbol(splat)`, and it takes only the first element. But when an entry is logged with **two or more** arguments, winston's splat format splices them out of the splat array and merges them onto the entry as own properties. So the read returns `[]`:

| call | old output | new output |
| --- | --- | --- |
| `logger.info("plain message")` | `plain message` | unchanged |
| `logger.warn("msg", { filePath })` | `msg { filePath }` | unchanged |
| `logger.error("msg", err)` | `msg Error: boom` | unchanged |
| `logger.error("msg", { a }, { b })` | **`msg []`** | `msg { a, b }` |
| `logger.info("to %s", "x")` | `to x "x"` | unchanged |

The new transport prefers the splat arguments — which is what keeps an `Error` inspectable in devtools instead of flattening it to `{ stack }` — and falls back to the entry's own extra fields, which is the only place the data exists in the multiple-argument case.

The level map also gains `verbose` and `silly`. Both previously resolved to `console[undefined]`; they only avoided throwing because the logger's level is `info`, so neither ever reached the transport.

`Symbol.for("splat")` is spelled out rather than imported as `SPLAT` from `triple-beam`, since that package is CommonJS too and this is the renderer.

**Validation**

- `pnpm type:check` — clean
- `biome check` on the three touched files — clean
- `trunk check` on the changed config files — clean
- new `browser-console-transport.test.ts` — 11 passed, covering each row of the table above and all six level mappings, driven through a real winston logger configured exactly as the application's is

Not covered by tests: that the renderer bundle no longer needs the interop unwrap. That is the removal of a workaround for a bundler behaviour, so it wants a look at the running dev app rather than a unit test.
