### PR TITLE
Replace typed-regex with plain RegExp and a namedCaptures helper

### DIFF
--- a/freelens/package.json
+++ b/freelens/package.json
@@ -100,7 +100,6 @@
     "tcp-port-used": "catalog:",
     "tempy": "catalog:",
     "triple-beam": "catalog:",
-    "typed-regex": "catalog:",
     "uuid": "catalog:",
     "winston": "catalog:",
     "ws": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -139,7 +139,6 @@
     "tcp-port-used": "catalog:",
     "tempy": "catalog:",
     "triple-beam": "catalog:",
-    "typed-regex": "catalog:",
     "uuid": "catalog:",
     "winston": "catalog:",
     "winston-transport": "catalog:",

--- a/packages/core/src/main/kube-auth-proxy/create-kube-auth-proxy.injectable.ts
+++ b/packages/core/src/main/kube-auth-proxy/create-kube-auth-proxy.injectable.ts
@@ -8,7 +8,6 @@ import assert from "node:assert";
 import { loggerInjectionToken } from "@freelensapp/logger";
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import { observable, when } from "mobx";
-import { TypedRegEx } from "typed-regex";
 import getDirnameOfPathInjectable from "../../common/path/get-dirname.injectable";
 import randomBytesInjectable from "../../common/utils/random-bytes.injectable";
 import clusterApiUrlInjectable from "../../features/cluster/connections/main/api-url.injectable";
@@ -31,10 +30,7 @@ export interface KubeAuthProxy {
 
 export type CreateKubeAuthProxy = (env: NodeJS.ProcessEnv) => KubeAuthProxy;
 
-const startingServeMatcher = "starting to serve on (?<address>.+)";
-const startingServeRegex = Object.assign(TypedRegEx(startingServeMatcher, "i"), {
-  rawMatcher: startingServeMatcher,
-});
+const startingServeRegex = /starting to serve on (?<address>.+)/i;
 
 const createKubeAuthProxyInjectable = getInjectable({
   id: "create-kube-auth-proxy",

--- a/packages/core/src/main/routes/port-forward/functionality/port-forward.ts
+++ b/packages/core/src/main/routes/port-forward/functionality/port-forward.ts
@@ -6,17 +6,13 @@
 
 import { spawn } from "node:child_process";
 import * as tcpPortUsed from "tcp-port-used";
-import { TypedRegEx } from "typed-regex";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
 import type { Logger } from "@freelensapp/logger";
 
 import type { GetPortFromStream } from "../../../utils/get-port-from-stream.injectable";
 
-const internalPortMatcher = "^forwarding from (?<address>.+) ->";
-const internalPortRegex = Object.assign(TypedRegEx(internalPortMatcher, "i"), {
-  rawMatcher: internalPortMatcher,
-});
+const internalPortRegex = /^forwarding from (?<address>.+) ->/i;
 
 export interface PortForwardArgs {
   clusterId: string;

--- a/packages/core/src/main/utils/get-port-from-stream.injectable.ts
+++ b/packages/core/src/main/utils/get-port-from-stream.injectable.ts
@@ -5,6 +5,7 @@
  */
 
 import { loggerInjectionToken } from "@freelensapp/logger";
+import { namedCaptures } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import type { Readable } from "node:stream";
 
@@ -13,16 +14,7 @@ export interface GetPortFromStreamArgs {
    * Should be case insensitive
    * Must have a named matching group called `address`
    */
-  lineRegex: {
-    match: (line: string) => {
-      matched: boolean;
-      groups?: {
-        address?: string;
-      };
-      raw?: RegExpExecArray;
-    };
-    rawMatcher: string;
-  };
+  lineRegex: RegExp;
   /**
    * Called when the port is found
    */
@@ -47,13 +39,13 @@ const getPortFromStreamInjectable = getInjectable({
       return new Promise<number>((resolve, reject) => {
         const handler = (data: unknown) => {
           const logItem = String(data);
-          const match = args.lineRegex.match(logItem);
+          const match = namedCaptures<{ address?: string }>(args.lineRegex, logItem);
 
           logLines.push(logItem);
 
-          if (match.matched) {
+          if (match) {
             // use unknown protocol so that there is no default port
-            const addr = new URL(`s://${match.groups?.address?.trim()}`);
+            const addr = new URL(`s://${match.address?.trim()}`);
 
             args.onFind?.();
             stream.off("data", handler);
@@ -63,7 +55,7 @@ const getPortFromStreamInjectable = getInjectable({
         };
         const timeoutID = setTimeout(() => {
           stream.off("data", handler);
-          logger.warn(`[getPortFrom]: failed to retrieve port via ${args.lineRegex.rawMatcher}`, logLines);
+          logger.warn(`[getPortFrom]: failed to retrieve port via ${args.lineRegex.source}`, logLines);
           reject(new Error("failed to retrieve port from stream"));
         }, args.timeout ?? 15000);
 

--- a/packages/core/src/renderer/components/extensions/install-extension-from-input.injectable.tsx
+++ b/packages/core/src/renderer/components/extensions/install-extension-from-input.injectable.tsx
@@ -67,7 +67,7 @@ const installExtensionFromInputInjectable = getInjectable({
 
           return await attemptInstall({ fileName, data });
         } catch (error) {
-          const extNameCaptures = InputValidators.isExtensionNameInstallRegex.captures(input);
+          const extNameCaptures = InputValidators.extensionNameInstallCaptures(input);
 
           if (extNameCaptures) {
             const { name, version } = extNameCaptures;

--- a/packages/core/src/renderer/components/input/input_validators.ts
+++ b/packages/core/src/renderer/components/input/input_validators.ts
@@ -4,8 +4,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { namedCaptures } from "@freelensapp/utilities";
 import fse from "fs-extra";
-import { TypedRegEx } from "typed-regex";
 
 import type { StrictReactNode } from "@freelensapp/utilities";
 
@@ -187,22 +187,19 @@ export const isUrl = inputValidator({
 });
 
 /**
- * NOTE: this cast is needed because of two bugs in the typed regex package
- * - https://github.com/phenax/typed-regex/issues/6
- * - https://github.com/phenax/typed-regex/issues/7
+ * The pattern is anchored, so the `g` flag it used to carry only made `test`
+ * and `exec` resume from `lastIndex` and answer differently on every other
+ * call.
  */
-export const isExtensionNameInstallRegex = TypedRegEx(
-  "^(?<name>(@[-\\w]+\\/)?[-\\w]+)(@(?<version>[a-z0-9-_.]+))?$",
-  "gi",
-) as {
-  isMatch(val: string): boolean;
-  captures(val: string): undefined | { name: string; version?: string };
-};
+export const isExtensionNameInstallRegex = /^(?<name>(@[-\w]+\/)?[-\w]+)(@(?<version>[a-z0-9-_.]+))?$/i;
+
+export const extensionNameInstallCaptures = (value: string) =>
+  namedCaptures<{ name: string; version?: string }>(isExtensionNameInstallRegex, value);
 
 export const isExtensionNameInstall = inputValidator({
   condition: ({ type }) => type === "text",
   message: () => "Not an extension name with optional version",
-  validate: (value) => isExtensionNameInstallRegex.isMatch(value),
+  validate: (value) => isExtensionNameInstallRegex.test(value),
 });
 
 export const isPath = asyncInputValidator({

--- a/packages/kube-object/package.json
+++ b/packages/kube-object/package.json
@@ -26,8 +26,7 @@
   "dependencies": {
     "@freelensapp/utilities": "workspace:^",
     "auto-bind": "catalog:",
-    "es-toolkit": "catalog:",
-    "typed-regex": "catalog:"
+    "es-toolkit": "catalog:"
   },
   "devDependencies": {
     "@freelensapp/typescript": "workspace:^",

--- a/packages/kube-object/src/specifics/node.ts
+++ b/packages/kube-object/src/specifics/node.ts
@@ -4,8 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { cpuUnitsToNumber, isObject, unitsToBytes } from "@freelensapp/utilities";
-import { TypedRegEx } from "typed-regex";
+import { cpuUnitsToNumber, isObject, namedCaptures, unitsToBytes } from "@freelensapp/utilities";
 import { KubeObject } from "../kube-object";
 
 import type { BaseKubeObjectCondition, ClusterScopedMetadata } from "../api-types";
@@ -44,7 +43,7 @@ const masterNodeLabels = ["master", "control-plane"];
  * This regex is used in the `getRoleLabels()` method bellow, but placed here
  * as factoring out regexes is best practice.
  */
-const nodeRoleLabelKeyMatcher = TypedRegEx("^.*node-role.kubernetes.io/+(?<role>.+)$");
+const nodeRoleLabelKeyMatcher = /^.*node-role.kubernetes.io\/+(?<role>.+)$/;
 
 export interface NodeSpec {
   podCIDR?: string;
@@ -175,10 +174,10 @@ export class Node extends KubeObject<ClusterScopedMetadata, NodeStatus, NodeSpec
     }
 
     for (const labelKey of Object.keys(labels)) {
-      const match = nodeRoleLabelKeyMatcher.match(labelKey);
+      const match = namedCaptures<{ role: string }>(nodeRoleLabelKeyMatcher, labelKey);
 
-      if (match?.groups) {
-        roleLabels.push(match.groups.role);
+      if (match) {
+        roleLabels.push(match.role);
       }
     }
 

--- a/packages/kubectl-versions/build/compute-versions.mts
+++ b/packages/kubectl-versions/build/compute-versions.mts
@@ -4,14 +4,13 @@ import { XMLParser } from "fast-xml-parser";
 import { writeFile } from "fs/promises";
 import { fetch } from "undici";
 import semver from "semver";
-import { TypedRegEx } from "typed-regex";
 
 const { SemVer } = semver;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const expectedResponseForm = TypedRegEx("v(?<version>\\d+\\.\\d+\\.\\d+)");
+const expectedResponseForm = /v(?<version>\d+\.\d+\.\d+)/;
 
 /**
  * Oldest minor the map may name, matching `MIN_SUPPORTED_MINOR` in
@@ -43,7 +42,7 @@ async function requestGreatestKubectlPatchVersion(majorMinor: string): Promise<s
   }
 
   const body = await response.text();
-  const match = expectedResponseForm.captures(body);
+  const match = expectedResponseForm.exec(body)?.groups as { version: string } | undefined;
 
   if (!match) {
     throw new Error(`failed to get stable version for ${majorMinor}: unexpected response shape. body="${body}"`);

--- a/packages/kubectl-versions/package.json
+++ b/packages/kubectl-versions/package.json
@@ -31,7 +31,6 @@
     "@types/semver": "catalog:",
     "fast-xml-parser": "catalog:",
     "semver": "catalog:",
-    "typed-regex": "catalog:",
     "typescript": "catalog:",
     "undici": "catalog:"
   },

--- a/packages/utility-features/utilities/index.ts
+++ b/packages/utility-features/utilities/index.ts
@@ -26,6 +26,7 @@ export * from "./src/jsonPath";
 export * from "./src/lowerAndPluralize";
 export * from "./src/metricUnitsToNumber";
 export * from "./src/name-parts";
+export * from "./src/named-captures";
 export * from "./src/noop";
 export * from "./src/object";
 export * from "./src/observable-crate";

--- a/packages/utility-features/utilities/package.json
+++ b/packages/utility-features/utilities/package.json
@@ -30,8 +30,7 @@
     "p-limit": "catalog:",
     "react": "catalog:",
     "semver": "catalog:",
-    "tar": "catalog:",
-    "typed-regex": "catalog:"
+    "tar": "catalog:"
   },
   "devDependencies": {
     "@freelensapp/typescript": "workspace:^",

--- a/packages/utility-features/utilities/src/convertCpu.ts
+++ b/packages/utility-features/utilities/src/convertCpu.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { TypedRegEx } from "typed-regex";
+import { namedCaptures } from "./named-captures";
 
 // Helper to convert CPU K8S units to numbers
 
@@ -21,10 +21,11 @@ const unitConverters = new Map([
   ["E", 1000 ** 6],
 ]);
 
-const cpuUnitsRegex = TypedRegEx("^(?<digits>[+-]?[0-9.]+(e[-+]?[0-9]+)?)(?<unit>[EinumkKMGTP]*)$");
+const cpuUnitsRegex = /^(?<digits>[+-]?[0-9.]+(e[-+]?[0-9]+)?)(?<unit>[EinumkKMGTP]*)$/;
 
 export function cpuUnitsToNumber(value: string) {
-  const match = cpuUnitsRegex.captures(value);
+  // `unit` matches the empty string, so it always participates in a match
+  const match = namedCaptures<{ digits?: string; unit: string }>(cpuUnitsRegex, value);
 
   if (!match) {
     return undefined;

--- a/packages/utility-features/utilities/src/jsonPath.ts
+++ b/packages/utility-features/utilities/src/jsonPath.ts
@@ -5,13 +5,13 @@
  */
 
 import { JSONPath } from "@astronautlabs/jsonpath";
-import { TypedRegEx } from "typed-regex";
+import { namedCaptures } from "./named-captures";
 
 const slashDashSearch = /[/\\-]/g;
 const pathByBareDots = /(?<=\w)\./;
 const textBeforeFirstSquare = /^.*(?=\[)/g;
 const backSlash = /\\/g;
-const kubectlOptionPrefix = TypedRegEx("^\\$?\\.?(?<pathExpression>.*)");
+const kubectlOptionPrefix = /^\$?\.?(?<pathExpression>.*)/;
 const sliceVersion = /\[]/g;
 const tripleDotName = /\.\.\.(?<trailing>.)/g;
 const trailingDotDot = /\.\.$/;
@@ -31,7 +31,9 @@ const trailingDotDot = /\.\.$/;
  * - Allow `...foo` as well as `..foo`
  */
 export function convertKubectlJsonPathToNodeJsonPath(jsonPath: string) {
-  const captures = kubectlOptionPrefix.captures(jsonPath);
+  // Every part of the pattern is optional, so it matches anything and
+  // `pathExpression` always participates
+  const captures = namedCaptures<{ pathExpression: string }>(kubectlOptionPrefix, jsonPath);
   let start = "$";
 
   if (!captures) {

--- a/packages/utility-features/utilities/src/named-captures.test.ts
+++ b/packages/utility-features/utilities/src/named-captures.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { namedCaptures } from "./named-captures";
+
+describe("namedCaptures", () => {
+  it("returns the named groups of a match", () => {
+    expect(namedCaptures(/^(?<key>\w+)=(?<value>\w+)$/, "answer=42")).toEqual({ key: "answer", value: "42" });
+  });
+
+  it("returns undefined when there is no match", () => {
+    expect(namedCaptures(/^(?<key>\w+)=(?<value>\w+)$/, "nope")).toBeUndefined();
+  });
+
+  it("leaves a group that did not participate undefined", () => {
+    expect(namedCaptures(/^(?<name>[-\w]+)(@(?<version>\d+))?$/, "some-extension")).toEqual({
+      name: "some-extension",
+      version: undefined,
+    });
+  });
+
+  it("answers the same way every time for a global regex", () => {
+    // A regex kept at module scope is shared between calls, and `exec` on a
+    // global one resumes from `lastIndex`. Without a reset the second call
+    // here returns undefined.
+    const global = /(?<word>\w+)/g;
+
+    expect(namedCaptures(global, "hello")).toEqual({ word: "hello" });
+    expect(namedCaptures(global, "hello")).toEqual({ word: "hello" });
+    expect(namedCaptures(global, "hello")).toEqual({ word: "hello" });
+  });
+
+  it("answers the same way every time for a sticky regex", () => {
+    const sticky = /(?<word>\w+)/y;
+
+    expect(namedCaptures(sticky, "hello")).toEqual({ word: "hello" });
+    expect(namedCaptures(sticky, "hello")).toEqual({ word: "hello" });
+  });
+});

--- a/packages/utility-features/utilities/src/named-captures.ts
+++ b/packages/utility-features/utilities/src/named-captures.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+/**
+ * The named capture groups of the first match of `regex` in `value`, or
+ * `undefined` when there is no match.
+ *
+ * `Groups` is the caller's claim about which groups the pattern has and which
+ * of them always participate in a match; nothing verifies it against the
+ * pattern, so keep the two next to each other.
+ *
+ * Replaces the `captures()` of the `typed-regex` package, which was last
+ * released in 2021-06.
+ */
+export const namedCaptures = <Groups extends Record<string, string | undefined>>(
+  regex: RegExp,
+  value: string,
+): Groups | undefined => {
+  // `exec` continues from `lastIndex` on a global or sticky regex, which makes
+  // repeated calls against the same regex answer differently. No caller wants
+  // that, and a shared module-level regex makes it a trap.
+  regex.lastIndex = 0;
+
+  return regex.exec(value)?.groups as Groups | undefined;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,9 +348,6 @@ catalogs:
     type-fest:
       specifier: 5.6.0
       version: 5.6.0
-    typed-regex:
-      specifier: 0.0.8
-      version: 0.0.8
     typescript:
       specifier: 7.0.2
       version: 7.0.2
@@ -604,9 +601,6 @@ importers:
       triple-beam:
         specifier: 'catalog:'
         version: 1.4.1
-      typed-regex:
-        specifier: 'catalog:'
-        version: 0.0.8
       undici:
         specifier: 'catalog:'
         version: 8.9.0
@@ -1079,9 +1073,6 @@ importers:
       triple-beam:
         specifier: 'catalog:'
         version: 1.4.1
-      typed-regex:
-        specifier: 'catalog:'
-        version: 0.0.8
       undici:
         specifier: 'catalog:'
         version: 8.9.0
@@ -1402,9 +1393,6 @@ importers:
       es-toolkit:
         specifier: 'catalog:'
         version: 1.49.0
-      typed-regex:
-        specifier: 'catalog:'
-        version: 0.0.8
     devDependencies:
       '@freelensapp/typescript':
         specifier: workspace:^
@@ -1436,9 +1424,6 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.8.5
-      typed-regex:
-        specifier: 'catalog:'
-        version: 0.0.8
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -2548,9 +2533,6 @@ importers:
       tar:
         specifier: 'catalog:'
         version: 7.5.21
-      typed-regex:
-        specifier: 'catalog:'
-        version: 0.0.8
     devDependencies:
       '@freelensapp/typescript':
         specifier: workspace:^
@@ -7242,9 +7224,6 @@ packages:
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
-
-  typed-regex@0.0.8:
-    resolution: {integrity: sha512-1XkGm1T/rUngbFROIOw9wPnMAKeMsRoc+c9O6GwOHz6aH/FrJFtcyd2sHASbT0OXeGLot5N1shPNpwHGTv9RdQ==}
 
   typescript-plugin-css-modules@5.2.0:
     resolution: {integrity: sha512-c5pAU5d+m3GciDr/WhkFldz1NIEGBafuP/3xhFt9BEXS2gmn/LvjkoZ11vEBIuP8LkXfPNhOt1BUhM5efFuwOw==}
@@ -12184,8 +12163,6 @@ snapshots:
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
-
-  typed-regex@0.0.8: {}
 
   typescript-plugin-css-modules@5.2.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.12.4)(typescript@7.0.2))(typescript@7.0.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -136,7 +136,6 @@ catalog:
   tcp-port-used: 1.0.3
   tempy: 3.2.0
   triple-beam: 1.4.1
-  typed-regex: 0.0.8
   typescript-plugin-css-modules: 5.2.0
   undici: 8.9.0
   uuid: 14.0.1


### PR DESCRIPTION
<!-- markdownlint-disable -->
Part of #2360 (fourth item of task list A2).

**Description of changes:**

- Add `namedCaptures(regex, value)` to `@freelensapp/utilities` and convert all seven `typed-regex` sites to plain `RegExp`.
- Drop `typed-regex` from `packages/core`, `freelens`, `packages/kube-object`, `packages/utility-features/utilities`, `packages/kubectl-versions`, the catalog and the lockfile.

`typed-regex` 0.0.8 was last released in 2021-06. Every usage was "a regex with named groups plus a typed `.captures()`", which is `RegExp.exec(...)?.groups` and a cast. The issue counted six sites; there are seven — `packages/kubectl-versions/build/compute-versions.mts` is the one the audit missed.

**The `lastIndex` reset is the point, not a detail**

These regexes live at module scope and are shared across calls. `exec` on a global or sticky regex resumes from `lastIndex`, so the same input answers differently every other time. `namedCaptures` resets it first.

`isExtensionNameInstallRegex` was exactly that trap: `gi` flags on an anchored `^…$` pattern, plus a cast whose comment pointed at two unfixed upstream bugs, phenax/typed-regex#6 and #7. The `g` is dropped along with the cast, and there is a regression test that the same input answers the same way three calls running.

**Two small shape changes this forced**

- `isExtensionNameInstallRegex.captures()` had one caller. A bare `RegExp` has no such method, so that goes through a new exported `extensionNameInstallCaptures`.
- `GetPortFromStreamArgs.lineRegex` is now a plain `RegExp`. It used to demand the typed-regex `.match()` shape *and* a `rawMatcher` string for the timeout log, which both call sites assembled with `Object.assign(TypedRegEx(...), { rawMatcher })`. `RegExp` already has `.source`, so both call sites collapse to a literal.

Patterns are translated verbatim, including the unescaped dots in `^.*node-role.kubernetes.io/+(?<role>.+)$` — they match any character today and still do, and tightening them is a separate question from removing a dependency.

**Validation**

- `pnpm type:check` — clean
- `biome check` on all touched TS files, `trunk check` on the `.mts` and the manifests — clean
- `@freelensapp/utilities` — 257 passed, including 5 new for `namedCaptures`
- `@freelensapp/kube-object` — 374 passed
- core, for the four touched areas (`main/utils`, `main/kube-auth-proxy`, `main/routes/port-forward`, `renderer/components/{input,extensions}`) — 63 passed

Not covered by tests: the port-matching path end to end, since `getPortFromStream` is exercised through mocks rather than a real `freelens-k8s-proxy` or `kubectl port-forward` process. Both regexes match the same strings as before, but that is the one behaviour here worth seeing in the running app.
