### PR TITLE
Vendor the used history surface into @freelensapp/routing

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -126,7 +126,6 @@
         "@xterm/xterm",
         "chart.js",
         "conf",
-        "history",
         "immer",
         "mobx",
         "monaco-editor",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -111,7 +111,6 @@
     "es-toolkit": "catalog:",
     "fs-extra": "catalog:",
     "handlebars": "catalog:",
-    "history": "catalog:",
     "http-proxy-node16": "catalog:",
     "immer": "catalog:",
     "joi": "catalog:",

--- a/packages/core/src/features/preferences/closing-preferences.test.tsx
+++ b/packages/core/src/features/preferences/closing-preferences.test.tsx
@@ -4,9 +4,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { createObservableHistory, observableHistoryInjectionToken, searchParamsOptions } from "@freelensapp/routing";
+import {
+  createMemoryHistory,
+  createObservableHistory,
+  observableHistoryInjectionToken,
+  searchParamsOptions,
+} from "@freelensapp/routing";
 import { getInjectable } from "@ogre-tools/injectable";
-import { createMemoryHistory } from "history";
 import { computed, runInAction } from "mobx";
 import { frontEndRouteInjectionToken } from "../../common/front-end-routing/front-end-route-injection-token";
 import navigateToFrontPageInjectable from "../../common/front-end-routing/navigate-to-front-page.injectable";

--- a/packages/core/src/renderer/components/drawer/drawer.tsx
+++ b/packages/core/src/renderer/components/drawer/drawer.tsx
@@ -18,9 +18,8 @@ import { createPortal } from "react-dom";
 import drawerStorageInjectable, { defaultDrawerWidth } from "./drawer-storage/drawer-storage.injectable";
 
 import type { AnimateName } from "@freelensapp/animate";
+import type { History } from "@freelensapp/routing";
 import type { StrictReactNode } from "@freelensapp/utilities";
-
-import type { History } from "history";
 
 import type { StorageLayer } from "../../utils/storage-helper";
 

--- a/packages/core/src/renderer/ipc/index.ts
+++ b/packages/core/src/renderer/ipc/index.ts
@@ -16,7 +16,7 @@ import { toJS } from "../../common/utils";
 import { getDiForExtensionApi } from "../../extensions/extension-api-di";
 import ipcRendererInjectable from "../utils/channel/ipc-renderer.injectable";
 
-import type { Location } from "history";
+import type { Location } from "@freelensapp/routing";
 
 import type { ClusterId, ClusterState } from "../../common/cluster-types";
 import type { InstalledExtension, LensExtensionId } from "../../extensions/installed-extension";

--- a/packages/core/src/renderer/navigation/history.global-override-for-injectable.ts
+++ b/packages/core/src/renderer/navigation/history.global-override-for-injectable.ts
@@ -4,8 +4,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { historyInjectionToken } from "@freelensapp/routing";
+import { createMemoryHistory, historyInjectionToken } from "@freelensapp/routing";
 import { getGlobalOverride } from "@freelensapp/test-utils";
-import { createMemoryHistory } from "history";
 
 export default getGlobalOverride(historyInjectionToken, () => createMemoryHistory());

--- a/packages/core/src/renderer/navigation/navigate.injectable.ts
+++ b/packages/core/src/renderer/navigation/navigate.injectable.ts
@@ -4,12 +4,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { observableHistoryInjectionToken } from "@freelensapp/routing";
+import { createPath, observableHistoryInjectionToken } from "@freelensapp/routing";
 import { getInjectable } from "@ogre-tools/injectable";
-import { createPath } from "history";
 import { action } from "mobx";
 
-import type { To } from "history";
+import type { To } from "@freelensapp/routing";
 
 export type Navigate = (location: To) => void;
 

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -40,7 +40,6 @@
     "@xterm/xterm": "catalog:extensions",
     "chart.js": "catalog:extensions",
     "conf": "catalog:extensions",
-    "history": "catalog:extensions",
     "immer": "catalog:extensions",
     "mobx": "catalog:extensions",
     "monaco-editor": "catalog:extensions",

--- a/packages/routing/index.ts
+++ b/packages/routing/index.ts
@@ -14,9 +14,29 @@ export { observableHistoryInjectionToken } from "./src/observable-history.inject
 export { ObservableSearchParams } from "./src/observable-search-params";
 export { Redirect, Route, Switch } from "./src/route";
 export { searchParamsOptions } from "./src/search-params";
+export { Action, createBrowserHistory, createMemoryHistory, createPath, parsePath } from "./src/vendor/history";
 
 export type { LinkProps, NavLinkProps } from "./src/link";
 export type { Match, MatchPathOptions } from "./src/match-path";
 export type { HistoryAdapter, ObservableHistoryOptions } from "./src/observable-history";
 export type { ObservableSearchParamsOptions, SearchParamsInit } from "./src/observable-search-params";
 export type { RedirectProps, RouteComponentProps, RouteProps, SwitchProps } from "./src/route";
+export type {
+  BrowserHistory,
+  BrowserHistoryOptions,
+  Hash,
+  History,
+  InitialEntry,
+  Key,
+  Listener,
+  Location,
+  MemoryHistory,
+  MemoryHistoryOptions,
+  PartialLocation,
+  PartialPath,
+  Path,
+  Pathname,
+  Search,
+  To,
+  Update,
+} from "./src/vendor/history";

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -25,7 +25,6 @@
     "@ogre-tools/fp": "catalog:",
     "@ogre-tools/injectable": "catalog:",
     "@ogre-tools/injectable-react": "catalog:",
-    "history": "catalog:",
     "mobx": "catalog:",
     "mobx-react": "catalog:",
     "react": "catalog:"

--- a/packages/routing/src/history.injectable.ts
+++ b/packages/routing/src/history.injectable.ts
@@ -5,9 +5,9 @@
  */
 
 import { getInjectable, getInjectionToken } from "@ogre-tools/injectable";
-import { createBrowserHistory } from "history";
+import { createBrowserHistory } from "./vendor/history";
 
-import type { History } from "history";
+import type { History } from "./vendor/history";
 
 export const historyInjectionToken = getInjectionToken<History>({
   id: "history-injection-token",

--- a/packages/routing/src/link.test.tsx
+++ b/packages/routing/src/link.test.tsx
@@ -9,12 +9,12 @@ import { registerMobX } from "@ogre-tools/injectable-extension-for-mobx";
 import { DiContextProvider } from "@ogre-tools/injectable-react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createMemoryHistory } from "history";
 import React, { createRef } from "react";
 import { routingFeature } from "./feature";
 import { historyInjectable } from "./history.injectable";
 import { Link, NavLink } from "./link";
 import { observableHistoryInjectionToken } from "./observable-history.injectable";
+import { createMemoryHistory } from "./vendor/history";
 
 import type { RenderResult } from "@testing-library/react";
 

--- a/packages/routing/src/link.tsx
+++ b/packages/routing/src/link.tsx
@@ -4,16 +4,15 @@
  */
 
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { parsePath } from "history";
 import { observer } from "mobx-react";
 import React from "react";
 import { matchPath } from "./match-path";
 import { observableHistoryInjectionToken } from "./observable-history.injectable";
-
-import type { Location, To } from "history";
+import { parsePath } from "./vendor/history";
 
 import type { Match } from "./match-path";
 import type { ObservableHistory } from "./observable-history";
+import type { Location, To } from "./vendor/history";
 
 /**
  * In-house replacement for `react-router-dom` v5's `<Link>` / `<NavLink>`.

--- a/packages/routing/src/observable-history.test.ts
+++ b/packages/routing/src/observable-history.test.ts
@@ -3,14 +3,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { createMemoryHistory } from "history";
 import { autorun, runInAction } from "mobx";
 import { createObservableHistory } from "./observable-history";
 import { searchParamsOptions } from "./search-params";
-
-import type { MemoryHistory } from "history";
+import { createMemoryHistory } from "./vendor/history";
 
 import type { ObservableHistory } from "./observable-history";
+import type { MemoryHistory } from "./vendor/history";
 
 function createTestObservableHistory(initialEntries: string[] = ["/"]): {
   history: MemoryHistory;

--- a/packages/routing/src/observable-history.ts
+++ b/packages/routing/src/observable-history.ts
@@ -3,13 +3,12 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { createPath, parsePath } from "history";
 import { action, intercept, makeObservable, observable, reaction } from "mobx";
 import { ObservableSearchParams } from "./observable-search-params";
-
-import type { Action, Location, To } from "history";
+import { createPath, parsePath } from "./vendor/history";
 
 import type { ObservableSearchParamsOptions } from "./observable-search-params";
+import type { Action, Location, To } from "./vendor/history";
 
 /**
  * The native `history` v5 runtime surface the observable wrapper is built on.

--- a/packages/routing/src/route.test.tsx
+++ b/packages/routing/src/route.test.tsx
@@ -8,12 +8,12 @@ import { createContainer } from "@ogre-tools/injectable";
 import { registerMobX } from "@ogre-tools/injectable-extension-for-mobx";
 import { DiContextProvider } from "@ogre-tools/injectable-react";
 import { render, waitFor } from "@testing-library/react";
-import { createMemoryHistory } from "history";
 import React from "react";
 import { routingFeature } from "./feature";
 import { historyInjectable } from "./history.injectable";
 import { observableHistoryInjectionToken } from "./observable-history.injectable";
 import { Redirect, Route, Switch } from "./route";
+import { createMemoryHistory } from "./vendor/history";
 
 import type { RenderResult } from "@testing-library/react";
 

--- a/packages/routing/src/route.tsx
+++ b/packages/routing/src/route.tsx
@@ -4,16 +4,15 @@
  */
 
 import { withInjectables } from "@ogre-tools/injectable-react";
-import { createPath } from "history";
 import { observer } from "mobx-react";
 import React from "react";
 import { matchPath } from "./match-path";
 import { observableHistoryInjectionToken } from "./observable-history.injectable";
-
-import type { Location, To } from "history";
+import { createPath } from "./vendor/history";
 
 import type { Match } from "./match-path";
 import type { ObservableHistory } from "./observable-history";
+import type { Location, To } from "./vendor/history";
 
 /**
  * In-house replacements for `react-router` v5's `<Route>` / `<Switch>` /

--- a/packages/routing/src/vendor/history.ts
+++ b/packages/routing/src/vendor/history.ts
@@ -1,0 +1,528 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+/**
+ * Vendored port of `history` v5.3.0.
+ *
+ * Upstream: https://github.com/remix-run/history/blob/v5.3.0/packages/history/index.ts
+ * License:  MIT (c) React Training 2015-2019, (c) Remix Software 2020-2021
+ *
+ * `history` v5.3.0 was published in 2022-02 and remix-run/history is
+ * effectively frozen -- React Router absorbed the code and develops it there.
+ * The package nevertheless sat in `catalogs.extensions`, so every extension
+ * author had to resolve an unmaintained package to compile against the API,
+ * because `To`, `Location` and `History` reach it through `@freelensapp/icon`,
+ * `renderer/ipc` and the drawer. Vendoring it is the same move as
+ * `path-to-regexp` v1 in #2261: the routing contract stays put and we own the
+ * code. See `docs/v2-routing-modernization.md`.
+ *
+ * Deliberately faithful to upstream so it can be diffed against v5.3.0. Only
+ * the following changes were made:
+ *   - converted to TypeScript with the declarations from upstream's
+ *     `index.d.ts` inlined;
+ *   - `createHashHistory` dropped -- nothing in Freelens creates a hash
+ *     history;
+ *   - navigation blocking dropped -- `block()`, `Blocker`, `Transition`, the
+ *     `blockers` event list, `allowTx`, `blockedPopTx` and the `beforeunload`
+ *     prompt. Nothing calls `block()`, and it is the bulk of what is left of
+ *     the module. Dropping it makes `push`/`replace`/`go` unconditional, and
+ *     `handlePop` reduces to `applyTx(Action.Pop)`;
+ *   - the dev-only `warning()` helper dropped, along with the relative-pathname
+ *     warnings it produced;
+ *   - `readOnly` always freezes, rather than being an identity function in
+ *     production builds.
+ */
+
+/**
+ * Actions represent the type of change to a location value.
+ */
+export enum Action {
+  /**
+   * A POP indicates a change to an arbitrary index in the history stack, such
+   * as a back or forward navigation. It does not describe the direction of the
+   * navigation, only that the current index changed.
+   *
+   * Note: This is the default action for newly created history objects.
+   */
+  Pop = "POP",
+
+  /**
+   * A PUSH indicates a new entry being added to the history stack, such as when
+   * a link is clicked and a new page loads. When this happens, all subsequent
+   * entries in the stack are lost.
+   */
+  Push = "PUSH",
+
+  /**
+   * A REPLACE indicates the entry at the current index in the history stack
+   * being replaced by a new one.
+   */
+  Replace = "REPLACE",
+}
+
+export type Pathname = string;
+export type Search = string;
+export type Hash = string;
+export type Key = string;
+
+/**
+ * The pathname, search, and hash values of a URL.
+ */
+export interface Path {
+  /**
+   * A URL pathname, beginning with a /.
+   */
+  pathname: Pathname;
+
+  /**
+   * A URL search string, beginning with a ?.
+   */
+  search: Search;
+
+  /**
+   * A URL fragment identifier, beginning with a #.
+   */
+  hash: Hash;
+}
+
+/**
+ * An entry in a history stack. A location contains information about the URL
+ * path, as well as possibly some arbitrary state and a key.
+ */
+export interface Location extends Path {
+  /**
+   * A value of arbitrary data associated with this location.
+   */
+  state: unknown;
+
+  /**
+   * A unique string associated with this location. May be used to safely store
+   * and retrieve data in some other storage API, like `localStorage`.
+   */
+  key: Key;
+}
+
+export type PartialPath = Partial<Path>;
+export type PartialLocation = Partial<Location>;
+
+/**
+ * A change to the current location.
+ */
+export interface Update {
+  /**
+   * The action that triggered the change.
+   */
+  action: Action;
+
+  /**
+   * The new location.
+   */
+  location: Location;
+}
+
+/**
+ * A function that receives notifications about location changes.
+ */
+export interface Listener {
+  (update: Update): void;
+}
+
+/**
+ * Describes a location that is the destination of some navigation, either via
+ * `history.push` or `history.replace`. May be either a URL or the pieces of a
+ * URL path.
+ */
+export type To = string | PartialPath;
+
+/**
+ * A history is an interface to the navigation stack. The history serves as the
+ * source of truth for the current location, as well as provides a set of
+ * methods that may be used to change it.
+ */
+export interface History {
+  /**
+   * The last action that modified the current location. This will always be
+   * Action.Pop when a history instance is first created.
+   */
+  readonly action: Action;
+
+  /**
+   * The current location.
+   */
+  readonly location: Location;
+
+  /**
+   * Returns a valid href for the given `to` value that may be used as the value
+   * of an <a href> attribute.
+   */
+  createHref(to: To): string;
+
+  /**
+   * Pushes a new location onto the history stack, increasing its length by one.
+   * If there were any entries in the stack after the current one, they are lost.
+   */
+  push(to: To, state?: unknown): void;
+
+  /**
+   * Replaces the current location in the history stack with a new one. The
+   * location that was replaced will no longer be available.
+   */
+  replace(to: To, state?: unknown): void;
+
+  /**
+   * Navigates `n` entries backward/forward in the history stack relative to the
+   * current index.
+   */
+  go(delta: number): void;
+
+  /**
+   * Navigates to the previous entry in the stack.
+   */
+  back(): void;
+
+  /**
+   * Navigates to the next entry in the stack.
+   */
+  forward(): void;
+
+  /**
+   * Sets up a listener that will be called whenever the current location
+   * changes. Returns a function that may be used to stop listening.
+   */
+  listen(listener: Listener): () => void;
+}
+
+/**
+ * A browser history stores the current location in the normal URL in an actual
+ * browser window.
+ */
+export interface BrowserHistory extends History {}
+
+/**
+ * A memory history stores locations in memory.
+ */
+export interface MemoryHistory extends History {
+  readonly index: number;
+}
+
+export type BrowserHistoryOptions = { window?: Window };
+
+export type InitialEntry = string | PartialLocation;
+
+export type MemoryHistoryOptions = {
+  initialEntries?: InitialEntry[];
+  initialIndex?: number;
+};
+
+const readOnly = <T>(obj: T): T => Object.freeze(obj);
+
+const PopStateEventType = "popstate";
+
+interface HistoryState {
+  usr: unknown;
+  key: Key;
+  idx: number;
+}
+
+/**
+ * Browser history stores the location in regular URLs. This is the standard for
+ * most web apps, but it requires some configuration on the server to ensure you
+ * serve the same app at multiple URLs.
+ */
+export function createBrowserHistory(options: BrowserHistoryOptions = {}): BrowserHistory {
+  const { window = document.defaultView as Window } = options;
+  const globalHistory = window.history;
+
+  function getIndexAndLocation(): [number, Location] {
+    const { pathname, search, hash } = window.location;
+    const state = (globalHistory.state || {}) as Partial<HistoryState>;
+
+    return [
+      state.idx as number,
+      readOnly<Location>({
+        pathname,
+        search,
+        hash,
+        state: state.usr || null,
+        key: state.key || "default",
+      }),
+    ];
+  }
+
+  function handlePop() {
+    applyTx(Action.Pop);
+  }
+
+  window.addEventListener(PopStateEventType, handlePop);
+
+  let action = Action.Pop;
+  let [index, location] = getIndexAndLocation();
+  const listeners = createEvents<Update>();
+
+  if (index == null) {
+    index = 0;
+    globalHistory.replaceState({ ...globalHistory.state, idx: index }, "");
+  }
+
+  function createHref(to: To) {
+    return typeof to === "string" ? to : createPath(to);
+  }
+
+  // state defaults to `null` because `window.history.state` does
+  function getNextLocation(to: To, state: unknown = null): Location {
+    return readOnly<Location>({
+      pathname: location.pathname,
+      hash: "",
+      search: "",
+      ...(typeof to === "string" ? parsePath(to) : to),
+      state,
+      key: createKey(),
+    });
+  }
+
+  function getHistoryStateAndUrl(nextLocation: Location, index: number): [HistoryState, string] {
+    return [
+      {
+        usr: nextLocation.state,
+        key: nextLocation.key,
+        idx: index,
+      },
+      createHref(nextLocation),
+    ];
+  }
+
+  function applyTx(nextAction: Action) {
+    action = nextAction;
+    [index, location] = getIndexAndLocation();
+    listeners.call({ action, location });
+  }
+
+  function push(to: To, state?: unknown) {
+    const nextAction = Action.Push;
+    const nextLocation = getNextLocation(to, state);
+    const [historyState, url] = getHistoryStateAndUrl(nextLocation, index + 1);
+
+    // TODO: Support forced reloading
+    // try...catch because iOS limits us to 100 pushState calls :/
+    try {
+      globalHistory.pushState(historyState, "", url);
+    } catch {
+      // They are going to lose state here, but there is no real
+      // way to warn them about it since the page will refresh...
+      window.location.assign(url);
+    }
+
+    applyTx(nextAction);
+  }
+
+  function replace(to: To, state?: unknown) {
+    const nextAction = Action.Replace;
+    const nextLocation = getNextLocation(to, state);
+    const [historyState, url] = getHistoryStateAndUrl(nextLocation, index);
+
+    // TODO: Support forced reloading
+    globalHistory.replaceState(historyState, "", url);
+    applyTx(nextAction);
+  }
+
+  function go(delta: number) {
+    globalHistory.go(delta);
+  }
+
+  const history: BrowserHistory = {
+    get action() {
+      return action;
+    },
+    get location() {
+      return location;
+    },
+    createHref,
+    push,
+    replace,
+    go,
+    back() {
+      go(-1);
+    },
+    forward() {
+      go(1);
+    },
+    listen(listener) {
+      return listeners.push(listener);
+    },
+  };
+
+  return history;
+}
+
+/**
+ * Memory history stores the current location in memory. It is designed for use
+ * in stateful non-browser environments like tests and React Native.
+ */
+export function createMemoryHistory(options: MemoryHistoryOptions = {}): MemoryHistory {
+  const { initialEntries = ["/"], initialIndex } = options;
+  const entries: Location[] = initialEntries.map((entry) =>
+    readOnly<Location>({
+      pathname: "/",
+      search: "",
+      hash: "",
+      state: null,
+      key: createKey(),
+      ...(typeof entry === "string" ? parsePath(entry) : entry),
+    }),
+  );
+  let index = clamp(initialIndex == null ? entries.length - 1 : initialIndex, 0, entries.length - 1);
+  let action = Action.Pop;
+  let location = entries[index];
+  const listeners = createEvents<Update>();
+
+  function createHref(to: To) {
+    return typeof to === "string" ? to : createPath(to);
+  }
+
+  function getNextLocation(to: To, state: unknown = null): Location {
+    return readOnly<Location>({
+      pathname: location.pathname,
+      search: "",
+      hash: "",
+      ...(typeof to === "string" ? parsePath(to) : to),
+      state,
+      key: createKey(),
+    });
+  }
+
+  function applyTx(nextAction: Action, nextLocation: Location) {
+    action = nextAction;
+    location = nextLocation;
+    listeners.call({ action, location });
+  }
+
+  function push(to: To, state?: unknown) {
+    const nextAction = Action.Push;
+    const nextLocation = getNextLocation(to, state);
+
+    index += 1;
+    entries.splice(index, entries.length, nextLocation);
+    applyTx(nextAction, nextLocation);
+  }
+
+  function replace(to: To, state?: unknown) {
+    const nextAction = Action.Replace;
+    const nextLocation = getNextLocation(to, state);
+
+    entries[index] = nextLocation;
+    applyTx(nextAction, nextLocation);
+  }
+
+  function go(delta: number) {
+    const nextIndex = clamp(index + delta, 0, entries.length - 1);
+    const nextAction = Action.Pop;
+    const nextLocation = entries[nextIndex];
+
+    index = nextIndex;
+    applyTx(nextAction, nextLocation);
+  }
+
+  const history: MemoryHistory = {
+    get index() {
+      return index;
+    },
+    get action() {
+      return action;
+    },
+    get location() {
+      return location;
+    },
+    createHref,
+    push,
+    replace,
+    go,
+    back() {
+      go(-1);
+    },
+    forward() {
+      go(1);
+    },
+    listen(listener) {
+      return listeners.push(listener);
+    },
+  };
+
+  return history;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// UTILS
+////////////////////////////////////////////////////////////////////////////////
+
+function clamp(n: number, lowerBound: number, upperBound: number) {
+  return Math.min(Math.max(n, lowerBound), upperBound);
+}
+
+interface Events<A> {
+  push(fn: (arg: A) => void): () => void;
+  call(arg: A): void;
+}
+
+// Upstream's version also exposes `length`, which only ever served the blocker
+// list that this port drops
+function createEvents<A>(): Events<A> {
+  let handlers: ((arg: A) => void)[] = [];
+
+  return {
+    push(fn) {
+      handlers.push(fn);
+
+      return function () {
+        handlers = handlers.filter((handler) => handler !== fn);
+      };
+    },
+    call(arg) {
+      handlers.forEach((fn) => fn?.(arg));
+    },
+  };
+}
+
+function createKey() {
+  return Math.random().toString(36).substr(2, 8);
+}
+
+/**
+ * Creates a string URL path from the given pathname, search, and hash components.
+ */
+export function createPath({ pathname = "/", search = "", hash = "" }: PartialPath) {
+  if (search && search !== "?") pathname += search.charAt(0) === "?" ? search : `?${search}`;
+  if (hash && hash !== "#") pathname += hash.charAt(0) === "#" ? hash : `#${hash}`;
+
+  return pathname;
+}
+
+/**
+ * Parses a string URL path into its separate pathname, search, and hash components.
+ */
+export function parsePath(path: string): PartialPath {
+  const parsedPath: PartialPath = {};
+
+  if (path) {
+    const hashIndex = path.indexOf("#");
+
+    if (hashIndex >= 0) {
+      parsedPath.hash = path.substr(hashIndex);
+      path = path.substr(0, hashIndex);
+    }
+
+    const searchIndex = path.indexOf("?");
+
+    if (searchIndex >= 0) {
+      parsedPath.search = path.substr(searchIndex);
+      path = path.substr(0, searchIndex);
+    }
+
+    if (path) {
+      parsedPath.pathname = path;
+    }
+  }
+
+  return parsedPath;
+}

--- a/packages/ui-components/icon/package.json
+++ b/packages/ui-components/icon/package.json
@@ -46,7 +46,6 @@
     "@ogre-tools/injectable-extension-for-mobx": "catalog:",
     "@testing-library/jest-dom": "catalog:",
     "@types/react": "catalog:",
-    "history": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/ui-components/icon/src/icon.tsx
+++ b/packages/ui-components/icon/src/icon.tsx
@@ -35,9 +35,8 @@ import Wheel from "../assets/wheel.svg?raw";
 import Workloads from "../assets/workloads.svg?raw";
 
 import type { Logger } from "@freelensapp/logger";
+import type { To } from "@freelensapp/routing";
 import type { StrictReactNode } from "@freelensapp/utilities";
-
-import type { To } from "history";
 
 const hrefValidation = /https?:\/\//;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,9 +210,6 @@ catalogs:
     handlebars:
       specifier: 4.7.9
       version: 4.7.9
-    history:
-      specifier: 5.3.0
-      version: 5.3.0
     http-proxy-node16:
       specifier: 1.0.6
       version: 1.0.6
@@ -406,9 +403,6 @@ catalogs:
     conf:
       specifier: ^15.1.0
       version: 15.1.0
-    history:
-      specifier: ^5.3.0
-      version: 5.3.0
     immer:
       specifier: ^11.1.8
       version: 11.1.8
@@ -986,9 +980,6 @@ importers:
       handlebars:
         specifier: 'catalog:'
         version: 4.7.9
-      history:
-        specifier: 'catalog:'
-        version: 5.3.0
       http-proxy-node16:
         specifier: 'catalog:'
         version: 1.0.6(debug@4.4.3(supports-color@8.1.1))
@@ -1270,9 +1261,6 @@ importers:
       electron:
         specifier: '>=42.0.0'
         version: 42.7.1(supports-color@8.1.1)
-      history:
-        specifier: catalog:extensions
-        version: 5.3.0
       immer:
         specifier: catalog:extensions
         version: 11.1.8
@@ -1514,9 +1502,6 @@ importers:
       '@ogre-tools/injectable-react':
         specifier: 'catalog:'
         version: 23.2.0(@ogre-tools/fp@23.2.0)(@ogre-tools/injectable@23.2.0(@ogre-tools/fp@23.2.0))(mobx-react@9.2.2(mobx@6.15.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(mobx@6.15.0)(react@19.2.8)
-      history:
-        specifier: 'catalog:'
-        version: 5.3.0
       mobx:
         specifier: 'catalog:'
         version: 6.15.0
@@ -2103,9 +2088,6 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
-      history:
-        specifier: 'catalog:'
-        version: 5.3.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -5582,9 +5564,6 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
-
-  history@5.3.0:
-    resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -10493,10 +10472,6 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
-
-  history@5.3.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
 
   hoist-non-react-statics@3.3.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -107,7 +107,6 @@ catalog:
   fs-extra: 11.3.6
   gunzip-maybe: 1.4.2
   handlebars: 4.7.9
-  history: 5.3.0
   http-proxy-node16: 1.0.6
   immer: 11.1.8
   joi: 18.2.3
@@ -160,7 +159,6 @@ catalogs:
     '@xterm/xterm': ^6.0.0
     chart.js: ^4.5.1
     conf: ^15.1.0
-    history: ^5.3.0
     immer: ^11.1.8
     mobx: ^6.15.0
     monaco-editor: ^0.56.0


### PR DESCRIPTION
<!-- markdownlint-disable -->
Part of #2360 (fourth item of task list A1). Continues the vendoring started in #2261.

**Description of changes:**

- Vendor `history` v5.3.0 at `packages/routing/src/vendor/history.ts`, next to the `path-to-regexp` v1 port from #2261 and following the same conventions.
- Re-export the surface from `@freelensapp/routing` and repoint all 19 import sites.
- Drop `history` from `packages/routing`, `packages/ui-components/icon`, `packages/extensions`, both catalogs, `knip.jsonc` and the lockfile.

`history` 5.3.0 was published in 2022-02 and remix-run/history is effectively frozen — React Router absorbed the code and develops it there. It still sat in `catalogs.extensions`, because `To`, `Location` and `History` reach the published API through `@freelensapp/icon`, `renderer/ipc` and the drawer.

**This takes `catalogs.extensions` from 19 entries to 18. `react-table` is the only one left in this issue.**

**What the port leaves out**

The port is deliberately faithful so it can be diffed against v5.3.0, and the header lists every deviation. Three of them are outright removals, checked against the tree first rather than assumed:

- **`createHashHistory`** — no call sites.
- **Navigation blocking** — `block()`, `Blocker`, `Transition`, the `blockers` event list, `allowTx`, `blockedPopTx` and the `beforeunload` prompt. Nothing calls `block()`. This is the single biggest cut: with the blockers gone, `push`/`replace`/`go` become unconditional and `handlePop` collapses from ~35 lines of revert-the-POP bookkeeping to `applyTx(Action.Pop)`.
- **The dev-only `warning()` helper** and the relative-pathname warnings it produced.

Plus one behavioural nicety: `readOnly` always freezes, where upstream makes it the identity function in production builds.

What remains is `Action`, the location and history types, `createBrowserHistory`, `createMemoryHistory`, `createPath` and `parsePath`.

**Fidelity notes**

- `getIndexAndLocation` keeps upstream's `state.usr || null` rather than `?? null`. `||` turns a user state of `0` or `""` into `null`, which is arguably an upstream bug, but this PR is a dependency swap and the port should diff cleanly.
- `substr` is kept where upstream uses it, for the same reason.
- `createEvents` loses its `length` accessor, which only ever served the blocker list.

**Wiring**

Imports inside `packages/routing` point at the vendored module by relative path; the six sites outside it import from `@freelensapp/routing`. `@freelensapp/icon` already depended on `@freelensapp/routing`, so no package gained a dependency and there is no new cycle.

**Validation**

- `pnpm type:check` — clean
- `biome check` on all 15 touched TS files, `trunk check` on the manifests — clean
- `packages/routing` — 55 passed. These are the real exercise of the port: `link.test.tsx`, `route.test.tsx` and `observable-history.test.ts` all drive a `createMemoryHistory` instance
- Full unit suite — **3582 passed**, 44 skipped, no snapshot churn

Per the risk note in #2360, this wants a live smoke test rather than only unit tests: `createBrowserHistory` is the one part with no unit coverage here, since the tests all use memory history. Worth clicking through cluster navigation, the drawer, and back/forward in the running app.
