### PR TITLE
Remove dead json-to-pretty-yaml type declaration

### DIFF
--- a/packages/core/types/json-to-pretty-yaml.d.ts
+++ b/packages/core/types/json-to-pretty-yaml.d.ts
@@ -1,9 +1,0 @@
-/**
- * Copyright (c) OpenLens Authors. All rights reserved.
- * Licensed under MIT License. See LICENSE in root directory for more information.
- */
-export = YAML;
-
-declare namespace YAML {
-  function stringify(source: string): string;
-}


### PR DESCRIPTION
Biome started reporting `noNamespace` on `packages/core/types/json-to-pretty-yaml.d.ts` once 9cff7775 stopped git-ignoring hand-written declaration files. The rule is right, but the fix is neither to silence it nor to rewrite the namespace: the module it declares is gone. `json-to-pretty-yaml` appears in no package.json, in no import, and in pnpm-lock.yaml not at all, so the declaration described a package that is not installed and cannot be resolved.

This is the same leftover that #2394 left behind for react-table: the `*.d.ts` ignore rule hid both files from ripgrep, so removing a dependency left its ambient types behind unnoticed.

Dropping the file changes nothing for TypeScript -- a tsc run over packages/core reports the identical set of diagnostics with and without it -- and leaves `biome check packages/core/types` clean.

Fixes #2397

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-5`