### PR TITLE
Add catalog navigation for disconnected clusters

### DIFF
--- a/packages/core/src/renderer/components/cluster-manager/cluster-status.test.tsx
+++ b/packages/core/src/renderer/components/cluster-manager/cluster-status.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Cluster } from "../../../common/cluster/cluster";
+import { NonInjectedClusterStatus } from "./cluster-status";
+
+import type { CatalogEntityRegistry } from "../../api/catalog/entity/registry";
+
+vi.mock("../../../common/ipc", () => ({
+  ipcRendererOn: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@freelensapp/icon", () => ({
+  Icon: () => null,
+}));
+
+describe("ClusterStatus", () => {
+  function renderStatus() {
+    const navigateToCatalog = vi.fn();
+    let component: NonInjectedClusterStatus | null = null;
+    const cluster = new Cluster({
+      contextName: "some-context",
+      id: "some-cluster-id",
+      kubeConfigPath: "/some/path/to/kubeconfig",
+    });
+
+    cluster.disconnected.set(false);
+
+    render(
+      <NonInjectedClusterStatus
+        ref={(instance) => {
+          component = instance;
+        }}
+        cluster={cluster}
+        navigateToCatalog={navigateToCatalog}
+        navigateToEntitySettings={vi.fn()}
+        requestClusterActivation={vi.fn(async () => {})}
+        entityRegistry={{ getById: () => undefined } as unknown as CatalogEntityRegistry}
+      />,
+    );
+
+    if (!component) {
+      throw new Error("ClusterStatus did not mount");
+    }
+
+    return {
+      cluster,
+      component: component as NonInjectedClusterStatus,
+      navigateToCatalog,
+    };
+  }
+
+  it("allows returning to the catalog after the cluster becomes disconnected", async () => {
+    const { cluster, navigateToCatalog } = renderStatus();
+
+    expect(screen.getByText("Connecting…")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Back to Catalog" })).not.toBeInTheDocument();
+
+    act(() => cluster.disconnected.set(true));
+
+    await userEvent.click(screen.getByRole("button", { name: "Back to Catalog" }));
+
+    expect(navigateToCatalog).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the existing recovery actions when connection errors are reported", () => {
+    const { cluster, component } = renderStatus();
+
+    act(() => {
+      cluster.disconnected.set(true);
+      component.authOutput.push({ level: "error", message: "Unable to reach cluster" });
+    });
+
+    expect(screen.getByRole("button", { name: "Reconnect" })).toBeInTheDocument();
+    expect(screen.getByText("Manage Proxy Settings")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back to Catalog" })).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/renderer/components/cluster-manager/cluster-status.tsx
+++ b/packages/core/src/renderer/components/cluster-manager/cluster-status.tsx
@@ -12,6 +12,7 @@ import { withInjectables } from "@ogre-tools/injectable-react";
 import { computed, makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
+import navigateToCatalogInjectable from "../../../common/front-end-routing/routes/catalog/navigate-to-catalog.injectable";
 import navigateToEntitySettingsInjectable from "../../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
 import { ipcRendererOn } from "../../../common/ipc";
 import requestClusterActivationInjectable from "../../../features/cluster/activation/renderer/request-activation.injectable";
@@ -22,6 +23,7 @@ import type { IClassName } from "@freelensapp/utilities";
 
 import type { Cluster } from "../../../common/cluster/cluster";
 import type { KubeAuthUpdate } from "../../../common/cluster-types";
+import type { NavigateToCatalog } from "../../../common/front-end-routing/routes/catalog/navigate-to-catalog.injectable";
 import type { NavigateToEntitySettings } from "../../../common/front-end-routing/routes/entity-settings/navigate-to-entity-settings.injectable";
 import type { RequestClusterActivation } from "../../../features/cluster/activation/common/request-token";
 import type { CatalogEntityRegistry } from "../../api/catalog/entity/registry";
@@ -32,13 +34,14 @@ export interface ClusterStatusProps {
 }
 
 interface Dependencies {
+  navigateToCatalog: NavigateToCatalog;
   navigateToEntitySettings: NavigateToEntitySettings;
   entityRegistry: CatalogEntityRegistry;
   requestClusterActivation: RequestClusterActivation;
 }
 
 @observer
-class NonInjectedClusterStatus extends React.Component<ClusterStatusProps & Dependencies> {
+export class NonInjectedClusterStatus extends React.Component<ClusterStatusProps & Dependencies> {
   private readonly disposers: (() => void)[] = [];
 
   @observable authOutput: KubeAuthUpdate[] = [];
@@ -116,6 +119,21 @@ class NonInjectedClusterStatus extends React.Component<ClusterStatusProps & Depe
     this.props.navigateToEntitySettings(this.cluster.id, "proxy");
   };
 
+  renderCatalogNavigation() {
+    if (!this.cluster.disconnected.get()) {
+      return undefined;
+    }
+
+    return (
+      <Button
+        primary={!this.hasErrorsOrWarnings}
+        label="Back to Catalog"
+        className="m-auto"
+        onClick={() => this.props.navigateToCatalog()}
+      />
+    );
+  }
+
   renderAuthenticationOutput() {
     return (
       <pre>
@@ -171,6 +189,7 @@ class NonInjectedClusterStatus extends React.Component<ClusterStatusProps & Depe
           {this.renderStatusIcon()}
           {this.renderAuthenticationOutput()}
           {this.renderReconnectionHelp()}
+          {this.renderCatalogNavigation()}
         </div>
       </div>
     );
@@ -180,6 +199,7 @@ class NonInjectedClusterStatus extends React.Component<ClusterStatusProps & Depe
 export const ClusterStatus = withInjectables<Dependencies, ClusterStatusProps>(NonInjectedClusterStatus, {
   getProps: (di, props) => ({
     ...props,
+    navigateToCatalog: di.inject(navigateToCatalogInjectable),
     navigateToEntitySettings: di.inject(navigateToEntitySettingsInjectable),
     entityRegistry: di.inject(catalogEntityRegistryInjectable),
     requestClusterActivation: di.inject(requestClusterActivationInjectable),


### PR DESCRIPTION
`ClusterStatus` now observes `cluster.disconnected` and displays a **Back to Catalog** button after a clean disconnect. Previously, recovery controls appeared only for authentication warnings or errors, so a disconnected cluster remained on “Connecting…” with no way back. Existing reconnect and proxy-settings actions remain available for connection errors.

The focused component test reproduced the missing action before the fix. It now verifies the reactive disconnect transition, catalog navigation, the unchanged active-connection state, and existing error recovery controls. The focused Vitest suite, repository-wide TypeScript check, and Biome check pass.

Fixes #1198