### PR TITLE
Update @kubernetes/client-node to 2.0.0-rc.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: 8.1.3
       version: 8.1.3
     '@kubernetes/client-node':
-      specifier: 1.4.0
-      version: 1.4.0
+      specifier: 2.0.0-rc.1
+      version: 2.0.0-rc.1
     '@mui/material':
       specifier: 9.2.0
       version: 9.2.0
@@ -420,6 +420,7 @@ catalogs:
       version: 5.6.0
 
 overrides:
+  '@kubernetes/client-node>@types/node': 24.12.4
   form-data: ^4.0.6
   http-proxy: npm:http-proxy-node16@^1.0.6
   mobx-react: ^9.1.1
@@ -495,7 +496,7 @@ importers:
         version: 8.1.3
       '@kubernetes/client-node':
         specifier: 'catalog:'
-        version: 1.4.0(encoding@0.1.13)(supports-color@8.1.1)
+        version: 2.0.0-rc.1(supports-color@8.1.1)
       '@ogre-tools/fp':
         specifier: 'catalog:'
         version: 23.2.0
@@ -901,7 +902,7 @@ importers:
         version: 8.1.3
       '@kubernetes/client-node':
         specifier: 'catalog:'
-        version: 1.4.0(encoding@0.1.13)(supports-color@8.1.1)
+        version: 2.0.0-rc.1(supports-color@8.1.1)
       '@mui/material':
         specifier: 'catalog:'
         version: 9.2.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@8.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.8)(supports-color@8.1.1))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1845,7 +1846,7 @@ importers:
         version: link:../../infrastructure/typescript
       '@kubernetes/client-node':
         specifier: 'catalog:'
-        version: 1.4.0(encoding@0.1.13)(supports-color@8.1.1)
+        version: 2.0.0-rc.1(supports-color@8.1.1)
       '@ogre-tools/fp':
         specifier: 'catalog:'
         version: 23.2.0
@@ -3505,8 +3506,8 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@kubernetes/client-node@1.4.0':
-    resolution: {integrity: sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==}
+  '@kubernetes/client-node@2.0.0-rc.1':
+    resolution: {integrity: sha512-t0SHsOana+pp848zALTOMtRDyO3H5OSAqK8BN67WhHkxe42gmVrubFV3s0T89iuqZ2aptoPZhQ5tnqKu6aziog==}
 
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
@@ -4402,9 +4403,6 @@ packages:
   '@types/ms@0.7.31':
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
@@ -5235,9 +5233,6 @@ packages:
 
   enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
-
-  encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -6177,15 +6172,6 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   node-gyp@12.4.0:
     resolution: {integrity: sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -6833,10 +6819,6 @@ packages:
     resolution: {integrity: sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==}
     engines: {node: '>= 20'}
 
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
   socks@2.8.4:
     resolution: {integrity: sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
@@ -7060,9 +7042,6 @@ packages:
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -7342,9 +7321,6 @@ packages:
   webcrypto-core@1.9.2:
     resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -7356,9 +7332,6 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
@@ -8421,28 +8394,27 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@kubernetes/client-node@1.4.0(encoding@0.1.13)(supports-color@8.1.1)':
+  '@kubernetes/client-node@2.0.0-rc.1(supports-color@8.1.1)':
     dependencies:
       '@types/js-yaml': 4.0.9
       '@types/node': 24.12.4
-      '@types/node-fetch': 2.6.13
       '@types/stream-buffers': 3.0.7
       form-data: 4.0.6
       hpagent: 1.2.0
       isomorphic-ws: 5.0.0(ws@8.21.0)
       js-yaml: 4.3.0
       jsonpath-plus: 10.3.0
-      node-fetch: 2.7.0(encoding@0.1.13)
       openid-client: 6.8.4
       rfc4648: 1.5.4
-      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
+      socks: 2.8.4
+      socks-proxy-agent: 10.1.0(supports-color@8.1.1)
       stream-buffers: 3.0.3
       tar-fs: 3.1.3
+      undici: 8.9.0
       ws: 8.21.0
     transitivePeerDependencies:
       - bare-buffer
       - bufferutil
-      - encoding
       - supports-color
       - utf-8-validate
 
@@ -9234,11 +9206,6 @@ snapshots:
       '@types/node': 24.12.4
 
   '@types/ms@0.7.31': {}
-
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 24.12.4
-      form-data: 4.0.6
 
   '@types/node@24.12.4':
     dependencies:
@@ -10074,11 +10041,6 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   enabled@2.0.0: {}
-
-  encoding@0.1.13:
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
 
   end-of-stream@1.4.4:
     dependencies:
@@ -11059,12 +11021,6 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  node-fetch@2.7.0(encoding@0.1.13):
-    dependencies:
-      whatwg-url: 5.0.0
-    optionalDependencies:
-      encoding: 0.1.13
-
   node-gyp@12.4.0:
     dependencies:
       env-paths: 2.2.1
@@ -11736,14 +11692,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socks-proxy-agent@8.0.5(supports-color@8.1.1):
-    dependencies:
-      agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
-      socks: 2.8.4
-    transitivePeerDependencies:
-      - supports-color
-
   socks@2.8.4:
     dependencies:
       ip-address: 9.0.5
@@ -11982,8 +11930,6 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.14
-
-  tr46@0.0.3: {}
 
   tr46@6.0.0:
     dependencies:
@@ -12252,8 +12198,6 @@ snapshots:
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@8.0.1: {}
 
   whatwg-mimetype@5.0.0: {}
@@ -12265,11 +12209,6 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   when-exit@2.1.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,7 +81,7 @@ catalog:
   '@dnd-kit/utilities': 3.2.2
   '@hapi/call': 9.0.1
   '@hapi/subtext': 8.1.3
-  '@kubernetes/client-node': 1.4.0
+  '@kubernetes/client-node': 2.0.0-rc.1
   '@mui/material': 9.2.0
   '@quantco/pnpm-licenses': 2.4.2
   '@tailwindcss/postcss': 4.2.4
@@ -176,6 +176,11 @@ allowBuilds:
 engineStrict: true
 
 overrides:
+  # @kubernetes/client-node declares @types/node ^25 as a runtime dependency.
+  # Left alone it installs a second major of the Node typings next to the
+  # catalog's 24.12.4, which then also becomes vite's resolved peer. The app
+  # targets Node 24 (.nvmrc), so keep the whole tree on one copy.
+  '@kubernetes/client-node>@types/node': 24.12.4
   form-data: ^4.0.6
   http-proxy: npm:http-proxy-node16@^1.0.6
   mobx-react: ^9.1.1


### PR DESCRIPTION
Updates the `@kubernetes/client-node` catalog entry from `1.4.0` to `2.0.0-rc.1`.

Closes #2404.

Note that this is a **release candidate**, not a stable release.

### Breaking changes vs. what this repo uses

No source changes were needed: the API surface Freelens touches is unchanged between the two tarballs.

| Change in v2 | Used here? |
| --- | --- |
| `KubeConfig.applyToFetchOptions()` removed | No |
| `RequestContext.setAgent()/getAgent()` -> `setDispatcher()/getDispatcher()` (undici `Dispatcher`) | No |
| `HttpMethod` `enum` -> const object + union type | No |
| `ExecAuth` `CredentialStatus.expirationTimestamp` now optional | No |
| `ListWatch` gained an `options` ctor param and reconnect backoff | No |
| New `KubeConfig.createDispatcherOptions()` / `DispatcherOptions` | No |
| `ResponseBody.stream()` added | No |
| `makeApiClient`, `ApiException`, `Watch`, `dumpYaml`, `Cluster`/`Context`/`User`, `KubernetesObject` | Yes - all byte-identical typings |

Other notes:

- Both `1.4.0` and `2.0.0-rc.1` are ESM-only, so there is no module-format change.
- Runtime HTTP moves from `node-fetch` to `undici@^8`. The catalog already pins `undici 8.9.0`, so it dedupes, and `node-fetch`, `@types/node-fetch`, `encoding`, `whatwg-url@5`, `tr46@0` and `webidl-conversions@3` drop out of the tree. `socks-proxy-agent` moves `8 -> 10` and `socks` becomes direct.
- Generated models only advance their OpenAPI header from Kubernetes v1.34.0 to v1.35.0, plus new `SchedulingV1alpha1Api` and `StoragemigrationV1beta1Api`.

### The `@types/node` override

v2 declares `@types/node: ^25` as a **runtime** dependency. Unpinned, that installs a second Node typings major beside the catalog's `24.12.4`, and every `@types/*` package carrying a `@types/node: *` range snaps to it - vite's resolved peer included, which churned ~200 lockfile lines. The app targets Node 24 (`.nvmrc`, `engines`), so this PR adds a scoped override:

```yaml
overrides:
  "@kubernetes/client-node>@types/node": 24.12.4
```

That keeps the tree on one copy of the Node typings and limits the lockfile diff to the client itself.

### Validation

- `pnpm type:check` - clean
- `pnpm test:unit` - 351 files / 3588 tests passed, 1 file + 44 tests skipped
- `pnpm build` - succeeds
- `trunk check` - no issues

Not verified: runtime behaviour against a live cluster. The undici migration changes how `KubeConfig` configures transport (dispatcher instead of `https.Agent`), so a manual smoke test of cluster connect, namespace listing and node shell would be worthwhile before this lands.

Generated with [Claude Code](https://claude.ai/code) | Model: `claude-opus-5`