### PR TITLE
Keep the Grype version pin in the form renovate writes

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -458,7 +458,10 @@ jobs:
 
     env:
       # Renovate keeps this version up to date via the inline datasource hint
-      # below (see .renovaterc.json5 customManagers).
+      # below (see .renovaterc.json5 customManagers). Stored without the leading
+      # "v" because that manager's extractVersionTemplate strips it on every
+      # bump; grype's installer needs the exact tag, so the "v" is re-added
+      # where this is consumed rather than kept here (it would not survive).
       GRYPE_VERSION: 0.116.1 # datasource=github-releases depName=anchore/grype
 
     steps:
@@ -491,7 +494,10 @@ jobs:
         id: grype
         uses: anchore/scan-action/download-grype@v7
         with:
-          grype-version: ${{ env.GRYPE_VERSION }}
+          # The "v" is added here, not in GRYPE_VERSION: grype's install.sh
+          # resolves the value as a literal git tag (releases are tagged
+          # "v0.116.1"), and a bare version 404s.
+          grype-version: v${{ env.GRYPE_VERSION }}
           cache-db: true
 
       - name: Scan SBOMs with Grype

--- a/.github/workflows/release-scan.yaml
+++ b/.github/workflows/release-scan.yaml
@@ -45,7 +45,10 @@ jobs:
 
     env:
       # Renovate keeps this version up to date via the inline datasource hint
-      # below (see .renovaterc.json5 customManagers).
+      # below (see .renovaterc.json5 customManagers). Stored without the leading
+      # "v" because that manager's extractVersionTemplate strips it on every
+      # bump; grype's installer needs the exact tag, so the "v" is re-added
+      # where this is consumed rather than kept here (it would not survive).
       GRYPE_VERSION: 0.116.1 # datasource=github-releases depName=anchore/grype
       DISCUSSION_NUMBER: 2339
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +71,10 @@ jobs:
         id: grype
         uses: anchore/scan-action/download-grype@v7
         with:
-          grype-version: ${{ env.GRYPE_VERSION }}
+          # The "v" is added here, not in GRYPE_VERSION: grype's install.sh
+          # resolves the value as a literal git tag (releases are tagged
+          # "v0.116.1"), and a bare version 404s.
+          grype-version: v${{ env.GRYPE_VERSION }}
           cache-db: true
 
       - name: Download the assets of the last release


### PR DESCRIPTION
Both scan workflows pin `GRYPE_VERSION` and pass it straight to `anchore/scan-action/download-grype`, which resolves the value as a literal git tag through grype's `install.sh`. Releases are tagged with a leading `v`, so a bare version 404s.

The pin used to carry that `v`, but the shared workflow-pin manager in `.renovaterc.json5` strips it via `extractVersionTemplate: "^v?(?<version>.*)$"`. So the bump in #2406 rewrote it to a bare `0.116.1`, and **both scans have been broken on main since 049511f7**:

- Release Scan, 2026-08-02 nightly ([run 30770396341](https://github.com/freelensapp/freelens/actions/runs/30770396341)) — failed; the three preceding nightlies passed
  ```
  [debug] http_download(url=https://github.com/anchore/grype/releases/0.116.1)
  [error] received HTTP status=404 for url='https://github.com/anchore/grype/releases/0.116.1'
  ```
- Integration tests, push of 049511f7 — failed; every preceding push on main passed

Restoring the `v` in `GRYPE_VERSION` would only break again on the next bump. Fix: keep the env var in the form renovate always writes and add the `v` where it is consumed.

- `.github/workflows/integration-tests.yaml` — the `security-scan` job
- `.github/workflows/release-scan.yaml`

The version itself is untouched at `0.116.1`. The same fix already landed in `freelens-for-claude-extension`, which hit this after its own first grype bump.

## Validation

`trunk check` passes on both files. Neither workflow exercises the change from this PR: `security-scan` is gated on `github.ref_name == 'main' && github.event_name != 'pull_request'`, and Release Scan runs on a schedule, `workflow_dispatch` and `workflow_run`. Confirming the grype install therefore means the push run on main after merge, a `workflow_dispatch` of Release Scan, or the next nightly.
