### PR TITLE
Add Kernel Version column to the Nodes list

### DIFF
--- a/packages/core/src/renderer/components/nodes/nodes.scss
+++ b/packages/core/src/renderer/components/nodes/nodes.scss
@@ -121,6 +121,11 @@
       flex-grow: 1.5;
     }
 
+    &.kernelVersion {
+      flex-grow: 1.3;
+      text-overflow: ellipsis;
+    }
+
     &.internalIp {
       flex-grow: 1.3;
     }

--- a/packages/core/src/renderer/components/nodes/route.tsx
+++ b/packages/core/src/renderer/components/nodes/route.tsx
@@ -50,6 +50,7 @@ enum columnId {
   taints = "taints",
   roles = "roles",
   version = "version",
+  kernelVersion = "kernelVersion",
   internalIp = "internalIp",
   age = "age",
   schedulable = "schedulable",
@@ -438,7 +439,13 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
       <TabLayout>
         <KubeObjectListLayout
           isConfigurable
-          defaultHiddenTableColumns={[columnId.pods, columnId.instanceType, columnId.nodeGroup, columnId.capacityType]}
+          defaultHiddenTableColumns={[
+            columnId.pods,
+            columnId.instanceType,
+            columnId.nodeGroup,
+            columnId.capacityType,
+            columnId.kernelVersion,
+          ]}
           tableId="nodes"
           className="Nodes"
           store={nodeStore}
@@ -457,6 +464,7 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
             [columnId.taints]: (node) => node.getTaints().length,
             [columnId.roles]: (node) => node.getRoleLabels(),
             [columnId.version]: (node) => node.getKubeletVersion(),
+            [columnId.kernelVersion]: (node) => node.getKernelVersion(),
             [columnId.internalIp]: (node) => node.getInternalIP(),
             [columnId.age]: (node) => -node.getCreationTimestamp(),
             [columnId.schedulable]: (node) => (node.isUnschedulable() ? "False" : "True"),
@@ -466,6 +474,7 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
             (node) => node.getSearchFields(),
             (node) => node.getRoleLabels(),
             (node) => node.getKubeletVersion(),
+            (node) => node.getKernelVersion(),
             (node) => node.getNodeConditionText(),
             (node) => node.getInternalIP(),
             (node) => node.getExternalIP(),
@@ -501,6 +510,12 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
             { title: "Roles", className: "roles", sortBy: columnId.roles, id: columnId.roles },
             { title: "Taints", className: "taints", sortBy: columnId.taints, id: columnId.taints },
             { title: "Version", className: "version", sortBy: columnId.version, id: columnId.version },
+            {
+              title: "Kernel Version",
+              className: "kernelVersion",
+              sortBy: columnId.kernelVersion,
+              id: columnId.kernelVersion,
+            },
             { title: "Internal IP", className: "internalIp", sortBy: columnId.internalIp, id: columnId.internalIp },
             { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
             { title: "Schedulable", className: "schedulable", sortBy: columnId.schedulable, id: columnId.schedulable },
@@ -532,6 +547,7 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
                 </Tooltip>
               </>,
               <WithTooltip>{node.getKubeletVersion()}</WithTooltip>,
+              <WithTooltip>{node.getKernelVersion()}</WithTooltip>,
               <WithTooltip>{node.getInternalIP()}</WithTooltip>,
               <KubeObjectAge key="age" object={node} />,
               <BadgeBoolean value={!node.isUnschedulable()} />,

--- a/packages/kube-object/src/specifics/node.test.ts
+++ b/packages/kube-object/src/specifics/node.test.ts
@@ -187,4 +187,66 @@ describe("Node tests", () => {
       expect(node.getRoleLabels()).toBe("foobar, master, master-v2-max");
     });
   });
+
+  describe("getKernelVersion()", () => {
+    it("should return the kernel version from status.nodeInfo", () => {
+      const node = new Node({
+        apiVersion: "foo",
+        kind: "Node",
+        metadata: {
+          name: "bar",
+          resourceVersion: "1",
+          uid: "bat",
+          selfLink: "/api/v1/nodes/bar",
+        },
+        status: {
+          nodeInfo: {
+            architecture: "amd64",
+            bootID: "boot",
+            containerRuntimeVersion: "containerd://1.7.22",
+            kernelVersion: "6.8.0-45-generic",
+            kubeProxyVersion: "v1.31.1",
+            kubeletVersion: "v1.31.1",
+            machineID: "machine",
+            operatingSystem: "linux",
+            osImage: "Ubuntu 24.04.1 LTS",
+            systemUUID: "system",
+          },
+        },
+      });
+
+      expect(node.getKernelVersion()).toBe("6.8.0-45-generic");
+    });
+
+    it("should return <unknown> if nodeInfo is not present", () => {
+      const node = new Node({
+        apiVersion: "foo",
+        kind: "Node",
+        metadata: {
+          name: "bar",
+          resourceVersion: "1",
+          uid: "bat",
+          selfLink: "/api/v1/nodes/bar",
+        },
+        status: {},
+      });
+
+      expect(node.getKernelVersion()).toBe("<unknown>");
+    });
+
+    it("should return <unknown> if status is not present", () => {
+      const node = new Node({
+        apiVersion: "foo",
+        kind: "Node",
+        metadata: {
+          name: "bar",
+          resourceVersion: "1",
+          uid: "bat",
+          selfLink: "/api/v1/nodes/bar",
+        },
+      });
+
+      expect(node.getKernelVersion()).toBe("<unknown>");
+    });
+  });
 });

--- a/packages/kube-object/src/specifics/node.ts
+++ b/packages/kube-object/src/specifics/node.ts
@@ -238,6 +238,10 @@ export class Node extends KubeObject<ClusterScopedMetadata, NodeStatus, NodeSpec
     return this.status?.nodeInfo?.kubeletVersion ?? "<unknown>";
   }
 
+  getKernelVersion() {
+    return this.status?.nodeInfo?.kernelVersion ?? "<unknown>";
+  }
+
   getOperatingSystem(): string {
     return (
       this.metadata?.labels?.["kubernetes.io/os"] ||


### PR DESCRIPTION
The kernel version is already shown in the Node detail drawer, but comparing it across a cluster meant opening each node one at a time.

Add it as a sortable and searchable column in the Nodes table, placed next to the existing kubelet Version column. It is listed in defaultHiddenTableColumns, so it starts hidden like Pods, Instance Type, Node Group and Capacity, and is enabled from the column visibility menu.

The value comes from a new Node.getKernelVersion() accessor, mirroring getKubeletVersion() including its "<unknown>" fallback.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>