### PR TITLE
fix: prevent multiple file/folder dialogs from opening simultaneously

### DIFF
--- a/packages/core/src/features/path-picking-dialog/renderer/pick-paths.injectable.ts
+++ b/packages/core/src/features/path-picking-dialog/renderer/pick-paths.injectable.ts
@@ -16,15 +16,26 @@ const openPathPickingDialogInjectable = getInjectable({
   id: "open-path-picking-dialog",
   instantiate: (di): OpenPathPickingDialog => {
     const requestFromChannel = di.inject(requestFromChannelInjectionToken);
+    let isDialogOpen = false;
 
     return async (options) => {
-      const { onPick, onCancel, ...dialogOptions } = options;
-      const response = await requestFromChannel(openPathPickingDialogChannel, dialogOptions);
+      if (isDialogOpen) {
+        return;
+      }
 
-      if (response.canceled) {
-        await onCancel?.();
-      } else {
-        await onPick?.(response.paths);
+      isDialogOpen = true;
+
+      try {
+        const { onPick, onCancel, ...dialogOptions } = options;
+        const response = await requestFromChannel(openPathPickingDialogChannel, dialogOptions);
+
+        if (response.canceled) {
+          await onCancel?.();
+        } else {
+          await onPick?.(response.paths);
+        }
+      } finally {
+        isDialogOpen = false;
       }
     };
   },

--- a/packages/core/src/renderer/components/path-picker/path-picker.tsx
+++ b/packages/core/src/renderer/components/path-picker/path-picker.tsx
@@ -8,6 +8,7 @@ import { Button } from "@freelensapp/button";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
+import React from "react";
 import openPathPickingDialogInjectable from "../../../features/path-picking-dialog/renderer/pick-paths.injectable";
 
 import type { FileFilter, OpenDialogOptions } from "electron";
@@ -36,14 +37,27 @@ interface Dependencies {
 
 const NonInjectedPathPicker = observer((props: PathPickerProps & Dependencies) => {
   const { className, disabled, openPathPickingDialog, ...pickOpts } = props;
+  const [isDialogOpen, setIsDialogOpen] = React.useState(false);
 
   return (
     <Button
       primary
       label={pickOpts.message}
-      disabled={disabled}
+      disabled={disabled || isDialogOpen}
       className={cssNames("PathPicker", className)}
-      onClick={() => void openPathPickingDialog(pickOpts)}
+      onClick={async () => {
+        if (isDialogOpen) {
+          return;
+        }
+
+        setIsDialogOpen(true);
+
+        try {
+          await openPathPickingDialog(pickOpts);
+        } finally {
+          setIsDialogOpen(false);
+        }
+      }}
     />
   );
 });


### PR DESCRIPTION
## Description

When clicking the + button in the Clusters Catalog (or any path-picking button) multiple times quickly, multiple file/folder selection dialogs open simultaneously. This creates a confusing UX.

## Changes

1. **openPathPickingDialog injectable**: Added a guard flag that prevents opening a new dialog while one is already open. Subsequent calls are silently ignored until the current dialog closes.
2. **PathPicker component**: Added a disabled state while the dialog is open, providing visual feedback and preventing accidental repeated clicks.

## Fixes

Fixes #1850