### PR TITLE
fix: keep cluster metrics history on clusters with node churn

### DIFF
--- a/packages/core/src/common/k8s-api/endpoints/metrics.api/request-cluster-metrics-by-node-names.injectable.ts
+++ b/packages/core/src/common/k8s-api/endpoints/metrics.api/request-cluster-metrics-by-node-names.injectable.ts
@@ -58,10 +58,16 @@ const requestClusterMetricsByNodeNamesInjectable = getInjectable({
     const requestMetrics = di.inject(requestMetricsInjectable);
 
     return (nodeNames, params = {}) => {
-      const opts = {
+      const opts: Record<string, string> = {
         category: "cluster",
-        nodes: nodeNames.join("|"),
       };
+
+      // Only filter by node names when a specific list is provided.
+      // When empty, cluster-wide metrics aggregate across all nodes,
+      // preserving historical data from replaced nodes (see #2409).
+      if (nodeNames.length > 0) {
+        opts.nodes = nodeNames.join("|");
+      }
       const { metrics = defaultClusterMetricKeys, ...requestParams } = params;
       const query = metrics.reduce(
         (acc, metricName) => {

--- a/packages/core/src/renderer/components/cluster/cluster-metrics.injectable.ts
+++ b/packages/core/src/renderer/components/cluster/cluster-metrics.injectable.ts
@@ -9,7 +9,6 @@ import { now } from "mobx-utils";
 import requestClusterMetricsByNodeNamesInjectable from "../../../common/k8s-api/endpoints/metrics.api/request-cluster-metrics-by-node-names.injectable";
 import { asyncComputed } from "../../../common/utils/async-computed";
 import selectedMetricsTimeRangeInjectable from "./overview/selected-metrics-time-range.injectable";
-import selectedNodeRoleForMetricsInjectable from "./overview/selected-node-role-for-metrics.injectable";
 
 import type { ClusterMetricData } from "../../../common/k8s-api/endpoints/metrics.api/request-cluster-metrics-by-node-names.injectable";
 
@@ -19,17 +18,19 @@ const clusterOverviewMetricsInjectable = getInjectable({
   id: "cluster-overview-metrics",
   instantiate: (di) => {
     const requestClusterMetricsByNodeNames = di.inject(requestClusterMetricsByNodeNamesInjectable);
-    const selectedNodeRoleForMetrics = di.inject(selectedNodeRoleForMetricsInjectable);
     const selectedMetricsTimeRange = di.inject(selectedMetricsTimeRangeInjectable);
 
     return asyncComputed<Partial<ClusterMetricData> | undefined>({
       getValueFromObservedPromise: async () => {
         now(everyMinute);
 
-        const nodeNames = selectedNodeRoleForMetrics.nodes.get().map((node) => node.getName());
         const { start, end, range } = selectedMetricsTimeRange.timestamps.get();
 
-        return requestClusterMetricsByNodeNames(nodeNames, {
+        // Pass an empty node list to indicate "all nodes, no filter".
+        // This avoids filtering cluster-wide metrics by currently-alive nodes,
+        // which would miss historical data from nodes that have been replaced
+        // on autoscaled clusters (see #2409).
+        return requestClusterMetricsByNodeNames([], {
           start,
           end,
           range,

--- a/packages/technical-features/prometheus/src/helm-provider.injectable.ts
+++ b/packages/technical-features/prometheus/src/helm-provider.injectable.ts
@@ -9,6 +9,8 @@ import {
   bytesSent,
   createPrometheusProvider,
   findFirstNamespacedService,
+  nodeFilter,
+  nodeFilterAdditive,
   prometheusProviderInjectionToken,
 } from "./provider";
 
@@ -20,41 +22,44 @@ export const getHelmLikeQueryFor =
     switch (opts.category) {
       case "cluster":
         switch (queryName) {
-          case "memoryUsage":
-            return `sum(node_memory_MemTotal_bytes - (node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes)) by (component)`.replace(
-              /_bytes/g,
-              `_bytes{node=~"${opts.nodes}"}`,
-            );
+          case "memoryUsage": {
+            const nf = nodeFilter(opts, "node");
+            return `sum(node_memory_MemTotal_bytes${nf} - (node_memory_MemFree_bytes${nf} + node_memory_Buffers_bytes${nf} + node_memory_Cached_bytes${nf})) by (component)`;
+          }
           case "workloadMemoryUsage":
-            return `sum(container_memory_working_set_bytes{container!="POD",container!="",image!="",instance=~"${opts.nodes}"}) by (component)`;
+            return `sum(container_memory_working_set_bytes{container!="POD",container!="",image!=""${nodeFilterAdditive(opts, "instance")}}) by (component)`;
           case "memoryRequests":
-            return `sum(kube_pod_container_resource_requests{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_pod_container_resource_requests{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "memoryLimits":
-            return `sum(kube_pod_container_resource_limits{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_pod_container_resource_limits{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "memoryCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_node_status_capacity{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "memoryAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_node_status_allocatable{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuUsage":
-            return `sum(rate(node_cpu_seconds_total{node=~"${opts.nodes}", mode=~"user|system"}[${rateAccuracy}]))`;
+            return `sum(rate(node_cpu_seconds_total{mode=~"user|system"${nodeFilterAdditive(opts, "node")}}[${rateAccuracy}]))`;
           case "cpuRequests":
-            return `sum(kube_pod_container_resource_requests{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_pod_container_resource_requests{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuLimits":
-            return `sum(kube_pod_container_resource_limits{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_pod_container_resource_limits{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_node_status_capacity{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_node_status_allocatable{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "podUsage":
-            return `sum({__name__=~"kubelet_running_pod_count|kubelet_running_pods", instance=~"${opts.nodes}"})`;
+            return `sum({__name__=~"kubelet_running_pod_count|kubelet_running_pods"${nodeFilterAdditive(opts, "instance")}})`;
           case "podCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="pods"}) by (component)`;
+            return `sum(kube_node_status_capacity{resource="pods"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "podAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="pods"}) by (component)`;
-          case "fsSize":
-            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (node)`;
-          case "fsUsage":
-            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"} - node_filesystem_avail_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (node)`;
+            return `sum(kube_node_status_allocatable{resource="pods"${nodeFilterAdditive(opts, "node")}}) by (component)`;
+          case "fsSize": {
+            const nf = nodeFilterAdditive(opts, "node");
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"${nf}}) by (node)`;
+          }
+          case "fsUsage": {
+            const nf = nodeFilterAdditive(opts, "node");
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"${nf}} - node_filesystem_avail_bytes{mountpoint=~"${opts.mountpoints}"${nf}}) by (node)`;
+          }
         }
         break;
       case "nodes":

--- a/packages/technical-features/prometheus/src/lens-provider.injectable.ts
+++ b/packages/technical-features/prometheus/src/lens-provider.injectable.ts
@@ -9,6 +9,8 @@ import {
   bytesSent,
   createPrometheusProvider,
   findNamespacedService,
+  nodeFilter,
+  nodeFilterAdditive,
   prometheusProviderInjectionToken,
 } from "./provider";
 
@@ -20,41 +22,44 @@ export const getLensLikeQueryFor =
     switch (opts.category) {
       case "cluster":
         switch (queryName) {
-          case "memoryUsage":
-            return `sum(node_memory_MemTotal_bytes - (node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes)) by (kubernetes_name)`.replace(
-              /_bytes/g,
-              `_bytes{kubernetes_node=~"${opts.nodes}"}`,
-            );
+          case "memoryUsage": {
+            const nf = nodeFilter(opts, "kubernetes_node");
+            return `sum(node_memory_MemTotal_bytes${nf} - (node_memory_MemFree_bytes${nf} + node_memory_Buffers_bytes${nf} + node_memory_Cached_bytes${nf})) by (kubernetes_name)`;
+          }
           case "workloadMemoryUsage":
-            return `sum(container_memory_working_set_bytes{container!="POD",container!="",image!="",instance=~"${opts.nodes}"}) by (component)`;
+            return `sum(container_memory_working_set_bytes{container!="POD",container!="",image!=""${nodeFilterAdditive(opts, "instance")}}) by (component)`;
           case "memoryRequests":
-            return `sum(kube_pod_container_resource_requests{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_pod_container_resource_requests{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "memoryLimits":
-            return `sum(kube_pod_container_resource_limits{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_pod_container_resource_limits{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "memoryCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_node_status_capacity{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "memoryAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_node_status_allocatable{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuUsage":
-            return `sum(rate(node_cpu_seconds_total{kubernetes_node=~"${opts.nodes}", mode=~"user|system"}[${rateAccuracy}]))`;
+            return `sum(rate(node_cpu_seconds_total{mode=~"user|system"${nodeFilterAdditive(opts, "kubernetes_node")}}[${rateAccuracy}]))`;
           case "cpuRequests":
-            return `sum(kube_pod_container_resource_requests{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_pod_container_resource_requests{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuLimits":
-            return `sum(kube_pod_container_resource_limits{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_pod_container_resource_limits{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_node_status_capacity{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_node_status_allocatable{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "podUsage":
-            return `sum({__name__=~"kubelet_running_pod_count|kubelet_running_pods", instance=~"${opts.nodes}"})`;
+            return `sum({__name__=~"kubelet_running_pod_count|kubelet_running_pods"${nodeFilterAdditive(opts, "instance")}})`;
           case "podCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="pods"}) by (component)`;
+            return `sum(kube_node_status_capacity{resource="pods"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "podAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="pods"}) by (component)`;
-          case "fsSize":
-            return `sum(node_filesystem_size_bytes{kubernetes_node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (kubernetes_node)`;
-          case "fsUsage":
-            return `sum(node_filesystem_size_bytes{kubernetes_node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"} - node_filesystem_avail_bytes{kubernetes_node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (kubernetes_node)`;
+            return `sum(kube_node_status_allocatable{resource="pods"${nodeFilterAdditive(opts, "node")}}) by (component)`;
+          case "fsSize": {
+            const nf = nodeFilterAdditive(opts, "kubernetes_node");
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"${nf}}) by (kubernetes_node)`;
+          }
+          case "fsUsage": {
+            const nf = nodeFilterAdditive(opts, "kubernetes_node");
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"${nf}} - node_filesystem_avail_bytes{mountpoint=~"${opts.mountpoints}"${nf}}) by (kubernetes_node)`;
+          }
         }
         break;
       case "nodes":

--- a/packages/technical-features/prometheus/src/operator-provider.injectable.ts
+++ b/packages/technical-features/prometheus/src/operator-provider.injectable.ts
@@ -9,6 +9,7 @@ import {
   bytesSent,
   createPrometheusProvider,
   findFirstNamespacedService,
+  nodeFilterAdditive,
   prometheusProviderInjectionToken,
 } from "./provider";
 
@@ -21,40 +22,41 @@ export const getOperatorLikeQueryFor =
       case "cluster":
         switch (queryName) {
           case "memoryUsage":
-            return `sum(node_memory_MemTotal_bytes - (node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes))`.replace(
-              /_bytes/g,
-              `_bytes * on (pod,namespace) group_left(node) max without(pod_ip,host_ip) (kube_pod_info{node=~"${opts.nodes}"})`,
-            );
+            return `sum(node_memory_MemTotal_bytes - (node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes))`;
           case "workloadMemoryUsage":
-            return `sum(container_memory_working_set_bytes{container!="",image!="", instance=~"${opts.nodes}"}) by (component)`;
+            return `sum(container_memory_working_set_bytes{container!="",image!=""${nodeFilterAdditive(opts, "instance")}}) by (component)`;
           case "memoryRequests":
-            return `sum(kube_pod_container_resource_requests{node=~"${opts.nodes}", resource="memory"})`;
+            return `sum(kube_pod_container_resource_requests{resource="memory"${nodeFilterAdditive(opts, "node")}})`;
           case "memoryLimits":
-            return `sum(kube_pod_container_resource_limits{node=~"${opts.nodes}", resource="memory"})`;
+            return `sum(kube_pod_container_resource_limits{resource="memory"${nodeFilterAdditive(opts, "node")}})`;
           case "memoryCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="memory"})`;
+            return `sum(kube_node_status_capacity{resource="memory"${nodeFilterAdditive(opts, "node")}})`;
           case "memoryAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="memory"})`;
+            return `sum(kube_node_status_allocatable{resource="memory"${nodeFilterAdditive(opts, "node")}})`;
           case "cpuUsage":
-            return `sum(rate(node_cpu_seconds_total{mode=~"user|system"}[${rateAccuracy}])* on (pod,namespace) group_left(node) max without(pod_ip,host_ip) (kube_pod_info{node=~"${opts.nodes}"}))`;
+            return `sum(rate(node_cpu_seconds_total{mode=~"user|system"${nodeFilterAdditive(opts, "node")}}[${rateAccuracy}]))`;
           case "cpuRequests":
-            return `sum(kube_pod_container_resource_requests{node=~"${opts.nodes}", resource="cpu"})`;
+            return `sum(kube_pod_container_resource_requests{resource="cpu"${nodeFilterAdditive(opts, "node")}})`;
           case "cpuLimits":
-            return `sum(kube_pod_container_resource_limits{node=~"${opts.nodes}", resource="cpu"})`;
+            return `sum(kube_pod_container_resource_limits{resource="cpu"${nodeFilterAdditive(opts, "node")}})`;
           case "cpuCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="cpu"})`;
+            return `sum(kube_node_status_capacity{resource="cpu"${nodeFilterAdditive(opts, "node")}})`;
           case "cpuAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="cpu"})`;
+            return `sum(kube_node_status_allocatable{resource="cpu"${nodeFilterAdditive(opts, "node")}})`;
           case "podUsage":
-            return `sum({__name__=~"kubelet_running_pod_count|kubelet_running_pods", node=~"${opts.nodes}"})`;
+            return `sum({__name__=~"kubelet_running_pod_count|kubelet_running_pods"${nodeFilterAdditive(opts, "node")}})`;
           case "podCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="pods"})`;
+            return `sum(kube_node_status_capacity{resource="pods"${nodeFilterAdditive(opts, "node")}})`;
           case "podAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="pods"})`;
-          case "fsSize":
-            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"} * on (pod,namespace) group_left(node) max without(pod_ip,host_ip) (kube_pod_info{node=~"${opts.nodes}"}))`;
-          case "fsUsage":
-            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"} * on (pod,namespace) group_left(node) max without(pod_ip,host_ip) (kube_pod_info{node=~"${opts.nodes}"}) - node_filesystem_avail_bytes{mountpoint=~"${opts.mountpoints}"} * on (pod,namespace) group_left(node) max without(pod_ip,host_ip) (kube_pod_info{node=~"${opts.nodes}"}))`;
+            return `sum(kube_node_status_allocatable{resource="pods"${nodeFilterAdditive(opts, "node")}})`;
+          case "fsSize": {
+            const nf = nodeFilterAdditive(opts, "node");
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"${nf}})`;
+          }
+          case "fsUsage": {
+            const nf = nodeFilterAdditive(opts, "node");
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"${nf}} - node_filesystem_avail_bytes{mountpoint=~"${opts.mountpoints}"${nf}})`;
+          }
         }
         break;
       case "nodes":

--- a/packages/technical-features/prometheus/src/provider.ts
+++ b/packages/technical-features/prometheus/src/provider.ts
@@ -118,6 +118,32 @@ export function bytesSent({ rateAccuracy, ingress, namespace, statuses }: BytesS
   return `sum(rate(nginx_ingress_controller_bytes_sent_sum{ingress="${ingress}",namespace="${namespace}",status=~"${statuses}"}[${rateAccuracy}])) by (ingress, namespace)`;
 }
 
+/**
+ * Only include the node label selector when `opts.nodes` is present.
+ * For metric references that have no other label matchers, use this version
+ * which wraps the selector in `{...}` braces (no leading comma).
+ *
+ * @example
+ *   `node_memory_...${nodeFilter(opts, "kubernetes_node")}` // → node_memory_...{kubernetes_node=~"n1|n2"}
+ *   `node_memory_...${nodeFilter(opts, "kubernetes_node")}` // → node_memory_... (when opts.nodes is empty)
+ */
+export function nodeFilter(opts: Record<string, string>, label: string): string {
+  return opts.nodes ? `{${label}=~"${opts.nodes}"}` : "";
+}
+
+/**
+ * For metric references that already have other label matchers inside `{...}`,
+ * use this version which adds a leading comma.
+ *
+ * @example
+ *   `kube_node_status_capacity{resource="memory"${nodeFilterAdditive(opts, "node")}}`
+ *   // → kube_node_status_capacity{resource="memory",node=~"n1|n2"}
+ *   // → kube_node_status_capacity{resource="memory"} (when opts.nodes is empty)
+ */
+export function nodeFilterAdditive(opts: Record<string, string>, label: string): string {
+  return opts.nodes ? `,${label}=~"${opts.nodes}"` : "";
+}
+
 export const prometheusProviderInjectionToken = getInjectionToken<PrometheusProvider>({
   id: "prometheus-provider",
 });

--- a/packages/technical-features/prometheus/src/stacklight-provider.injectable.ts
+++ b/packages/technical-features/prometheus/src/stacklight-provider.injectable.ts
@@ -9,6 +9,8 @@ import {
   bytesSent,
   createPrometheusProvider,
   findFirstNamespacedService,
+  nodeFilter,
+  nodeFilterAdditive,
   prometheusProviderInjectionToken,
 } from "./provider";
 
@@ -20,41 +22,44 @@ export const getStacklightLikeQueryFor =
     switch (opts.category) {
       case "cluster":
         switch (queryName) {
-          case "memoryUsage":
-            return `sum(node_memory_MemTotal_bytes - (node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes)) by (kubernetes_name)`.replace(
-              /_bytes/g,
-              `_bytes{node=~"${opts.nodes}"}`,
-            );
+          case "memoryUsage": {
+            const nf = nodeFilter(opts, "node");
+            return `sum(node_memory_MemTotal_bytes${nf} - (node_memory_MemFree_bytes${nf} + node_memory_Buffers_bytes${nf} + node_memory_Cached_bytes${nf})) by (kubernetes_name)`;
+          }
           case "workloadMemoryUsage":
-            return `sum(container_memory_working_set_bytes{container!="POD",container!="",image!="",instance=~"${opts.nodes}"}) by (component)`;
+            return `sum(container_memory_working_set_bytes{container!="POD",container!="",image!=""${nodeFilterAdditive(opts, "instance")}}) by (component)`;
           case "memoryRequests":
-            return `sum(kube_pod_container_resource_requests{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_pod_container_resource_requests{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "memoryLimits":
-            return `sum(kube_pod_container_resource_limits{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_pod_container_resource_limits{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "memoryCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_node_status_capacity{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "memoryAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="memory"}) by (component)`;
+            return `sum(kube_node_status_allocatable{resource="memory"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuUsage":
-            return `sum(rate(node_cpu_seconds_total{node=~"${opts.nodes}", mode=~"user|system"}[${rateAccuracy}]))`;
+            return `sum(rate(node_cpu_seconds_total{mode=~"user|system"${nodeFilterAdditive(opts, "node")}}[${rateAccuracy}]))`;
           case "cpuRequests":
-            return `sum(kube_pod_container_resource_requests{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_pod_container_resource_requests{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuLimits":
-            return `sum(kube_pod_container_resource_limits{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_pod_container_resource_limits{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_node_status_capacity{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "cpuAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="cpu"}) by (component)`;
+            return `sum(kube_node_status_allocatable{resource="cpu"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "podUsage":
-            return `sum({__name__=~"kubelet_running_pod_count|kubelet_running_pods", instance=~"${opts.nodes}"})`;
+            return `sum({__name__=~"kubelet_running_pod_count|kubelet_running_pods"${nodeFilterAdditive(opts, "instance")}})`;
           case "podCapacity":
-            return `sum(kube_node_status_capacity{node=~"${opts.nodes}", resource="pods"}) by (component)`;
+            return `sum(kube_node_status_capacity{resource="pods"${nodeFilterAdditive(opts, "node")}}) by (component)`;
           case "podAllocatableCapacity":
-            return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="pods"}) by (component)`;
-          case "fsSize":
-            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (node)`;
-          case "fsUsage":
-            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"} - node_filesystem_avail_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (node)`;
+            return `sum(kube_node_status_allocatable{resource="pods"${nodeFilterAdditive(opts, "node")}}) by (component)`;
+          case "fsSize": {
+            const nf = nodeFilterAdditive(opts, "node");
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"${nf}}) by (node)`;
+          }
+          case "fsUsage": {
+            const nf = nodeFilterAdditive(opts, "node");
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"${nf}} - node_filesystem_avail_bytes{mountpoint=~"${opts.mountpoints}"${nf}}) by (node)`;
+          }
         }
         break;
       case "nodes":


### PR DESCRIPTION
### Description

Fixes #2409

The cluster overview CPU/Memory charts build their PromQL node selector from the nodes alive at query time, but take the time window from the metrics range picker. On clusters with high node churn (Karpenter, Cluster Autoscaler, spot) nearly every node from earlier in the window has been replaced, so its samples are filtered out even though Prometheus still holds them.

### Fix

For cluster-level metrics, only filter by node names when a specific list is provided. The cluster overview now passes an empty node list, which tells the PromQL providers to omit the node label selector — aggregating all nodes over the time range.

### Changes

- **cluster-metrics.injectable.ts**: pass empty node list instead of current nodes
- **request-cluster-metrics-by-node-names.injectable.ts**: only set opts.nodes when nodeNames is non-empty
- **provider.ts**: add nodeFilter / nodeFilterAdditive helper functions
- **All 4 PromQL providers** (lens, helm, operator, stacklight): use conditional node filter

### How to Test

1. Connect to a cluster with autoscaler (Karpenter, Cluster Autoscaler) or node churn
2. Open Cluster overview → CPU/Memory charts
3. Select a time range spanning back before the current nodes were alive
4. Verify the chart shows historical data instead of being empty/ramp