### PR TITLE
Update core team role descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,13 +272,13 @@ Each member of the core team is focused on specific roles. You can contact us
 at any time according to them.
 
 - [Roberto Bandini](https://www.linkedin.com/in/bandiniroberto/) - [@robertobandini](https://github.com/robertobandini) - Founder<br/>
-General organization management, relationships, product management, community, marketing, freelens-ai extension
+General organization management, relationships, product management, community, marketing, extensions ecosystem (review, catalog, strategy and development)
 - [Piotr Roszatycki](https://www.linkedin.com/in/piotr.roszatycki) - [@dex4er](https://github.com/dex4er) - Maintainer<br/>
-Development direction, architecture and release management, flux-cd extension, freelens-ai extension
+Development direction, architecture and release management, extensions development
 - [Mario Offertucci](https://www.linkedin.com/in/mario-offertucci-703113b6/) - [@mariomamo](https://github.com/mariomamo) - Maintainer<br/>
-UI, Docs, freelens-ai extension development management
+UI, docs, extensions development
 - [Leopoldo Capuano](https://www.linkedin.com/in/leo-capuano/) - [@leo-capvano](https://github.com/leo-capvano) - Maintainer<br/>
-GenAI solutions & freelens-ai extension development management
+GenAI solutions, extensions development
 
 ### Release Engineering Team
 


### PR DESCRIPTION
## Motivation

The core team descriptions still referenced specific extensions (freelens-ai, flux-cd). All four of us now work across multiple extensions, and that split changes continuously, so naming individual extensions in the main README no longer gives an accurate picture of what we focus on and gets stale quickly.

This PR replaces those references with each member's actual focus areas, to keep the section current and clear. It is worth revisiting these descriptions from time to time as the project evolves.

## Changes

- Roberto Bandini: "freelens-ai extension" becomes "extensions ecosystem (review, catalog, strategy and development)"
- Piotr Roszatycki: "flux-cd extension, freelens-ai extension" becomes "extensions development"
- Mario Offertucci: "freelens-ai extension development management" becomes "extensions development"
- Leopoldo Capuano: "freelens-ai extension development management" becomes "extensions development"

## Review

@dex4er @mariomamo @leo-capvano please check the wording of your own description and feel free to propose changes to it directly in this PR.

Generated with [Claude Code](https://claude.com/claude-code)