### PR TITLE
feat(preferences): add custom theme and color support

### DIFF
--- a/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
+++ b/packages/core/src/features/preferences/renderer/preference-items/application/theme/theme.tsx
@@ -5,22 +5,31 @@
  */
 
 import { withInjectables } from "@ogre-tools/injectable-react";
+import { runInAction } from "mobx";
 import { observer } from "mobx-react";
+import React from "react";
 import { defaultColorThemePreference } from "../../../../../../common/vars";
+import { Input } from "../../../../../../renderer/components/input";
 import { SubTitle } from "../../../../../../renderer/components/layout/sub-title";
 import { Select } from "../../../../../../renderer/components/select";
 import { lensThemeDeclarationInjectionToken } from "../../../../../../renderer/themes/declaration";
 import userPreferencesStateInjectable from "../../../../../user-preferences/common/state.injectable";
+import applyLensThemeInjectable from "../../../../../../renderer/themes/apply-lens-theme.injectable";
+import activeThemeInjectable from "../../../../../../renderer/themes/active.injectable";
 
 import type { LensTheme } from "../../../../../../renderer/themes/lens-theme";
 import type { UserPreferencesState } from "../../../../../user-preferences/common/state.injectable";
+import type { ApplyLensTheme } from "../../../../../../renderer/themes/apply-lens-theme.injectable";
+import type { IComputedValue } from "mobx";
 
 interface Dependencies {
   state: UserPreferencesState;
   themes: LensTheme[];
+  applyLensTheme: ApplyLensTheme;
+  activeTheme: IComputedValue<LensTheme>;
 }
 
-const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
+const NonInjectedTheme = observer(({ state, themes, applyLensTheme, activeTheme }: Dependencies) => {
   const themeOptions = [
     {
       value: defaultColorThemePreference,
@@ -32,6 +41,13 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
     })),
   ];
 
+  const updateColor = (name: string, value: string) => {
+    runInAction(() => {
+      state.customColors[name] = value;
+      applyLensTheme(activeTheme.get());
+    });
+  };
+
   return (
     <section id="appearance">
       <SubTitle title="Theme" />
@@ -42,6 +58,55 @@ const NonInjectedTheme = observer(({ state, themes }: Dependencies) => {
         onChange={(value) => (state.colorTheme = value?.value ?? defaultColorThemePreference)}
         themeName="lens"
       />
+
+      <div className="mt-4">
+        <SubTitle title="Custom Colors" />
+        <div className="flex column flow">
+          <div className="flex align-center flow">
+            <div className="w-32">Primary Color</div>
+            <Input
+              theme="round-black"
+              type="color"
+              value={state.customColors.primary || "#00a7a0"}
+              onChange={(val) => updateColor("primary", val)}
+              className="w-16 h-8"
+            />
+            <Input
+              theme="round-black"
+              value={state.customColors.primary || "#00a7a0"}
+              onChange={(val) => updateColor("primary", val)}
+              placeholder="#00a7a0"
+            />
+          </div>
+          <div className="flex align-center flow">
+            <div className="w-32">Accent Color</div>
+            <Input
+              theme="round-black"
+              type="color"
+              value={state.customColors.textColorAccent || "#ffffff"}
+              onChange={(val) => updateColor("textColorAccent", val)}
+              className="w-16 h-8"
+            />
+            <Input
+              theme="round-black"
+              value={state.customColors.textColorAccent || "#ffffff"}
+              onChange={(val) => updateColor("textColorAccent", val)}
+              placeholder="#ffffff"
+            />
+          </div>
+          <button
+            className="p-2 mt-2 text-sm text-center border rounded cursor-pointer border-borderColor hover:bg-sidebarItemHoverBackground"
+            onClick={() => {
+              runInAction(() => {
+                state.customColors = {};
+                applyLensTheme(activeTheme.get());
+              });
+            }}
+          >
+            Reset to Default Colors
+          </button>
+        </div>
+      </div>
     </section>
   );
 });
@@ -50,5 +115,7 @@ export const Theme = withInjectables<Dependencies>(NonInjectedTheme, {
   getProps: (di) => ({
     state: di.inject(userPreferencesStateInjectable),
     themes: di.injectMany(lensThemeDeclarationInjectionToken),
+    applyLensTheme: di.inject(applyLensThemeInjectable),
+    activeTheme: di.inject(activeThemeInjectable),
   }),
 });

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -53,6 +53,10 @@ const userPreferenceDescriptorsInjectable = getInjectable({
         fromStore: (val) => val || defaultColorThemePreference,
         toStore: (val) => (!val || val === defaultColorThemePreference ? undefined : val),
       }),
+      customColors: getPreferenceDescriptor<Record<string, string>>({
+        fromStore: (val) => val || {},
+        toStore: (val) => (Object.keys(val || {}).length === 0 ? undefined : val),
+      }),
       terminalTheme: getPreferenceDescriptor<string>({
         fromStore: (val) => val || "",
         toStore: (val) => val || undefined,

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -39,6 +39,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.allowErrorReporting = descriptors.allowErrorReporting.fromStore(preferences.allowErrorReporting);
         state.allowUntrustedCAs = descriptors.allowUntrustedCAs.fromStore(preferences.allowUntrustedCAs);
         state.colorTheme = descriptors.colorTheme.fromStore(preferences.colorTheme);
+        state.customColors = descriptors.customColors.fromStore(preferences.customColors);
         state.downloadBinariesPath = descriptors.downloadBinariesPath.fromStore(preferences.downloadBinariesPath);
         state.downloadKubectlBinaries = descriptors.downloadKubectlBinaries.fromStore(
           preferences.downloadKubectlBinaries,
@@ -71,6 +72,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             allowErrorReporting: descriptors.allowErrorReporting.toStore(state.allowErrorReporting),
             allowUntrustedCAs: descriptors.allowUntrustedCAs.toStore(state.allowUntrustedCAs),
             colorTheme: descriptors.colorTheme.toStore(state.colorTheme),
+            customColors: descriptors.customColors.toStore(state.customColors),
             downloadBinariesPath: descriptors.downloadBinariesPath.toStore(state.downloadBinariesPath),
             downloadKubectlBinaries: descriptors.downloadKubectlBinaries.toStore(state.downloadKubectlBinaries),
             downloadMirror: descriptors.downloadMirror.toStore(state.downloadMirror),

--- a/packages/core/src/renderer/themes/apply-lens-theme.injectable.ts
+++ b/packages/core/src/renderer/themes/apply-lens-theme.injectable.ts
@@ -8,6 +8,7 @@ import { loggerInjectionToken } from "@freelensapp/logger";
 import { object } from "@freelensapp/utilities";
 import { getInjectable } from "@ogre-tools/injectable";
 import resetThemeInjectable from "../../features/user-preferences/common/reset-theme.injectable";
+import userPreferencesStateInjectable from "../../features/user-preferences/common/state.injectable";
 
 import type { LensTheme } from "./lens-theme";
 
@@ -21,7 +22,9 @@ const applyLensThemeInjectable = getInjectable({
 
     return (theme) => {
       try {
-        const colors = object.entries(theme.colors);
+        const state = di.inject(userPreferencesStateInjectable);
+        const mergedColors = { ...theme.colors, ...state.customColors };
+        const colors = object.entries(mergedColors);
 
         for (const [name, value] of colors) {
           document.documentElement.style.setProperty(`--${name}`, value);


### PR DESCRIPTION
Hi! I've been using Freelens and love the interface, but I felt like it would be great if we could customize the colors a bit more beyond the standard dark/light themes. 

I've implemented a 'Custom Colors' feature in the Appearance settings. It allows users to override the primary and accent colors using a color picker or by entering hex codes. The changes are saved to user preferences and applied instantly across the app without requiring a restart. I've also added a reset button to easily go back to the default theme colors.

Technical highlights:
- Added `customColors` to `UserPreferencesState` for persistence.
- Updated `applyLensTheme` to merge custom colors with the active theme tokens.
- Added a new UI section in the Theme preferences using existing component patterns (Input, SubTitle, Select).

Hope this is a welcome addition! Let me know if you'd like any changes. 🎨🚀🤝