### PR TITLE
Avoid macOS certificate verifier timeout for renderer proxy

### DIFF
--- a/packages/core/src/main/start-main-application/runnables/__test__/setup-hostnames.test.ts
+++ b/packages/core/src/main/start-main-application/runnables/__test__/setup-hostnames.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { rootCertificates } from "node:tls";
+import lensProxyCertificateInjectable from "../../../../common/certificate/lens-proxy-certificate.injectable";
+import electronAppInjectable from "../../../electron-app/electron-app.injectable";
+import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
+import setupHostnamesInjectable, { getCertificateSpkiFingerprint } from "../setup-hostnames.injectable";
+import setupLensProxyCertificateInjectable from "../setup-lens-proxy-certificate.injectable";
+
+import type { App } from "electron";
+
+describe("setupHostnames", () => {
+  it("configures Chromium with the renderer proxy public key", () => {
+    const di = getDiForUnitTesting();
+    const appendSwitch = vi.fn();
+    const certificate = rootCertificates[0];
+
+    di.override(electronAppInjectable, () => ({ commandLine: { appendSwitch } }) as unknown as App);
+    di.override(lensProxyCertificateInjectable, () => ({
+      get: () => ({ cert: certificate, private: "", public: "" }),
+      set: vi.fn(),
+    }));
+
+    const setupHostnames = di.inject(setupHostnamesInjectable);
+
+    setupHostnames.run();
+
+    expect(appendSwitch).toHaveBeenCalledWith(
+      "ignore-certificate-errors-spki-list",
+      getCertificateSpkiFingerprint(certificate),
+    );
+    expect(setupHostnames.runAfter).toBe(setupLensProxyCertificateInjectable);
+  });
+});

--- a/packages/core/src/main/start-main-application/runnables/setup-hostnames.injectable.ts
+++ b/packages/core/src/main/start-main-application/runnables/setup-hostnames.injectable.ts
@@ -4,9 +4,21 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import { createHash, X509Certificate } from "node:crypto";
 import { beforeElectronIsReadyInjectionToken } from "@freelensapp/application-for-electron-main";
 import { getInjectable } from "@ogre-tools/injectable";
+import lensProxyCertificateInjectable from "../../../common/certificate/lens-proxy-certificate.injectable";
 import electronAppInjectable from "../../electron-app/electron-app.injectable";
+import setupLensProxyCertificateInjectable from "./setup-lens-proxy-certificate.injectable";
+
+export const getCertificateSpkiFingerprint = (certificate: string): string => {
+  const publicKey = new X509Certificate(certificate).publicKey.export({
+    type: "spki",
+    format: "der",
+  });
+
+  return createHash("sha256").update(publicKey).digest("base64");
+};
 
 const setupHostnamesInjectable = getInjectable({
   id: "setup-hostnames",
@@ -14,6 +26,7 @@ const setupHostnamesInjectable = getInjectable({
   instantiate: (di) => ({
     run: () => {
       const app = di.inject(electronAppInjectable);
+      const lensProxyCertificate = di.inject(lensProxyCertificateInjectable).get();
 
       app.commandLine.appendSwitch(
         "host-resolver-rules",
@@ -24,10 +37,19 @@ const setupHostnamesInjectable = getInjectable({
         ].join(),
       );
 
+      // Chromium's platform certificate verifier can hang before Electron's
+      // setCertificateVerifyProc callback is reached. Trust only the ephemeral
+      // public key generated for this process's loopback renderer proxy.
+      app.commandLine.appendSwitch(
+        "ignore-certificate-errors-spki-list",
+        getCertificateSpkiFingerprint(lensProxyCertificate.cert),
+      );
+
       // NOTE: Proxy bypass is configured via session.setProxy() to preserve external proxy access
 
       return undefined;
     },
+    runAfter: setupLensProxyCertificateInjectable,
   }),
 
   injectionToken: beforeElectronIsReadyInjectionToken,


### PR DESCRIPTION
## Summary

- add the generated renderer proxy certificate's SHA-256 SPKI fingerprint to Chromium before Electron is ready
- order hostname setup after renderer proxy certificate generation
- add focused coverage for the command-line switch and startup dependency

## Problem

On macOS 26.5.2 arm64 with Freelens 1.10.3 and Electron 41.10.0, navigation to the loopback HTTPS renderer could remain in Chromium's `CERT_VERIFIER_JOB` for 30 seconds and then fail with `net::ERR_TIMED_OUT`. Electron's JavaScript certificate verifier was not reached because the platform certificate verifier stalled first.

## Fix

The renderer proxy already generates an ephemeral certificate for each application process. This change calculates the certificate public key's SHA-256 SPKI fingerprint and passes that exact value through Chromium's `ignore-certificate-errors-spki-list` switch before Electron becomes ready.

The exception is limited to the ephemeral public key used by the local renderer proxy. It does not disable certificate validation globally or trust a hostname independently of that key.
