### PR TITLE
Hide the broken Star History chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,13 @@ Anyone is welcome to request to be added to the official list by opening a dedic
 Anyone is welcome to collaborate to advance the Freelens project. Read
 [CONTRIBUTING.md](CONTRIBUTING.md) to see how you can help.
 
+<!-- TODO: restore the Star History chart once GitHub makes stargazer data available again.
+The chart is hidden because on 2026-06-30 GitHub restricted the stargazers API to repository
+admins and collaborators, which makes the embedded image render a placeholder instead:
+https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/
+
 ![Star History Chart](https://api.star-history.com/svg?repos=freelensapp/freelens&type=Date)
+-->
 
 ## Expenses and Donations
 


### PR DESCRIPTION
## Summary

- Since 2026-06-30 GitHub restricts the `stargazers` API to repository admins and collaborators ([changelog](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/)). As a result the Star History image in the README no longer renders a chart but a placeholder saying that access to star data was restricted.
- Wrap the image in an HTML comment with a short explanation and a link to the changelog, so the chart disappears from the rendered README and can be restored with a one-line change once the data is available again. The star-history maintainers report that GitHub is actively working on restoring the previous behavior (star-history/star-history#552).
- This replaces the approach proposed in #2417, which pointed the image at a third-party service not affiliated with star-history.

## Test plan

- [x] `trunk check README.md` passes with no issues
- [x] Rendered the changed section with GitHub's markdown API: no `<img>` and no `star-history` reference in the output
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)