### PR TITLE
fix(#1110): show metrics for init containers

### DIFF
--- a/packages/core/src/renderer/components/workloads-pods/pod-details-container.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details-container.tsx
@@ -116,7 +116,7 @@ class NonInjectedPodDetailsContainer extends React.Component<PodDetailsContainer
           <StatusBrick className={containerStatusClassName(container, status)} />
           {name}
         </div>
-        {isMetricVisible && containersType === "containers" && (
+        {isMetricVisible && (containersType === "containers" || containersType === "initContainers") && (
           <>
             {containerMetrics.map((ContainerMetrics) => (
               <ContainerMetrics.Component key={ContainerMetrics.id} container={container} pod={pod} />


### PR DESCRIPTION
Fixes #1110

Init container metrics were never rendered because the metrics block in pod-details-container.tsx was gated on containersType === "containers". Init containers carry type: "initContainers", so the condition excluded them.

podContainerMetricsInjectable already keys on ${pod.getId()}-${container.name} and queries with the pod, container, namespace selector, both of which resolve fine for init containers — so no changes were needed beyond widening the condition.

Ephemeral containers are intentionally left out of this change.

Note: I don't currently have a working local build environment, so this hasn't been verified by running the app. Happy to hold this until it can be validated, or wait to be assigned first per #2293 if that's preferred.