### PR TITLE
Add faceted search with operators and saved searches

### DIFF
--- a/packages/core/src/features/catalog/__snapshots__/custom-columns.test.tsx.snap
+++ b/packages/core/src/features/catalog/__snapshots__/custom-columns.test.tsx.snap
@@ -345,10 +345,10 @@ exports[`custom category columns for catalog > renders 1`] = `
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -374,6 +374,20 @@ exports[`custom category columns for catalog > renders 1`] = `
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -1098,10 +1112,10 @@ exports[`custom category columns for catalog > when category is added using defa
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -1127,6 +1141,20 @@ exports[`custom category columns for catalog > when category is added using defa
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -1851,10 +1879,10 @@ exports[`custom category columns for catalog > when category is added using defa
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -1880,6 +1908,20 @@ exports[`custom category columns for catalog > when category is added using defa
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -2594,10 +2636,10 @@ exports[`custom category columns for catalog > when category is added using defa
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -2623,6 +2665,20 @@ exports[`custom category columns for catalog > when category is added using defa
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -3323,10 +3379,10 @@ exports[`custom category columns for catalog > when category is added with custo
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -3352,6 +3408,20 @@ exports[`custom category columns for catalog > when category is added with custo
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -4076,10 +4146,10 @@ exports[`custom category columns for catalog > when category is added with custo
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -4105,6 +4175,20 @@ exports[`custom category columns for catalog > when category is added with custo
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -4757,10 +4841,10 @@ exports[`custom category columns for catalog > when category is added without de
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -4786,6 +4870,20 @@ exports[`custom category columns for catalog > when category is added without de
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -5510,10 +5608,10 @@ exports[`custom category columns for catalog > when category is added without de
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -5539,6 +5637,20 @@ exports[`custom category columns for catalog > when category is added without de
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"

--- a/packages/core/src/features/catalog/__snapshots__/entity-running.test.tsx.snap
+++ b/packages/core/src/features/catalog/__snapshots__/entity-running.test.tsx.snap
@@ -376,10 +376,10 @@ exports[`entity running technical tests > when navigated to catalog > renders 1`
                     1 item
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -405,6 +405,20 @@ exports[`entity running technical tests > when navigated to catalog > renders 1`
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -1229,10 +1243,10 @@ exports[`entity running technical tests > when navigated to catalog > when detai
                     1 item
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -1258,6 +1272,20 @@ exports[`entity running technical tests > when navigated to catalog > when detai
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"

--- a/packages/core/src/features/catalog/__snapshots__/opening-entity-details.test.tsx.snap
+++ b/packages/core/src/features/catalog/__snapshots__/opening-entity-details.test.tsx.snap
@@ -779,10 +779,10 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                     3 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -808,6 +808,20 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -1776,10 +1790,10 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                     3 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -1805,6 +1819,20 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -2805,10 +2833,10 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                     3 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -2834,6 +2862,20 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -4086,10 +4128,10 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                     3 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -4115,6 +4157,20 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -5335,10 +5391,10 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                     3 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -5364,6 +5420,20 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -6352,10 +6422,10 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                     3 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -6381,6 +6451,20 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -7540,10 +7624,10 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                     3 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -7569,6 +7653,20 @@ exports[`opening catalog entity details panel > when navigated to the catalog > 
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"

--- a/packages/core/src/features/cluster/delete-dialog/__snapshots__/delete-cluster-dialog.test.tsx.snap
+++ b/packages/core/src/features/cluster/delete-dialog/__snapshots__/delete-cluster-dialog.test.tsx.snap
@@ -345,10 +345,10 @@ exports[`Deleting a cluster > when an internal kubeconfig cluster is used > when
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput"
+                      class="Input SearchInput searchInput"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -374,6 +374,20 @@ exports[`Deleting a cluster > when an internal kubeconfig cluster is used > when
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -1123,10 +1137,10 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput"
+                      class="Input SearchInput searchInput"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -1152,6 +1166,20 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -1934,10 +1962,10 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput"
+                      class="Input SearchInput searchInput"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -1963,6 +1991,20 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -2826,10 +2868,10 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput focused"
+                      class="Input SearchInput searchInput focused"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -2855,6 +2897,20 @@ exports[`Deleting a cluster > when the kubeconfig has multiple clusters > when t
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"
@@ -3718,10 +3774,10 @@ exports[`Deleting a cluster > when the kubeconfig has only one cluster > when th
                     0 items
                   </div>
                   <div
-                    style="display: flex; align-items: center; gap: 8px;"
+                    class="wrapper"
                   >
                     <div
-                      class="Input SearchInput"
+                      class="Input SearchInput searchInput"
                     >
                       <label
                         class="input-area flex items-center gap-2"
@@ -3747,6 +3803,20 @@ exports[`Deleting a cluster > when the kubeconfig has only one cluster > when th
                       <div
                         class="input-info flex gap-2"
                       />
+                    </div>
+                    <i
+                      class="Icon material interactive focusable small"
+                      tabindex="0"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="bookmark_border"
+                      >
+                        bookmark_border
+                      </span>
+                    </i>
+                    <div>
+                      Saved searches
                     </div>
                     <i
                       class="Icon material interactive focusable small"

--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
@@ -468,10 +468,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -497,6 +497,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -1298,10 +1312,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -1327,6 +1341,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -2133,10 +2161,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -2162,6 +2190,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -3067,10 +3109,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -3096,6 +3138,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -3949,10 +4005,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -3978,6 +4034,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -4933,10 +5003,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -4962,6 +5032,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -5919,10 +6003,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -5948,6 +6032,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -6867,10 +6965,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -6896,6 +6994,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -7810,10 +7922,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -7839,6 +7951,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -8744,10 +8870,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -8773,6 +8899,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -9678,10 +9818,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -9707,6 +9847,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -10612,10 +10766,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -10641,6 +10795,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -11351,10 +11519,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -11380,6 +11548,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -12294,10 +12476,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -12323,6 +12505,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -13228,10 +13424,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -13257,6 +13453,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -14162,10 +14372,10 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                   0 items
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -14191,6 +14401,20 @@ exports[`cluster/namespaces - edit namespace from new tab > when navigating to n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"

--- a/packages/core/src/features/cluster/workloads/__snapshots__/pods.test.tsx.snap
+++ b/packages/core/src/features/cluster/workloads/__snapshots__/pods.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`workloads / pods > when navigating to workloads / pods view > given a n
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -582,6 +582,20 @@ exports[`workloads / pods > when navigating to workloads / pods view > given a n
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -1743,10 +1757,10 @@ exports[`workloads / pods > when navigating to workloads / pods view > given no 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -1772,6 +1786,20 @@ exports[`workloads / pods > when navigating to workloads / pods view > given no 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -2785,10 +2813,10 @@ exports[`workloads / pods > when navigating to workloads / pods view > given pod
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -2814,6 +2842,20 @@ exports[`workloads / pods > when navigating to workloads / pods view > given pod
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"

--- a/packages/core/src/features/custom-resources/__snapshots__/view-with-extra-columns.test.ts.snap
+++ b/packages/core/src/features/custom-resources/__snapshots__/view-with-extra-columns.test.ts.snap
@@ -440,10 +440,10 @@ exports[`Viewing Custom Resources with extra columns > renders 1`] = `
                 1 item
               </div>
               <div
-                style="display: flex; align-items: center; gap: 8px;"
+                class="wrapper"
               >
                 <div
-                  class="Input SearchInput focused"
+                  class="Input SearchInput searchInput focused"
                 >
                   <label
                     class="input-area flex items-center gap-2"
@@ -469,6 +469,20 @@ exports[`Viewing Custom Resources with extra columns > renders 1`] = `
                   <div
                     class="input-info flex gap-2"
                   />
+                </div>
+                <i
+                  class="Icon material interactive focusable small"
+                  tabindex="0"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="bookmark_border"
+                  >
+                    bookmark_border
+                  </span>
+                </i>
+                <div>
+                  Saved searches
                 </div>
                 <i
                   class="Icon material interactive focusable small"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
@@ -1065,10 +1065,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -1094,6 +1094,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -2145,10 +2159,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -2174,6 +2188,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -3103,10 +3131,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -3132,6 +3160,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -4329,10 +4371,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -4358,6 +4400,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -5524,10 +5580,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -5553,6 +5609,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -6714,10 +6784,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -6743,6 +6813,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -7904,10 +7988,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -7933,6 +8017,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -9116,10 +9214,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -9145,6 +9243,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -10342,10 +10454,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -10371,6 +10483,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -11532,10 +11658,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -11561,6 +11687,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -12777,10 +12917,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -12806,6 +12946,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -13902,10 +14056,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -13931,6 +14085,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -14800,10 +14968,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -14829,6 +14997,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -15851,10 +16033,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -15880,6 +16062,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -17254,10 +17450,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -17283,6 +17479,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -18264,10 +18474,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -18293,6 +18503,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -19508,10 +19732,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -19537,6 +19761,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -20750,10 +20988,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -20779,6 +21017,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -21940,10 +22192,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -21969,6 +22221,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -23130,10 +23396,10 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -23159,6 +23425,20 @@ exports[`installing helm chart from new tab > given tab for installing chart was
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/opening-dock-tab-for-installing-helm-chart.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/opening-dock-tab-for-installing-helm-chart.test.ts.snap
@@ -466,10 +466,10 @@ exports[`opening dock tab for installing helm chart > given application is start
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -495,6 +495,20 @@ exports[`opening dock tab for installing helm chart > given application is start
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -1164,10 +1178,10 @@ exports[`opening dock tab for installing helm chart > given application is start
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -1193,6 +1207,20 @@ exports[`opening dock tab for installing helm chart > given application is start
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -2031,10 +2059,10 @@ exports[`opening dock tab for installing helm chart > given application is start
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -2060,6 +2088,20 @@ exports[`opening dock tab for installing helm chart > given application is start
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -2955,10 +2997,10 @@ exports[`opening dock tab for installing helm chart > given application is start
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -2984,6 +3026,20 @@ exports[`opening dock tab for installing helm chart > given application is start
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -4029,10 +4085,10 @@ exports[`opening dock tab for installing helm chart > given application is start
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -4058,6 +4114,20 @@ exports[`opening dock tab for installing helm chart > given application is start
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -5113,10 +5183,10 @@ exports[`opening dock tab for installing helm chart > given application is start
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -5142,6 +5212,20 @@ exports[`opening dock tab for installing helm chart > given application is start
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -6187,10 +6271,10 @@ exports[`opening dock tab for installing helm chart > given application is start
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -6216,6 +6300,20 @@ exports[`opening dock tab for installing helm chart > given application is start
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -7265,10 +7363,10 @@ exports[`opening dock tab for installing helm chart > given application is start
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -7294,6 +7392,20 @@ exports[`opening dock tab for installing helm chart > given application is start
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -8349,10 +8461,10 @@ exports[`opening dock tab for installing helm chart > given application is start
                 class="header flex gap-4 items-center"
               >
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -8378,6 +8490,20 @@ exports[`opening dock tab for installing helm chart > given application is start
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"

--- a/packages/core/src/features/helm-charts/upgrade-chart/__snapshots__/upgrade-chart-new-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/upgrade-chart/__snapshots__/upgrade-chart-new-tab.test.ts.snap
@@ -553,10 +553,10 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -582,6 +582,20 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -1425,10 +1439,10 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -1454,6 +1468,20 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -2439,10 +2467,10 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -2468,6 +2496,20 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -3507,10 +3549,10 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -3536,6 +3578,20 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -4611,10 +4667,10 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -4640,6 +4696,20 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -5872,10 +5942,10 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -5901,6 +5971,20 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -7135,10 +7219,10 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -7164,6 +7248,20 @@ exports[`New Upgrade Helm Chart Dock Tab > given a namespace is selected > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"

--- a/packages/core/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
+++ b/packages/core/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
@@ -553,10 +553,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -582,6 +582,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -1506,10 +1520,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -1535,6 +1549,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -2733,10 +2761,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -2762,6 +2790,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -4021,10 +4063,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -4050,6 +4092,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -5309,10 +5365,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -5338,6 +5394,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -6843,10 +6913,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -6872,6 +6942,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -8377,10 +8461,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -8406,6 +8490,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -9911,10 +10009,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -9940,6 +10038,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -11171,10 +11283,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -11200,6 +11312,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -12433,10 +12559,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -12462,6 +12588,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -13967,10 +14107,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput"
+                    class="Input SearchInput searchInput"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -13996,6 +14136,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -15255,10 +15409,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -15284,6 +15438,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -16545,10 +16713,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -16574,6 +16742,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -17772,10 +17954,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -17801,6 +17983,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -19060,10 +19256,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -19089,6 +19285,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -20348,10 +20558,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -20377,6 +20587,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -21636,10 +21860,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -21665,6 +21889,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"
@@ -23170,10 +23408,10 @@ exports[`showing details for helm release > given application is started > when 
                   </div>
                 </div>
                 <div
-                  style="display: flex; align-items: center; gap: 8px;"
+                  class="wrapper"
                 >
                   <div
-                    class="Input SearchInput focused"
+                    class="Input SearchInput searchInput focused"
                   >
                     <label
                       class="input-area flex items-center gap-2"
@@ -23199,6 +23437,20 @@ exports[`showing details for helm release > given application is started > when 
                     <div
                       class="input-info flex gap-2"
                     />
+                  </div>
+                  <i
+                    class="Icon material interactive focusable small"
+                    tabindex="0"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="bookmark_border"
+                    >
+                      bookmark_border
+                    </span>
+                  </i>
+                  <div>
+                    Saved searches
                   </div>
                   <i
                     class="Icon material interactive focusable small"

--- a/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/preference-descriptors.injectable.ts
@@ -29,10 +29,18 @@ import type {
   KubeconfigSyncEntry,
   KubeconfigSyncValue,
   LogViewerPreferences,
+  SavedSearch,
   TerminalConfig,
 } from "./preferences-helpers";
 
 export type PreferenceDescriptors = ReturnType<(typeof userPreferenceDescriptorsInjectable)["instantiate"]>;
+
+const isSavedSearch = (value: unknown): value is SavedSearch =>
+  typeof value === "object" &&
+  value !== null &&
+  ["name", "view", "search", "op", "facets"].every(
+    (key) => typeof (value as Record<string, unknown>)[key] === "string",
+  );
 
 const userPreferenceDescriptorsInjectable = getInjectable({
   id: "user-preference-descriptors",
@@ -112,6 +120,12 @@ const userPreferenceDescriptorsInjectable = getInjectable({
       persistentSearch: getPreferenceDescriptor<boolean>({
         fromStore: (val) => val ?? false,
         toStore: (val) => (!val ? undefined : val),
+      }),
+      savedSearches: getPreferenceDescriptor<SavedSearch[]>({
+        // Hand-edited or older files reach this, so anything malformed is
+        // dropped rather than left to blow up when a search is applied.
+        fromStore: (val) => (Array.isArray(val) ? val.filter(isSavedSearch) : []),
+        toStore: (val) => (val.length === 0 ? undefined : val),
       }),
       logViewerPreferences: getPreferenceDescriptor<Partial<LogViewerPreferences>, LogViewerPreferences>({
         fromStore: (val) => ({

--- a/packages/core/src/features/user-preferences/common/preferences-helpers.ts
+++ b/packages/core/src/features/user-preferences/common/preferences-helpers.ts
@@ -57,6 +57,25 @@ export const defaultEditorConfig: EditorConfiguration = {
   },
 };
 
+/**
+ * A named search a user can re-apply from the search box.
+ *
+ * The search state is kept as the raw URL params rather than a parsed model:
+ * applying one is then just writing those params back, and this preference does
+ * not have to track the facet types living in the renderer.
+ */
+export interface SavedSearch {
+  name: string;
+  /** Route it was saved from. Searches are offered on that view only. */
+  view: string;
+  /** The `search` param: free text over every searchable field. */
+  search: string;
+  /** The `searchOp` param, empty for the default operator. */
+  op: string;
+  /** The `facets` param, already serialized. */
+  facets: string;
+}
+
 export type StoreType<P> = P extends PreferenceDescription<unknown, infer Store> ? Store : never;
 
 export interface PreferenceDescription<T, R = T> {

--- a/packages/core/src/features/user-preferences/common/storage.injectable.ts
+++ b/packages/core/src/features/user-preferences/common/storage.injectable.ts
@@ -57,6 +57,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
         state.showTrayIcon = descriptors.showTrayIcon.fromStore(preferences.showTrayIcon);
         state.hotbarAutoHide = descriptors.hotbarAutoHide.fromStore(preferences.hotbarAutoHide);
         state.persistentSearch = descriptors.persistentSearch.fromStore(preferences.persistentSearch);
+        state.savedSearches = descriptors.savedSearches.fromStore(preferences.savedSearches);
         state.logViewerPreferences = descriptors.logViewerPreferences.fromStore(preferences.logViewerPreferences);
         state.shell = descriptors.shell.fromStore(preferences.shell);
         state.syncKubeconfigEntries = descriptors.syncKubeconfigEntries.fromStore(preferences.syncKubeconfigEntries);
@@ -87,6 +88,7 @@ const userPreferencesPersistentStorageInjectable = getInjectable({
             showTrayIcon: descriptors.showTrayIcon.toStore(state.showTrayIcon),
             hotbarAutoHide: descriptors.hotbarAutoHide.toStore(state.hotbarAutoHide),
             persistentSearch: descriptors.persistentSearch.toStore(state.persistentSearch),
+            savedSearches: descriptors.savedSearches.toStore(state.savedSearches),
             logViewerPreferences: descriptors.logViewerPreferences.toStore(state.logViewerPreferences),
             shell: descriptors.shell.toStore(state.shell),
             syncKubeconfigEntries: descriptors.syncKubeconfigEntries.toStore(state.syncKubeconfigEntries),

--- a/packages/core/src/renderer/components/config-maps/config-maps.tsx
+++ b/packages/core/src/renderer/components/config-maps/config-maps.tsx
@@ -45,7 +45,13 @@ class NonInjectedConfigMaps extends React.Component<Dependencies> {
             [columnId.keys]: (configMap) => configMap.getKeys(),
             [columnId.age]: (configMap) => -configMap.getCreationTimestamp(),
           }}
-          searchFilters={[(configMap) => configMap.getSearchFields(), (configMap) => configMap.getKeys()]}
+          searchFields={[
+            { id: "name", title: "Name", getValue: (configMap) => configMap.getName() },
+            { id: "namespace", title: "Namespace", getValue: (configMap) => configMap.getNs() },
+            { id: "labels", title: "Labels", getValue: (configMap) => configMap.getLabels() },
+            { id: "keys", title: "Keys", getValue: (configMap) => configMap.getKeys() },
+            { id: "uid", title: "UID", hidden: true, getValue: (configMap) => configMap.getId() },
+          ]}
           renderHeaderTitle="Config Maps"
           renderTableHeader={[
             { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },

--- a/packages/core/src/renderer/components/config-secrets/secrets.tsx
+++ b/packages/core/src/renderer/components/config-secrets/secrets.tsx
@@ -51,7 +51,15 @@ class NonInjectedSecrets extends React.Component<Dependencies> {
             [columnId.type]: (secret) => secret.type,
             [columnId.age]: (secret) => -secret.getCreationTimestamp(),
           }}
-          searchFilters={[(secret) => secret.getSearchFields(), (secret) => secret.getKeys()]}
+          searchFields={[
+            { id: "name", title: "Name", getValue: (secret) => secret.getName() },
+            { id: "namespace", title: "Namespace", getValue: (secret) => secret.getNs() },
+            { id: "labels", title: "Labels", getValue: (secret) => secret.getLabels() },
+            // Keys only - a Secret's values are deliberately never searchable.
+            { id: "keys", title: "Keys", getValue: (secret) => secret.getKeys() },
+            { id: "type", title: "Type", getValue: (secret) => secret.type },
+            { id: "uid", title: "UID", hidden: true, getValue: (secret) => secret.getId() },
+          ]}
           renderHeaderTitle="Secrets"
           renderTableHeader={[
             { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },

--- a/packages/core/src/renderer/components/events/events.tsx
+++ b/packages/core/src/renderer/components/events/events.tsx
@@ -180,11 +180,18 @@ class NonInjectedEvents extends React.Component<Dependencies & EventsProps> {
           onSort: (params) => Object.assign(this.sorting, params),
         }}
         sortingCallbacks={this.sortingCallbacks}
-        searchFilters={[
-          (event) => event.getSearchFields(),
-          (event) => event.message,
-          (event) => event.getSource(),
-          (event) => event.involvedObject.name,
+        searchFields={[
+          // An Event's own name is generated noise, so it is searchable through
+          // "All fields" but not worth a facet. This getter also carries the
+          // namespace, uid and labels.
+          { id: "metadata", title: "Metadata", hidden: true, getValue: (event) => event.getSearchFields() },
+          { id: "namespace", title: "Namespace", getValue: (event) => event.getNs() },
+          { id: "type", title: "Type", getValue: (event) => event.type },
+          { id: "reason", title: "Reason", getValue: (event) => event.reason },
+          { id: "message", title: "Message", getValue: (event) => event.message },
+          { id: "source", title: "Source", getValue: (event) => event.getSource() },
+          { id: "object", title: "Object", getValue: (event) => event.involvedObject.name },
+          { id: "objectKind", title: "Object kind", getValue: (event) => event.involvedObject.kind },
         ]}
         renderTableHeader={[
           { title: "Type", className: "type", sortBy: columnId.type, id: columnId.type },

--- a/packages/core/src/renderer/components/input/facets-url-page-param.injectable.ts
+++ b/packages/core/src/renderer/components/input/facets-url-page-param.injectable.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getInjectable } from "@ogre-tools/injectable";
+import createPageParamInjectable from "../../navigation/create-page-param.injectable";
+
+/**
+ * Holds the named-field facets, kept separate from `search`.
+ *
+ * Splitting them means every URL, bookmark and `searchUrlParam.set(...)` caller
+ * that predates facets - the catalog's label badges, for one - keeps behaving
+ * exactly as before: a bare `search` is still the "all fields" query.
+ */
+const facetsUrlPageParamInjectable = getInjectable({
+  id: "facets-url-page-param",
+  instantiate: (di) => {
+    const createPageParam = di.inject(createPageParamInjectable);
+
+    return createPageParam({
+      name: "facets",
+      defaultValue: "",
+    });
+  },
+});
+
+export default facetsUrlPageParamInjectable;

--- a/packages/core/src/renderer/components/input/input.tsx
+++ b/packages/core/src/renderer/components/input/input.tsx
@@ -66,6 +66,7 @@ export type InputProps = Omit<InputElementProps, "onChange" | "onSubmit"> & {
   showErrorsAsTooltip?: boolean | Omit<TooltipProps, "targetId">; // show validation errors as a tooltip :hover (instead of block below)
   iconLeft?: IconData;
   iconRight?: IconData;
+  contentLeft?: string | StrictReactNode; // Any component or string goes before iconLeft, inside the field
   contentRight?: string | StrictReactNode; // Any component of string goes after iconRight
   validators?: SingleOrMany<InputValidator>;
   blurOnEnter?: boolean;
@@ -397,6 +398,7 @@ export class Input extends React.Component<InputProps, State> {
       autoSelectOnFocus,
       iconLeft,
       iconRight,
+      contentLeft,
       contentRight,
       id,
       dirty: _dirty, // excluded from passing to input-element
@@ -457,6 +459,7 @@ export class Input extends React.Component<InputProps, State> {
       <div id={componentId} className={className}>
         {tooltipError}
         <label className="input-area flex items-center gap-2" id="">
+          {contentLeft}
           {this.renderIcon(iconLeft)}
           {multiLine ? <textarea {...(inputProps as object)} /> : <input {...(inputProps as object)} />}
           {this.renderIcon(iconRight)}

--- a/packages/core/src/renderer/components/input/persistent-search-store.injectable.test.ts
+++ b/packages/core/src/renderer/components/input/persistent-search-store.injectable.test.ts
@@ -37,16 +37,31 @@ describe("persistent search store", () => {
     expect(userPreferencesState.persistentSearch).toBe(false);
   });
 
-  it("keeps search text session-only and out of user preferences", () => {
+  it("keeps the search session-only and out of user preferences", () => {
     const sharedSearchKey = "global:linked";
+    const stored = { search: "pods", op: "", facets: "" };
 
     persistentSearchStore.setEnabled(true);
     const userPreferencesBeforeSettingValue = { ...userPreferencesState };
-    persistentSearchStore.setValue(sharedSearchKey, "pods");
+    persistentSearchStore.setValue(sharedSearchKey, stored);
 
-    expect(persistentSearchStore.getValue(sharedSearchKey)).toBe("pods");
+    expect(persistentSearchStore.getValue(sharedSearchKey)).toEqual(stored);
     expect(userPreferencesState.persistentSearch).toBe(true);
     expect(userPreferencesState[sharedSearchKey]).toBeUndefined();
     expect({ ...userPreferencesState }).toEqual(userPreferencesBeforeSettingValue);
+  });
+
+  it("reports an empty search for a key it has never seen", () => {
+    expect(persistentSearchStore.getValue("nothing:here")).toEqual({ search: "", op: "", facets: "" });
+  });
+
+  // Carrying only the text was what turned a faceted search into a bare query
+  // on navigating away and back.
+  it("keeps the operator and the facets alongside the text", () => {
+    const stored = { search: "nginx", op: "notContains", facets: '[{"field":"status","values":["Failed"]}]' };
+
+    persistentSearchStore.setValue("global:linked", stored);
+
+    expect(persistentSearchStore.getValue("global:linked")).toEqual(stored);
   });
 });

--- a/packages/core/src/renderer/components/input/persistent-search-store.injectable.ts
+++ b/packages/core/src/renderer/components/input/persistent-search-store.injectable.ts
@@ -10,11 +10,29 @@ import userPreferencesStateInjectable from "../../../features/user-preferences/c
 import type { UserPreferencesState } from "../../../features/user-preferences/common/state.injectable";
 
 /**
+ * A whole search, as the three URL params that express it.
+ *
+ * Navigating to another view pushes a path with no query, so all three are lost
+ * and have to be restored from here. Keeping only the text - which is all this
+ * store held before facets existed - brought a query back without its facets,
+ * leaving text in the box that no longer filtered anything.
+ */
+export interface PersistedSearch {
+  search: string;
+  op: string;
+  facets: string;
+}
+
+const emptyPersistedSearch: PersistedSearch = { search: "", op: "", facets: "" };
+
+export const isEmptySearch = (state: PersistedSearch) => state.search === "" && state.op === "" && state.facets === "";
+
+/**
  * Store for managing persistent search across views within the same namespace.
  * Search values are stored per-namespace and only in memory (session-only).
  */
 class PersistentSearchStore {
-  @observable private searchValuesByNamespace = new Map<string, string>();
+  @observable private searchValuesByNamespace = new Map<string, PersistedSearch>();
 
   constructor(private readonly userPreferencesState: UserPreferencesState) {
     makeObservable(this);
@@ -31,12 +49,12 @@ class PersistentSearchStore {
   }
 
   @action
-  setValue(namespace: string, value: string) {
+  setValue(namespace: string, value: PersistedSearch) {
     this.searchValuesByNamespace.set(namespace, value);
   }
 
-  getValue(namespace: string): string {
-    return this.searchValuesByNamespace.get(namespace) || "";
+  getValue(namespace: string): PersistedSearch {
+    return this.searchValuesByNamespace.get(namespace) ?? emptyPersistedSearch;
   }
 }
 

--- a/packages/core/src/renderer/components/input/register-injectables.ts
+++ b/packages/core/src/renderer/components/input/register-injectables.ts
@@ -6,7 +6,10 @@
  * This replaces the webpack-based auto-registration system.
  */
 
+import facetsUrlPageParamInjectable from "./facets-url-page-param.injectable";
 import persistentSearchStoreInjectable from "./persistent-search-store.injectable";
+import savedSearchesStoreInjectable from "./saved-searches-store.injectable";
+import searchOperatorUrlPageParamInjectable from "./search-operator-url-page-param.injectable";
 import searchUrlPageParamInjectable from "./search-url-page-param.injectable";
 import { registerInjectables as registerValidatorsInjectables } from "./validators/register-injectables";
 
@@ -14,7 +17,22 @@ import type { DiContainerForInjection } from "@ogre-tools/injectable";
 
 export function registerInjectables(di: DiContainerForInjection): void {
   try {
+    di.register(facetsUrlPageParamInjectable);
+  } catch (e) {
+    /* Ignore duplicate registration */
+  }
+  try {
     di.register(persistentSearchStoreInjectable);
+  } catch (e) {
+    /* Ignore duplicate registration */
+  }
+  try {
+    di.register(savedSearchesStoreInjectable);
+  } catch (e) {
+    /* Ignore duplicate registration */
+  }
+  try {
+    di.register(searchOperatorUrlPageParamInjectable);
   } catch (e) {
     /* Ignore duplicate registration */
   }

--- a/packages/core/src/renderer/components/input/saved-searches-panel.tsx
+++ b/packages/core/src/renderer/components/input/saved-searches-panel.tsx
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { Icon } from "@freelensapp/icon";
+import { cssNames } from "@freelensapp/utilities";
+import { observer } from "mobx-react";
+import styles from "./search-input-url.module.scss";
+
+import type { SavedSearch } from "../../../features/user-preferences/common/preferences-helpers";
+
+export interface SavedSearchesPanelProps {
+  searches: SavedSearch[];
+  /** False while there is nothing worth naming, which disables saving. */
+  canSave: boolean;
+  newName: string;
+  onNewNameChange: (name: string) => void;
+  onSave: () => void;
+  onApply: (saved: SavedSearch) => void;
+  onDelete: (name: string) => void;
+}
+
+/** The saved searches of the current view, and the row that adds one. */
+export const SavedSearchesPanel = observer(
+  ({ searches, canSave, newName, onNewNameChange, onSave, onApply, onDelete }: SavedSearchesPanelProps) => (
+    <div className={styles.suggestions} data-testid="saved-searches">
+      <div className={styles.hint}>Saved searches for this view</div>
+      {searches.length === 0 && <div className={styles.hint}>None yet</div>}
+      {searches.map((entry) => (
+        <div
+          key={entry.name}
+          className={cssNames(styles.suggestion, styles.savedSearch)}
+          data-testid={`saved-search-${entry.name}`}
+          // mousedown, not click: the input blurs first otherwise and the panel
+          // unmounts before the click ever lands.
+          onMouseDown={(evt) => {
+            evt.preventDefault();
+            onApply(entry);
+          }}
+        >
+          <span className={styles.suggestionField}>{entry.name}</span>
+          <Icon
+            small
+            material="delete"
+            className={styles.savedSearchDelete}
+            // Also mousedown, and stopped: the row's own handler would apply
+            // the search before a click on the bin ever landed.
+            onMouseDown={(evt) => {
+              evt.preventDefault();
+              evt.stopPropagation();
+              onDelete(entry.name);
+            }}
+            tooltip={`Delete saved search: ${entry.name}`}
+          />
+        </div>
+      ))}
+      <div className={styles.saveRow}>
+        <input
+          className={styles.saveName}
+          placeholder={canSave ? "Save current search as..." : "Nothing to save yet"}
+          disabled={!canSave}
+          value={newName}
+          onChange={(evt) => onNewNameChange(evt.target.value)}
+          onKeyDown={(evt) => {
+            if (evt.key === "Enter") {
+              evt.preventDefault();
+              onSave();
+            }
+
+            // The search box's own handler would read these as editing the query.
+            evt.stopPropagation();
+          }}
+        />
+        <button
+          type="button"
+          className={styles.saveButton}
+          disabled={!canSave || newName.trim() === ""}
+          onClick={onSave}
+          data-testid="save-search"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  ),
+);

--- a/packages/core/src/renderer/components/input/saved-searches-store.injectable.test.ts
+++ b/packages/core/src/renderer/components/input/saved-searches-store.injectable.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import directoryForUserDataInjectable from "../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
+import userPreferencesStateInjectable from "../../../features/user-preferences/common/state.injectable";
+import { getDiForUnitTesting } from "../../getDiForUnitTesting";
+import savedSearchesStoreInjectable from "./saved-searches-store.injectable";
+
+import type { DiContainer } from "@ogre-tools/injectable";
+
+describe("saved searches store", () => {
+  let di: DiContainer;
+  let store: ReturnType<typeof savedSearchesStoreInjectable.instantiate>;
+
+  const state = (search: string, facets = "", op = "") => ({ search, op, facets });
+
+  beforeEach(() => {
+    di = getDiForUnitTesting();
+    di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
+    store = di.inject(savedSearchesStoreInjectable);
+  });
+
+  it("starts empty", () => {
+    expect(store.forView("/pods")).toEqual([]);
+  });
+
+  it("keeps a saved search for its view", () => {
+    store.save("/pods", "Broken", state("", '[{"field":"status","values":["Failed"]}]'));
+
+    expect(store.forView("/pods")).toEqual([
+      { view: "/pods", name: "Broken", search: "", op: "", facets: '[{"field":"status","values":["Failed"]}]' },
+    ]);
+  });
+
+  // A search saved on Pods filters on fields another view does not have, where
+  // a positive facet matches nothing. Offering it there would look broken.
+  it("does not offer it on another view", () => {
+    store.save("/pods", "Broken", state("", '[{"field":"status","values":["Failed"]}]'));
+
+    expect(store.forView("/deployments")).toEqual([]);
+  });
+
+  it("keeps the same name on two views apart", () => {
+    store.save("/pods", "Mine", state("a"));
+    store.save("/deployments", "Mine", state("b"));
+
+    expect(store.forView("/pods")[0]?.search).toBe("a");
+    expect(store.forView("/deployments")[0]?.search).toBe("b");
+  });
+
+  it("replaces a search saved again under the same name", () => {
+    store.save("/pods", "Mine", state("first"));
+    store.save("/pods", "Mine", state("second"));
+
+    expect(store.forView("/pods")).toEqual([{ view: "/pods", name: "Mine", search: "second", op: "", facets: "" }]);
+  });
+
+  it("sorts by name so the list does not reorder as searches are added", () => {
+    store.save("/pods", "Zulu", state("z"));
+    store.save("/pods", "Alpha", state("a"));
+    store.save("/pods", "Mike", state("m"));
+
+    expect(store.forView("/pods").map(({ name }) => name)).toEqual(["Alpha", "Mike", "Zulu"]);
+  });
+
+  it("trims the name and ignores a blank one", () => {
+    store.save("/pods", "  Padded  ", state("a"));
+    store.save("/pods", "   ", state("b"));
+
+    expect(store.forView("/pods").map(({ name }) => name)).toEqual(["Padded"]);
+  });
+
+  it("removes only the named search", () => {
+    store.save("/pods", "Keep", state("a"));
+    store.save("/pods", "Drop", state("b"));
+
+    store.remove("/pods", "Drop");
+
+    expect(store.forView("/pods").map(({ name }) => name)).toEqual(["Keep"]);
+  });
+
+  it("leaves the same name on another view when removing", () => {
+    store.save("/pods", "Mine", state("a"));
+    store.save("/deployments", "Mine", state("b"));
+
+    store.remove("/pods", "Mine");
+
+    expect(store.forView("/pods")).toEqual([]);
+    expect(store.forView("/deployments").map(({ name }) => name)).toEqual(["Mine"]);
+  });
+
+  it("writes through to the preference that persists it", () => {
+    store.save("/pods", "Mine", state("a"));
+
+    expect(di.inject(userPreferencesStateInjectable).savedSearches).toHaveLength(1);
+  });
+});

--- a/packages/core/src/renderer/components/input/saved-searches-store.injectable.ts
+++ b/packages/core/src/renderer/components/input/saved-searches-store.injectable.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getInjectable } from "@ogre-tools/injectable";
+import { action, computed, makeObservable } from "mobx";
+import userPreferencesStateInjectable from "../../../features/user-preferences/common/state.injectable";
+
+import type { SavedSearch } from "../../../features/user-preferences/common/preferences-helpers";
+import type { UserPreferencesState } from "../../../features/user-preferences/common/state.injectable";
+
+/** The part of a saved search that is not its identity. */
+type SavedSearchState = Pick<SavedSearch, "search" | "op" | "facets">;
+
+/**
+ * Named searches, persisted with the user's preferences.
+ *
+ * A search is identified by its view and its name, so saving over an existing
+ * name replaces it - no ids to generate, and no way to end up with two entries
+ * a user cannot tell apart.
+ */
+class SavedSearchesStore {
+  constructor(private readonly userPreferencesState: UserPreferencesState) {
+    makeObservable(this);
+  }
+
+  @computed
+  private get all(): SavedSearch[] {
+    return this.userPreferencesState.savedSearches ?? [];
+  }
+
+  /**
+   * The searches offered on a view.
+   *
+   * Scoped per view because facets name fields: a search saved on Pods filters
+   * on `status` and `node`, and on a view without those fields a positive facet
+   * matches nothing. Offering it there would look broken rather than useful.
+   */
+  forView(view: string): SavedSearch[] {
+    return this.all.filter((saved) => saved.view === view).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  @action
+  save(view: string, name: string, state: SavedSearchState) {
+    const trimmed = name.trim();
+
+    if (!trimmed) {
+      return;
+    }
+
+    const others = this.all.filter((saved) => !(saved.view === view && saved.name === trimmed));
+
+    this.userPreferencesState.savedSearches = [...others, { view, name: trimmed, ...state }];
+  }
+
+  @action
+  remove(view: string, name: string) {
+    this.userPreferencesState.savedSearches = this.all.filter((saved) => !(saved.view === view && saved.name === name));
+  }
+}
+
+const savedSearchesStoreInjectable = getInjectable({
+  id: "saved-searches-store",
+  instantiate: (di) => new SavedSearchesStore(di.inject(userPreferencesStateInjectable)),
+});
+
+export default savedSearchesStoreInjectable;

--- a/packages/core/src/renderer/components/input/search-facet-suggestions.tsx
+++ b/packages/core/src/renderer/components/input/search-facet-suggestions.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { cssNames } from "@freelensapp/utilities";
+import { observer } from "mobx-react";
+import { facetOperatorSymbol, facetOperators } from "./search-facets";
+import styles from "./search-input-url.module.scss";
+
+import type { FacetOperator, SearchFieldOption } from "./search-facets";
+
+export interface SearchFacetSuggestionsProps {
+  /** Fields the typed text can be turned into a facet on. */
+  options: SearchFieldOption[];
+  /** The text being typed, previewed on each option. */
+  value: string;
+  operator: FacetOperator;
+  onPickOperator: (op: FacetOperator) => void;
+  highlighted: number;
+  onHighlight: (index: number) => void;
+  onPick: (field: string) => void;
+}
+
+/** Operator row plus the fields the current text can be committed against. */
+export const SearchFacetSuggestions = observer(
+  ({ options, value, operator, onPickOperator, highlighted, onHighlight, onPick }: SearchFacetSuggestionsProps) => (
+    <div className={styles.suggestions} data-testid="search-facet-suggestions">
+      <div className={styles.operators}>
+        {facetOperators.map(({ op, title, symbol }) => (
+          <button
+            type="button"
+            key={op}
+            className={cssNames(styles.operator, { [styles.operatorActive]: op === operator })}
+            data-testid={`search-facet-operator-${op}`}
+            title={title}
+            // Keeps focus (and the typed text) in the input; the click still
+            // fires, and Tab still reaches the button for keyboard users.
+            onMouseDown={(evt) => evt.preventDefault()}
+            onClick={() => onPickOperator(op)}
+          >
+            {symbol}
+          </button>
+        ))}
+      </div>
+      <div className={styles.hint}>Add a filter for</div>
+      {options.map((option, index) => (
+        <div
+          key={option.id}
+          className={cssNames(styles.suggestion, { [styles.highlighted]: index === highlighted })}
+          data-testid={`search-facet-option-${option.id}`}
+          onMouseEnter={() => onHighlight(index)}
+          // mousedown, not click: the input blurs first otherwise and this list
+          // unmounts before the click ever lands.
+          onMouseDown={(evt) => {
+            evt.preventDefault();
+            onPick(option.id);
+          }}
+        >
+          <span className={styles.suggestionField}>{option.title}</span>
+          <span className={styles.suggestionOperator}>{facetOperatorSymbol(operator)}</span>
+          <span className={styles.suggestionValue}>{value}</span>
+        </div>
+      ))}
+    </div>
+  ),
+);

--- a/packages/core/src/renderer/components/input/search-facets.test.ts
+++ b/packages/core/src/renderer/components/input/search-facets.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { compileFacet, parseFacets, serializeFacets, withFacetValue, withoutFacet } from "./search-facets";
+
+import type { FacetText, SearchFacet } from "./search-facets";
+
+/**
+ * Runs a facet the way `ItemListLayout` does: walk the texts with `test`, then
+ * apply `negated`. Returns undefined when the facet does not compile.
+ */
+const matches = (facet: SearchFacet, texts: FacetText[]): boolean | undefined => {
+  const compiled = compileFacet(facet);
+
+  if (!compiled) {
+    return undefined;
+  }
+
+  const found = texts.some((text) => compiled.test(text));
+
+  return compiled.negated ? !found : found;
+};
+
+describe("search facets", () => {
+  describe("parseFacets", () => {
+    it("round-trips through serializeFacets", () => {
+      const facets: SearchFacet[] = [
+        { field: "name", values: ["nginx"], op: "contains" },
+        { field: "namespace", values: ["kube-system", "default"], op: "equals" },
+      ];
+
+      expect(parseFacets(serializeFacets(facets))).toEqual(facets);
+    });
+
+    it("collapses an empty set to an empty param", () => {
+      expect(serializeFacets([])).toBe("");
+      expect(serializeFacets([{ field: "name", values: [] }])).toBe("");
+    });
+
+    it("yields nothing for an empty param", () => {
+      expect(parseFacets("")).toEqual([]);
+    });
+
+    // The param is user-editable and lives in bookmarks across versions, so bad
+    // input must degrade rather than throw.
+    it.each([
+      ["not json at all", "nginx"],
+      ["a regex that looks like the start of JSON", "[a-z]+"],
+      ["valid JSON of the wrong shape", '["nginx"]'],
+      ["valid JSON that is not an array", '{"field":"name","values":["x"]}'],
+      ["an array of malformed entries", '[{"field":"name"},{"values":["x"]},{"field":1,"values":[]}]'],
+      ["an unknown operator", '[{"field":"name","values":["x"],"op":"startsWith"}]'],
+    ])("survives %s", (_, raw) => {
+      expect(parseFacets(raw)).toEqual([]);
+    });
+
+    it("drops valueless facets it finds in the param", () => {
+      expect(parseFacets('[{"field":"name","values":[]},{"field":"ns","values":["kube-system"]}]')).toEqual([
+        { field: "ns", values: ["kube-system"], op: undefined },
+      ]);
+    });
+
+    // Regex was a flag beside the operator before it became one of its own.
+    it("translates the legacy regex flag into the matching operator", () => {
+      expect(parseFacets('[{"field":"name","values":["^prod"],"regex":true}]')).toEqual([
+        { field: "name", values: ["^prod"], op: "matches" },
+      ]);
+    });
+
+    it("translates a negated legacy regex flag", () => {
+      expect(parseFacets('[{"field":"name","values":["^prod"],"op":"notContains","regex":true}]')).toEqual([
+        { field: "name", values: ["^prod"], op: "notMatches" },
+      ]);
+    });
+
+    it("carries the stored label through", () => {
+      expect(parseFacets('[{"field":"ip","values":["10.0.0.1"],"title":"IP"}]')).toEqual([
+        { field: "ip", values: ["10.0.0.1"], op: undefined, title: "IP" },
+      ]);
+    });
+
+    it("rejects a facet whose label is not a string", () => {
+      expect(parseFacets('[{"field":"ip","values":["10.0.0.1"],"title":42}]')).toEqual([]);
+    });
+
+    it("leaves an explicit regex operator alone", () => {
+      expect(parseFacets('[{"field":"name","values":["^prod"],"op":"matches","regex":true}]')).toEqual([
+        { field: "name", values: ["^prod"], op: "matches" },
+      ]);
+    });
+  });
+
+  describe("compileFacet", () => {
+    it("matches any value in the facet, case-insensitively", () => {
+      const facet: SearchFacet = { field: "name", values: ["nginx", "redis"] };
+
+      expect(matches(facet, ["my-NGINX-pod"])).toBe(true);
+      expect(matches(facet, ["redis-master"])).toBe(true);
+      expect(matches(facet, ["postgres-0"])).toBe(false);
+    });
+
+    it("does not compile when the facet has no values", () => {
+      expect(compileFacet({ field: "name", values: [] })).toBeUndefined();
+    });
+
+    it("defaults to contains when the facet carries no operator", () => {
+      // Facets written before operators existed must keep their meaning.
+      expect(matches({ field: "name", values: ["ngin"] }, ["my-nginx"])).toBe(true);
+    });
+  });
+
+  describe("contains", () => {
+    it("treats metacharacters literally", () => {
+      expect(matches({ field: "name", values: ["^prod"], op: "contains" }, ["prod-api"])).toBe(false);
+    });
+  });
+
+  describe("equals", () => {
+    it("requires the whole text to match", () => {
+      const facet: SearchFacet = { field: "namespace", values: ["default"], op: "equals" };
+
+      expect(matches(facet, ["default"])).toBe(true);
+      expect(matches(facet, ["default-2"])).toBe(false);
+      expect(matches(facet, ["my-default"])).toBe(false);
+    });
+
+    it("is case-insensitive, like contains", () => {
+      expect(matches({ field: "status", values: ["running"], op: "equals" }, ["Running"])).toBe(true);
+    });
+
+    it("matches any one of several values", () => {
+      const facet: SearchFacet = { field: "status", values: ["Running", "Failed"], op: "equals" };
+
+      expect(matches(facet, ["Failed"])).toBe(true);
+      expect(matches(facet, ["Pending"])).toBe(false);
+    });
+
+    it("stays literal, so a pattern is not interpreted", () => {
+      expect(matches({ field: "name", values: ["prod-\\w+"], op: "equals" }, ["prod-api"])).toBe(false);
+    });
+  });
+
+  describe("matches", () => {
+    it("applies the pattern", () => {
+      const facet: SearchFacet = { field: "name", values: ["^prod"], op: "matches" };
+
+      expect(matches(facet, ["prod-api"])).toBe(true);
+      expect(matches(facet, ["my-prod-api"])).toBe(false);
+    });
+
+    // Anchoring by default would make the common case useless in a search box.
+    it("is unanchored unless the pattern says otherwise", () => {
+      expect(matches({ field: "name", values: ["ngin"], op: "matches" }, ["my-nginx-pod"])).toBe(true);
+      expect(matches({ field: "name", values: ["^ngin$"], op: "matches" }, ["my-nginx-pod"])).toBe(false);
+    });
+
+    it("honours character classes, which lowercasing the source would break", () => {
+      expect(matches({ field: "labels", values: ["^Team=[A-Z]"], op: "matches" }, ["Team=Platform"])).toBe(true);
+    });
+
+    it("honours alternation", () => {
+      const facet: SearchFacet = { field: "name", values: ["^(staging|dev)-"], op: "matches" };
+
+      expect(matches(facet, ["staging-api"])).toBe(true);
+      expect(matches(facet, ["dev-api"])).toBe(true);
+      expect(matches(facet, ["prod-api"])).toBe(false);
+    });
+
+    it("does not compile when every value is still an incomplete pattern", () => {
+      expect(compileFacet({ field: "name", values: ["(", "[a-"], op: "matches" })).toBeUndefined();
+    });
+
+    it("keeps the usable half when only some values are incomplete", () => {
+      const facet: SearchFacet = { field: "name", values: ["^prod", "("], op: "matches" };
+
+      expect(matches(facet, ["prod-api"])).toBe(true);
+      expect(matches(facet, ["dev-api"])).toBe(false);
+    });
+
+    it("skips absent texts instead of matching a phantom undefined", () => {
+      expect(matches({ field: "ip", values: ["undefined"], op: "matches" }, [undefined, null])).toBe(false);
+    });
+
+    it("reuses one regex across texts without skipping matches", () => {
+      const compiled = compileFacet({ field: "name", values: ["pod"], op: "matches" });
+
+      expect(compiled?.test("pod-a")).toBe(true);
+      expect(compiled?.test("pod-b")).toBe(true);
+      expect(compiled?.test("pod-c")).toBe(true);
+    });
+  });
+
+  describe("notContains", () => {
+    it("excludes the texts that contain the value", () => {
+      const facet: SearchFacet = { field: "name", values: ["api"], op: "notContains" };
+
+      expect(matches(facet, ["prod-web"])).toBe(true);
+      expect(matches(facet, ["prod-api"])).toBe(false);
+    });
+
+    // OR-ing negations would be true for almost everything, so a facet with
+    // several values means "none of them".
+    it("requires none of its values to be present", () => {
+      const facet: SearchFacet = { field: "name", values: ["api", "web"], op: "notContains" };
+
+      expect(matches(facet, ["prod-worker"])).toBe(true);
+      expect(matches(facet, ["prod-web"])).toBe(false);
+      expect(matches(facet, ["prod-api"])).toBe(false);
+    });
+
+    it("excludes an item when any one of a field's texts matches", () => {
+      // Labels yield several texts; one hit is enough to exclude the item.
+      const facet: SearchFacet = { field: "labels", values: ["app=web"], op: "notContains" };
+
+      expect(matches(facet, ["env=prod", "app=api"])).toBe(true);
+      expect(matches(facet, ["env=prod", "app=web"])).toBe(false);
+    });
+  });
+
+  describe("notEquals", () => {
+    it("keeps texts that merely contain the value", () => {
+      const facet: SearchFacet = { field: "namespace", values: ["default"], op: "notEquals" };
+
+      expect(matches(facet, ["default"])).toBe(false);
+      expect(matches(facet, ["default-2"])).toBe(true);
+    });
+
+    it("keeps an item whose field is absent", () => {
+      // Nothing without a status is "Running", so excluding Running keeps it.
+      expect(matches({ field: "status", values: ["Running"], op: "notEquals" }, [undefined])).toBe(true);
+    });
+  });
+
+  describe("notMatches", () => {
+    it("excludes the texts the pattern matches", () => {
+      const facet: SearchFacet = { field: "name", values: ["^prod"], op: "notMatches" };
+
+      expect(matches(facet, ["staging-api"])).toBe(true);
+      expect(matches(facet, ["prod-api"])).toBe(false);
+    });
+
+    it("does not compile while the pattern is incomplete, so nothing is excluded", () => {
+      expect(compileFacet({ field: "name", values: ["^(prod"], op: "notMatches" })).toBeUndefined();
+    });
+  });
+
+  describe("withFacetValue", () => {
+    it("adds a facet for a field that has none", () => {
+      expect(withFacetValue([], "name", "contains", "nginx")).toEqual([
+        { field: "name", op: "contains", values: ["nginx"] },
+      ]);
+    });
+
+    it("ORs a second value into the same field and operator", () => {
+      const facets = withFacetValue(
+        [{ field: "name", op: "contains", values: ["nginx"] }],
+        "name",
+        "contains",
+        "redis",
+      );
+
+      expect(facets).toEqual([{ field: "name", op: "contains", values: ["nginx", "redis"] }]);
+    });
+
+    it("ignores a repeated value, which would render as an indistinguishable chip", () => {
+      const facets = withFacetValue(
+        [{ field: "name", op: "contains", values: ["nginx"] }],
+        "name",
+        "contains",
+        "nginx",
+      );
+
+      expect(facets).toEqual([{ field: "name", op: "contains", values: ["nginx"] }]);
+    });
+
+    it("keeps other fields as separate facets", () => {
+      const facets = withFacetValue(
+        [{ field: "name", op: "contains", values: ["nginx"] }],
+        "namespace",
+        "contains",
+        "default",
+      );
+
+      expect(facets.map(({ field }) => field)).toEqual(["name", "namespace"]);
+    });
+
+    // Merging them would change what either one means.
+    it("keeps two operators on the same field as separate facets", () => {
+      const facets = withFacetValue(
+        [{ field: "name", op: "contains", values: ["prod"] }],
+        "name",
+        "notContains",
+        "canary",
+      );
+
+      expect(facets).toEqual([
+        { field: "name", op: "contains", values: ["prod"] },
+        { field: "name", op: "notContains", values: ["canary"] },
+      ]);
+    });
+
+    // The linked search carries facets onto views that do not have the field,
+    // where the chip would otherwise fall back to the raw id and read as a bug.
+    it("stores the label the facet was created with", () => {
+      expect(withFacetValue([], "ip", "equals", "10.0.0.1", "IP")).toEqual([
+        { field: "ip", op: "equals", values: ["10.0.0.1"], title: "IP" },
+      ]);
+    });
+
+    it("keeps the stored label when a second value is added without one", () => {
+      const facets = withFacetValue(
+        [{ field: "ip", op: "contains", values: ["10.0.0.1"], title: "IP" }],
+        "ip",
+        "contains",
+        "10.0.0.2",
+      );
+
+      expect(facets).toEqual([{ field: "ip", op: "contains", values: ["10.0.0.1", "10.0.0.2"], title: "IP" }]);
+    });
+
+    it("treats a missing operator as contains when grouping", () => {
+      const facets = withFacetValue([{ field: "name", values: ["nginx"] }], "name", "contains", "redis");
+
+      expect(facets).toEqual([{ field: "name", op: "contains", values: ["nginx", "redis"] }]);
+    });
+  });
+
+  describe("withoutFacet", () => {
+    it("drops the whole facet for a field and operator", () => {
+      const facets: SearchFacet[] = [
+        { field: "name", op: "contains", values: ["nginx", "redis"] },
+        { field: "namespace", op: "contains", values: ["default"] },
+      ];
+
+      expect(withoutFacet(facets, "name", "contains")).toEqual([
+        { field: "namespace", op: "contains", values: ["default"] },
+      ]);
+    });
+
+    it("leaves the other operator on the same field alone", () => {
+      const facets: SearchFacet[] = [
+        { field: "name", op: "contains", values: ["prod"] },
+        { field: "name", op: "notContains", values: ["canary"] },
+      ];
+
+      expect(withoutFacet(facets, "name", "contains")).toEqual([
+        { field: "name", op: "notContains", values: ["canary"] },
+      ]);
+    });
+
+    it("leaves the set alone for a field that has no facet", () => {
+      const facets: SearchFacet[] = [{ field: "name", op: "contains", values: ["nginx"] }];
+
+      expect(withoutFacet(facets, "namespace", "contains")).toEqual(facets);
+    });
+  });
+});

--- a/packages/core/src/renderer/components/input/search-facets.ts
+++ b/packages/core/src/renderer/components/input/search-facets.ts
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { compileSearchRegex } from "./search-regex";
+
+/** Field id standing for "look in every searchable field of the view". */
+export const allFieldsId = "*";
+
+/** A searchable field the box can offer as a facet, without its getter. */
+export interface SearchFieldOption {
+  id: string;
+  title: string;
+}
+
+/**
+ * How a facet compares its values against a field's texts.
+ *
+ * `=~` and `!~` take a regular expression; the rest are literal. `:` is the
+ * substring match a search box wants as its default.
+ */
+export type FacetOperator = "contains" | "equals" | "matches" | "notContains" | "notEquals" | "notMatches";
+
+export const facetOperators: { op: FacetOperator; title: string; symbol: string }[] = [
+  { op: "contains", title: "contains", symbol: ":" },
+  { op: "equals", title: "equals", symbol: "=" },
+  { op: "matches", title: "matches regular expression", symbol: "=~" },
+  { op: "notContains", title: "does not contain", symbol: "!:" },
+  { op: "notEquals", title: "not equals", symbol: "!=" },
+  { op: "notMatches", title: "does not match regular expression", symbol: "!~" },
+];
+
+export const defaultFacetOperator: FacetOperator = "contains";
+
+const operatorTitles = new Map(facetOperators.map(({ op, title }) => [op, title]));
+const operatorSymbols = new Map(facetOperators.map(({ op, symbol }) => [op, symbol]));
+
+const negatedOperators = new Set<FacetOperator>(["notContains", "notEquals", "notMatches"]);
+const exactOperators = new Set<FacetOperator>(["equals", "notEquals"]);
+const regexOperators = new Set<FacetOperator>(["matches", "notMatches"]);
+
+export const facetOperatorTitle = (op: FacetOperator | undefined) =>
+  operatorTitles.get(op ?? defaultFacetOperator) ?? defaultFacetOperator;
+export const facetOperatorSymbol = (op: FacetOperator | undefined) =>
+  operatorSymbols.get(op ?? defaultFacetOperator) ?? ":";
+export const isRegexOperator = (op: FacetOperator | undefined) => regexOperators.has(op ?? defaultFacetOperator);
+
+/**
+ * One committed search facet: the values inside a facet are OR-ed, and separate
+ * facets are AND-ed.
+ *
+ * `op` is frozen when the facet is committed rather than read live, so a chip
+ * keeps meaning what it meant when it was added even after the operator is
+ * changed for the next one. It is optional so facets written by an older build
+ * still parse, defaulting to `contains`.
+ */
+export interface SearchFacet {
+  field: string;
+  values: string[];
+  op?: FacetOperator;
+  /**
+   * Label the facet was created with, used only when the current view does not
+   * know the field - the linked search carries facets across views, and a chip
+   * falling back to its raw id reads as a bug rather than as a deliberate
+   * "not applicable here". A view that does know the field always wins, so a
+   * renamed label never sticks; this is for display only and never filters.
+   */
+  title?: string;
+}
+
+/** A text of a single searchable field, as `ListLayoutSearchFilter` yields it. */
+export type FacetText = string | number | undefined | null;
+
+/**
+ * A facet ready to run against items.
+ *
+ * `test` takes one text at a time rather than a whole array so callers can walk
+ * an item's fields lazily and stop at the first hit. Materialising every text of
+ * every field for every item is what makes a list of a few thousand pods feel
+ * slow on each keystroke.
+ */
+export interface CompiledFacet {
+  test: (text: FacetText) => boolean;
+  /** When set, the facet holds only if *no* text passes `test`. */
+  negated: boolean;
+}
+
+/** Two facets on the same field differ when their operators differ. */
+export const facetKey = (facet: Pick<SearchFacet, "field" | "op">) =>
+  `${facet.field}|${facet.op ?? defaultFacetOperator}`;
+
+const isFacetOperator = (value: unknown): value is FacetOperator =>
+  typeof value === "string" && operatorTitles.has(value as FacetOperator);
+
+/** Reads an operator out of its URL param, falling back to the default. */
+export const parseFacetOperator = (raw: string): FacetOperator => (isFacetOperator(raw) ? raw : defaultFacetOperator);
+
+const isSearchFacet = (value: unknown): value is SearchFacet => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<SearchFacet>;
+
+  return (
+    typeof candidate.field === "string" &&
+    Array.isArray(candidate.values) &&
+    candidate.values.every((entry) => typeof entry === "string") &&
+    (candidate.op === undefined || isFacetOperator(candidate.op)) &&
+    (candidate.title === undefined || typeof candidate.title === "string")
+  );
+};
+
+/**
+ * Reads facets out of their URL param.
+ *
+ * Anything unparseable yields no facets rather than throwing: the param is
+ * user-editable and survives in bookmarks across versions, so a malformed
+ * value must degrade to "no facets", never break the view.
+ */
+export function parseFacets(raw: string): SearchFacet[] {
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .filter(isSearchFacet)
+      .filter((facet) => facet.values.length > 0)
+      .map((facet) => {
+        // Regex used to be a flag beside the operator instead of an operator of
+        // its own. Translate rather than drop it, or a link from that build
+        // would silently start matching literally.
+        const legacyRegex = (facet as { regex?: unknown }).regex === true;
+        const op = facet.op ?? defaultFacetOperator;
+
+        if (!legacyRegex || isRegexOperator(op)) {
+          return { field: facet.field, values: facet.values, op: facet.op, title: facet.title };
+        }
+
+        return {
+          field: facet.field,
+          values: facet.values,
+          op: negatedOperators.has(op) ? ("notMatches" as const) : ("matches" as const),
+          title: facet.title,
+        };
+      });
+  } catch {
+    return [];
+  }
+}
+
+/** Writes facets to their URL param, collapsing an empty set to "". */
+export function serializeFacets(facets: readonly SearchFacet[]): string {
+  const usable = facets.filter((facet) => facet.values.length > 0);
+
+  return usable.length > 0 ? JSON.stringify(usable) : "";
+}
+
+const normalize = (value: FacetText) => String(value).toLowerCase();
+
+/**
+ * Builds the matcher for one facet, compiling any regex exactly once instead of
+ * per item per field.
+ *
+ * Returns undefined when the facet cannot currently match anything meaningful -
+ * no values, or every value is a regex the engine rejects because the user is
+ * still typing it. Callers treat that as "this facet filters nothing", which
+ * keeps the list from blanking mid-keystroke.
+ *
+ * A field the view does not have yields no texts at all, so a positive operator
+ * matches nothing and a negative one matches everything. That falls straight out
+ * of negating the same predicate, and the chip stays visible either way.
+ */
+export function compileFacet(facet: SearchFacet): CompiledFacet | undefined {
+  if (facet.values.length === 0) {
+    return undefined;
+  }
+
+  const op = facet.op ?? defaultFacetOperator;
+  const negated = negatedOperators.has(op);
+
+  if (regexOperators.has(op)) {
+    // Left unanchored: in a search box `=~ ngin` has to find `my-nginx`, and
+    // `^`/`$` are there when anchoring is wanted.
+    const regexes = facet.values.map(compileSearchRegex).filter((regex): regex is RegExp => regex !== undefined);
+
+    if (regexes.length === 0) {
+      return undefined;
+    }
+
+    return {
+      negated,
+      // Absent fields are skipped rather than stringified, so `.` or `un`
+      // cannot match a phantom "undefined". Case is handled by the regex `i`
+      // flag, so the source is left alone - lowercasing would break `[A-Z]`.
+      test: (text) => text != null && regexes.some((regex) => regex.test(String(text))),
+    };
+  }
+
+  const exact = exactOperators.has(op);
+  const needles = facet.values.map(normalize);
+
+  return {
+    negated,
+    test: exact
+      ? (text) => {
+          const normalized = normalize(text);
+
+          return needles.some((needle) => normalized === needle);
+        }
+      : (text) => {
+          const normalized = normalize(text);
+
+          return needles.some((needle) => normalized.includes(needle));
+        },
+  };
+}
+
+/**
+ * Adds a value to the facet for this field and operator, creating it if needed.
+ *
+ * The operator is part of the identity: `Name = x` and `Name != y` are two
+ * chips, because merging them would change what either one means.
+ */
+export function withFacetValue(
+  facets: readonly SearchFacet[],
+  field: string,
+  op: FacetOperator,
+  value: string,
+  title?: string,
+): SearchFacet[] {
+  const key = facetKey({ field, op });
+  const existing = facets.find((facet) => facetKey(facet) === key);
+  const others = facets.filter((facet) => facetKey(facet) !== key);
+
+  // A repeated value would render as a duplicate chip that cannot be told apart
+  // from its twin, and OR-ing a value with itself changes nothing anyway.
+  const values = existing?.values.includes(value) ? existing.values : [...(existing?.values ?? []), value];
+
+  return [...others, { field, op, values, title: title ?? existing?.title }];
+}
+
+/**
+ * Drops one facet.
+ *
+ * A chip carries every value of its facet, so removing it removes the group.
+ */
+export function withoutFacet(facets: readonly SearchFacet[], field: string, op: FacetOperator): SearchFacet[] {
+  const key = facetKey({ field, op });
+
+  return facets.filter((facet) => facetKey(facet) !== key);
+}

--- a/packages/core/src/renderer/components/input/search-input-url.module.scss
+++ b/packages/core/src/renderer/components/input/search-input-url.module.scss
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+// Colours come from the same theme variables the Select menu and the filter
+// area already use, so both themes stay consistent:
+//   panel        --contentColor  + --halfGray border   (Select__menu)
+//   highlight    --colorInfo     + --textColorAccent   (Select option focused)
+//   chip         --filterAreaBackground                (PageFiltersList)
+
+.wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.searchInput {
+  // The chips live inside the field, so it has to be free to grow with them
+  // instead of holding the fixed width a plain search box gets.
+  flex: 1 1 auto;
+  max-width: none;
+}
+
+.facets {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  // Many chips must not push the text cursor out of the field; they scroll.
+  max-width: 60%;
+  overflow-x: auto;
+  // The field is short, so a horizontal scrollbar inside it would eat the text.
+  scrollbar-width: none;
+  // Keeps the caret off the last chip. The label's own gap alone reads as the
+  // text being part of the chip.
+  padding-right: 6px;
+  margin-right: 2px;
+  border-right: 1px solid var(--borderFaintColor);
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.facet {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+  padding: 1px 2px 1px 6px;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--borderFaintColor);
+  background-color: var(--filterAreaBackground);
+  color: var(--textColorPrimary);
+  font-size: smaller;
+  line-height: 1.5;
+  white-space: nowrap;
+  // The chip sits in a <label>, whose default text cursor would suggest the
+  // chip itself is editable.
+  cursor: default;
+}
+
+// A facet whose field this view does not have. Kept visible and removable, but
+// struck through: it is not filtering, and a chip that looks applied when it is
+// not would misrepresent what the list is showing.
+.facetUnavailable {
+  opacity: 0.55;
+
+  // Only the text is struck through. Running the line through the remove icon
+  // as well just looks like a rendering fault, and the icon still works.
+  > span {
+    text-decoration: line-through;
+  }
+}
+
+.facetTitle {
+  color: var(--textColorSecondary);
+}
+
+.facetOperator {
+  font-family: monospace;
+  font-weight: 600;
+  color: var(--textColorAccent);
+}
+
+.facetRegex {
+  font-family: monospace;
+  color: var(--textColorSecondary);
+}
+
+.suggestions {
+  position: absolute;
+  // Sits directly under the input, and above the table rows below it.
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 10;
+  min-width: 300px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 4px 0;
+  border-radius: var(--border-radius);
+  background-color: var(--contentColor);
+  color: var(--textColorPrimary);
+  box-shadow:
+    0 0 0 1px var(--halfGray),
+    0 4px 12px rgb(0 0 0 / 25%);
+}
+
+.operators {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--borderFaintColor);
+}
+
+.operator {
+  min-width: 30px;
+  padding: 2px 6px;
+  border: 1px solid var(--inputControlBorder);
+  border-radius: var(--border-radius);
+  background: none;
+  color: var(--textColorPrimary);
+  font-family: monospace;
+  font-size: smaller;
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--inputControlHoverBorder);
+  }
+}
+
+.operatorActive {
+  border-color: var(--colorInfo);
+  background-color: var(--colorInfo);
+  color: var(--textColorAccent);
+}
+
+.saveButton {
+  flex-shrink: 0;
+  padding: 2px 10px;
+  border: 1px solid var(--inputControlBorder);
+  border-radius: var(--border-radius);
+  background: none;
+  color: var(--textColorPrimary);
+  font-size: smaller;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    border-color: var(--inputControlHoverBorder);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.saveRow {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  padding: 6px 12px;
+  border-top: 1px solid var(--borderFaintColor);
+}
+
+.saveName {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 2px 6px;
+  border: 1px solid var(--inputControlBorder);
+  border-radius: var(--border-radius);
+  background: var(--inputControlBackground);
+  color: var(--textColorPrimary);
+  font-size: smaller;
+
+  &:disabled {
+    opacity: 0.6;
+  }
+}
+
+.suggestion {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover,
+  &.highlighted {
+    background-color: var(--colorInfo);
+    color: var(--textColorAccent);
+  }
+}
+
+.savedSearch {
+  // The name and the bin read as one row, so they line up on their middles
+  // rather than on the baseline the field suggestions use.
+  align-items: center;
+  gap: 12px;
+}
+
+.savedSearchDelete {
+  // Pinned to the right edge whatever the name's length.
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.suggestionField {
+  font-weight: 600;
+}
+
+.suggestionOperator {
+  font-family: monospace;
+}
+
+.suggestionValue {
+  color: var(--textColorSecondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+// Inherit on hover, or the dimmed colours stay unreadable on the highlight.
+.suggestion:hover,
+.suggestion.highlighted {
+  .suggestionValue {
+    color: inherit;
+  }
+}
+
+.hint {
+  padding: 4px 12px;
+  color: var(--textColorTertiary);
+  font-size: smaller;
+  white-space: nowrap;
+}

--- a/packages/core/src/renderer/components/input/search-input-url.tsx
+++ b/packages/core/src/renderer/components/input/search-input-url.tsx
@@ -6,28 +6,66 @@
 
 import { Icon } from "@freelensapp/icon";
 import { storesAndApisCanBeCreatedInjectionToken } from "@freelensapp/kube-api-specifics";
+import { historyInjectionToken } from "@freelensapp/routing";
+import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { debounce } from "es-toolkit/compat";
 import { comparer, makeObservable, observable, reaction } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
 import namespaceStoreInjectable from "../namespaces/store.injectable";
-import persistentSearchStoreInjectable from "./persistent-search-store.injectable";
+import facetsUrlPageParamInjectable from "./facets-url-page-param.injectable";
+import persistentSearchStoreInjectable, { isEmptySearch } from "./persistent-search-store.injectable";
+import { SavedSearchesPanel } from "./saved-searches-panel";
+import savedSearchesStoreInjectable from "./saved-searches-store.injectable";
+import { SearchFacetSuggestions } from "./search-facet-suggestions";
+import {
+  allFieldsId,
+  defaultFacetOperator,
+  facetKey,
+  facetOperatorSymbol,
+  facetOperatorTitle,
+  isRegexOperator,
+  parseFacetOperator,
+  parseFacets,
+  serializeFacets,
+  withFacetValue,
+  withoutFacet,
+} from "./search-facets";
 import { SearchInput } from "./search-input";
+import styles from "./search-input-url.module.scss";
+import searchOperatorUrlPageParamInjectable from "./search-operator-url-page-param.injectable";
+import { compileSearchRegex } from "./search-regex";
 import searchUrlPageParamInjectable from "./search-url-page-param.injectable";
 
+import type { History } from "@freelensapp/routing";
+
+import type { SavedSearch } from "../../../features/user-preferences/common/preferences-helpers";
 import type { PageParam } from "../../navigation/page-param";
 import type { InputProps } from "./input";
+import type { PersistedSearch } from "./persistent-search-store.injectable";
+import type { FacetOperator, SearchFacet, SearchFieldOption } from "./search-facets";
 
 export interface SearchInputUrlProps extends InputProps {
   compact?: boolean; // show only search-icon when not focused
+  /**
+   * Named fields to offer as facets. Empty (the default) keeps the box exactly
+   * as it was before facets existed: plain text over every searchable field.
+   */
+  searchFields?: SearchFieldOption[];
 }
 
 interface Dependencies {
   searchUrlParam: PageParam<string>;
+  facetsUrlParam: PageParam<string>;
+  searchOperatorUrlParam: PageParam<string>;
   persistentSearchStore: ReturnType<typeof persistentSearchStoreInjectable.instantiate>;
+  savedSearchesStore: ReturnType<typeof savedSearchesStoreInjectable.instantiate>;
   namespaceStore?: ReturnType<typeof namespaceStoreInjectable.instantiate>;
+  history: History;
 }
+
+const allFieldsTitle = "All fields";
 
 @observer
 class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & Dependencies> {
@@ -40,9 +78,35 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
 
   readonly updateUrl = debounce((val: string) => this.props.searchUrlParam.set(val), 250);
   readonly updateStorage = debounce((storageKey: string, val: string) => {
-    this.props.persistentSearchStore.setValue(storageKey, val);
+    this.props.persistentSearchStore.setValue(storageKey, { ...this.currentSearchState, search: val });
     this.userTyping = false;
   }, 250);
+
+  /** The three params that together are the current search. */
+  private get currentSearchState(): PersistedSearch {
+    return {
+      search: this.props.searchUrlParam.get(),
+      op: this.props.searchOperatorUrlParam.get(),
+      facets: this.props.facetsUrlParam.get(),
+    };
+  }
+
+  private setSearchState(state: PersistedSearch) {
+    this.props.searchUrlParam.set(state.search);
+    this.props.searchOperatorUrlParam.set(state.op);
+    this.props.facetsUrlParam.set(state.facets);
+  }
+
+  /**
+   * Records the whole search so navigating away and back restores it.
+   *
+   * Called from the discrete actions - committing or removing a chip, picking an
+   * operator, applying a saved search - while typed text goes through the
+   * debounced {@link updateStorage}.
+   */
+  private persistCurrentState() {
+    this.props.persistentSearchStore.setValue(this.getStorageKey(), this.currentSearchState);
+  }
 
   private getCurrentNamespaceKey(): string {
     const { namespaceStore } = this.props;
@@ -73,6 +137,8 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
   componentDidMount(): void {
     const { searchUrlParam, persistentSearchStore, namespaceStore, placeholder } = this.props;
 
+    this.disposers.push(this.listenForClicksOutside());
+
     // Capture props into local closures for the reactions below: mobx-react 9
     // forbids reading this.props inside a derivation, and the reaction data
     // functions call getStorageKey/getCurrentNamespaceKey (which read this.props).
@@ -99,13 +165,14 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
     this.lastNamespaceKey = getCurrentNamespaceKey();
     this.lastPlaceholder = placeholder || "default";
 
-    // On first mount, load the stored value and sync to URL
-    const storageKey = getStorageKey();
-    const storedValue = persistentSearchStore.getValue(storageKey);
+    // On first mount, load the stored search and sync it back to the URL. This
+    // is what survives navigation, since moving to another view pushes a path
+    // with no query at all.
+    const storedValue = persistentSearchStore.getValue(getStorageKey());
 
-    if (storedValue) {
-      this.inputVal = storedValue;
-      searchUrlParam.set(storedValue);
+    if (!isEmptySearch(storedValue)) {
+      this.inputVal = storedValue.search;
+      this.setSearchState(storedValue);
     } else {
       // If no stored value, check URL
       const urlValue = searchUrlParam.get();
@@ -140,14 +207,14 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
 
           // When persistence is enabled, sync to persisted value
           if (isEnabled) {
-            this.inputVal = persistedValue;
-            searchUrlParam.set(persistedValue);
+            this.inputVal = persistedValue.search;
+            this.setSearchState(persistedValue);
           } else {
             // When persistence is disabled
             if (contextChanged) {
               // Load stored value for this specific placeholder+namespace or clear if none
-              this.inputVal = persistedValue;
-              searchUrlParam.set(persistedValue);
+              this.inputVal = persistedValue.search;
+              this.setSearchState(persistedValue);
             } else {
               // When user types in URL or uses browser back/forward, sync from URL
               if (urlValue !== this.inputVal) {
@@ -175,7 +242,7 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
             const persistedValue = persistentSearchStore.getValue(storageKey);
 
             // Always sync to URL, even if empty (to clear filter when switching namespaces)
-            searchUrlParam.set(persistedValue);
+            this.setSearchState(persistedValue);
           }
         },
         { fireImmediately: true, equals: comparer.structural },
@@ -186,6 +253,13 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
   componentWillUnmount(): void {
     this.disposers.forEach((dispose) => dispose());
   }
+
+  // Capture, so a handler that stops propagation cannot leave a panel stuck open.
+  private readonly listenForClicksOutside = () => {
+    window.addEventListener("mousedown", this.onClickOutside, true);
+
+    return () => window.removeEventListener("mousedown", this.onClickOutside, true);
+  };
 
   setValue = (value: string) => {
     const storageKey = this.getStorageKey();
@@ -211,27 +285,334 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
   togglePersistence = (newState: boolean) => {
     const { persistentSearchStore } = this.props;
 
+    // The whole search moves across, chips included: carrying only the text
+    // would turn a faceted search into a bare query on toggling the link.
+    const currentState = this.currentSearchState;
+
     if (newState) {
       // When enabling linking (switching to global shared):
-      // 1. Save current search value to the global key FIRST
+      // 1. Save current search to the global key FIRST
       // 2. Then enable persistence
-      const globalKey = "global:linked";
-      if (this.inputVal) {
-        persistentSearchStore.setValue(globalKey, this.inputVal);
+      if (!isEmptySearch(currentState)) {
+        persistentSearchStore.setValue("global:linked", currentState);
       }
       persistentSearchStore.setEnabled(newState);
     } else {
       // When disabling linking (switching to per-namespace per-placeholder):
       // 1. Disable persistence first
       // 2. Save current value to namespace+placeholder-specific key
-      const currentValue = this.inputVal;
       persistentSearchStore.setEnabled(newState);
-      const newStorageKey = this.getStorageKey(); // This will now be namespace+placeholder-specific
-      if (currentValue) {
-        persistentSearchStore.setValue(newStorageKey, currentValue);
+
+      if (!isEmptySearch(currentState)) {
+        // getStorageKey is namespace+placeholder-specific now
+        persistentSearchStore.setValue(this.getStorageKey(), currentState);
       }
     }
   };
+
+  @observable private highlightedSuggestion = -1;
+
+  /**
+   * Operator applied to the text being typed and to the next facet committed.
+   *
+   * Kept in a URL param rather than component state so `ItemListLayout` can
+   * apply it to the live query: picking `=` has to re-filter immediately, not
+   * wait for a chip. It stays put after a commit, so adding several `!=`
+   * filters in a row does not mean re-picking each time.
+   */
+  private get pendingOperator(): FacetOperator {
+    return parseFacetOperator(this.props.searchOperatorUrlParam.get());
+  }
+
+  private setPendingOperator(op: FacetOperator) {
+    // The default is the empty param, keeping it out of a shared link.
+    this.props.searchOperatorUrlParam.set(op === defaultFacetOperator ? "" : op);
+    this.persistCurrentState();
+  }
+
+  private get facets(): SearchFacet[] {
+    return parseFacets(this.props.facetsUrlParam.get());
+  }
+
+  private setFacets(facets: SearchFacet[]) {
+    this.props.facetsUrlParam.set(serializeFacets(facets));
+    this.persistCurrentState();
+  }
+
+  @observable private savedSearchesOpen = false;
+  @observable private newSearchName = "";
+
+  private readonly wrapperRef = React.createRef<HTMLDivElement>();
+
+  /**
+   * Closes whichever panel is open when the click lands outside the box.
+   *
+   * Clicking away confirms the query being typed rather than discarding it: it
+   * becomes an "All fields" chip carrying the armed operator, so the work of
+   * typing and picking an operator is not lost to a stray click.
+   */
+  private onClickOutside = (evt: MouseEvent) => {
+    const wrapper = this.wrapperRef.current;
+
+    if (!wrapper || wrapper.contains(evt.target as Node)) {
+      return;
+    }
+
+    this.savedSearchesOpen = false;
+
+    if (this.suggestions.length > 0) {
+      this.commitFacet(allFieldsId);
+    }
+  };
+
+  /** Route the saved searches of this box belong to. */
+  private get view(): string {
+    return this.props.history.location.pathname;
+  }
+
+  private get hasSomethingToSave(): boolean {
+    const { search, facets } = this.currentSearchState;
+
+    // The operator alone filters nothing, so it is not worth a saved entry.
+    return search !== "" || facets !== "";
+  }
+
+  private applySavedSearch = (saved: SavedSearch) => {
+    const { search, op, facets } = saved;
+
+    // Cancel first: a pending debounce from the text being typed would land
+    // after this and overwrite the search that was just applied.
+    this.updateUrl.cancel();
+    this.updateStorage.cancel();
+    this.userTyping = false;
+
+    this.setSearchState({ search, op, facets });
+
+    // The box shows committed state as chips, so the draft text is whatever the
+    // saved "all fields" query was.
+    this.inputVal = search;
+
+    // Persisted too, or navigating away and back would lose it: moving to
+    // another view pushes a path with no query.
+    this.persistCurrentState();
+    this.savedSearchesOpen = false;
+  };
+
+  private saveCurrentSearch = () => {
+    const name = this.newSearchName.trim();
+
+    if (!name || !this.hasSomethingToSave) {
+      return;
+    }
+
+    // Flush first: the typed text only reaches the URL after a debounce, and
+    // saving mid-debounce would store the previous query.
+    this.updateUrl.flush();
+    this.props.savedSearchesStore.save(this.view, name, this.currentSearchState);
+    this.newSearchName = "";
+  };
+
+  private titleForField(field: string): string | undefined {
+    if (field === allFieldsId) {
+      return allFieldsTitle;
+    }
+
+    return this.props.searchFields?.find(({ id }) => id === field)?.title;
+  }
+
+  /**
+   * How a chip names its field.
+   *
+   * This view's own label wins, so renaming one takes effect everywhere. The
+   * label frozen into the facet only covers the fields this view does not have,
+   * which the linked search brings in from elsewhere; the raw id is the last
+   * resort, for a facet hand-written into the URL.
+   */
+  private titleForFacet(facet: SearchFacet): string {
+    return this.titleForField(facet.field) ?? facet.title ?? facet.field;
+  }
+
+  /**
+   * Whether the facet's field is searchable in this view.
+   *
+   * Mirrors the rule `ItemListLayout` filters by, off the same field list, so a
+   * chip is struck through exactly when it is being skipped.
+   */
+  private isFieldAvailable(field: string): boolean {
+    return field === allFieldsId || (this.props.searchFields ?? []).some(({ id }) => id === field);
+  }
+
+  /** The fields offered for the text being typed: every named one, plus "all". */
+  private get suggestions(): SearchFieldOption[] {
+    const { searchFields = [] } = this.props;
+
+    if (searchFields.length === 0 || this.inputVal.trim() === "") {
+      return [];
+    }
+
+    return [{ id: allFieldsId, title: allFieldsTitle }, ...searchFields];
+  }
+
+  private commitFacet = (field: string) => {
+    const value = this.inputVal.trim();
+
+    if (!value) {
+      return;
+    }
+
+    // The label travels with the facet so it still reads properly on a view that
+    // does not have this field.
+    this.setFacets(withFacetValue(this.facets, field, this.pendingOperator, value, this.titleForField(field)));
+
+    // The text has become a chip, so the live "all fields" query that was
+    // filtering while it was typed has to go, or it would AND on top of itself.
+    this.clear();
+    this.highlightedSuggestion = -1;
+  };
+
+  private removeFacet = (facet: SearchFacet) => {
+    this.setFacets(withoutFacet(this.facets, facet.field, facet.op ?? defaultFacetOperator));
+  };
+
+  private onSearchKeyDown = (evt: React.KeyboardEvent<any>) => {
+    const { suggestions } = this;
+
+    if (evt.key === "Backspace" && this.inputVal === "") {
+      const last = this.facets.at(-1);
+
+      if (last) {
+        this.removeFacet(last);
+        evt.preventDefault();
+      }
+
+      return;
+    }
+
+    if (suggestions.length === 0) {
+      return;
+    }
+
+    switch (evt.key) {
+      case "ArrowDown":
+        this.highlightedSuggestion = (this.highlightedSuggestion + 1) % suggestions.length;
+        evt.preventDefault();
+        break;
+
+      case "ArrowUp":
+        this.highlightedSuggestion =
+          this.highlightedSuggestion <= 0 ? suggestions.length - 1 : this.highlightedSuggestion - 1;
+        evt.preventDefault();
+        break;
+
+      case "Enter": {
+        // Without a pick, Enter is left alone: the text is already filtering
+        // every field live, which is what it did before facets existed.
+        const chosen = suggestions[this.highlightedSuggestion];
+
+        if (chosen) {
+          this.commitFacet(chosen.id);
+          evt.preventDefault();
+        }
+        break;
+      }
+
+      case "Escape":
+        // Collapse the list first; a second Escape reaches SearchInput and
+        // clears the text, which is the pre-existing behaviour.
+        if (this.highlightedSuggestion !== -1) {
+          this.highlightedSuggestion = -1;
+          evt.stopPropagation();
+        }
+        break;
+    }
+  };
+
+  private renderFacets() {
+    const { facets } = this;
+
+    if (facets.length === 0) {
+      return null;
+    }
+
+    return (
+      <div className={styles.facets}>
+        {facets.map((facet) => {
+          const title = this.titleForFacet(facet);
+          const description = `${title} ${facetOperatorTitle(facet.op)} ${facet.values.join(" or ")}`;
+          const available = this.isFieldAvailable(facet.field);
+
+          return (
+            <div
+              key={facetKey(facet)}
+              className={cssNames(styles.facet, { [styles.facetUnavailable]: !available })}
+              title={
+                available ? description : `${description} - this view has no ${title} field, so it is not applied here`
+              }
+              data-testid={`search-facet-${facet.field}`}
+            >
+              <span className={styles.facetTitle}>{title}</span>
+              <span className={styles.facetOperator}>{facetOperatorSymbol(facet.op)}</span>
+              <span>{facet.values.join(" or ")}</span>
+              <Icon
+                smallest
+                material="close"
+                // The chip sits inside the field's <label>, so a bare click
+                // would also be a click on the label. Stop it there.
+                onClick={(evt) => {
+                  evt.preventDefault();
+                  evt.stopPropagation();
+                  this.removeFacet(facet);
+                }}
+                tooltip={`Remove filter: ${description}`}
+              />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  private renderSavedSearches() {
+    if (!this.savedSearchesOpen) {
+      return null;
+    }
+
+    return (
+      <SavedSearchesPanel
+        searches={this.props.savedSearchesStore.forView(this.view)}
+        canSave={this.hasSomethingToSave}
+        newName={this.newSearchName}
+        onNewNameChange={(name) => {
+          this.newSearchName = name;
+        }}
+        onSave={this.saveCurrentSearch}
+        onApply={this.applySavedSearch}
+        onDelete={(name) => this.props.savedSearchesStore.remove(this.view, name)}
+      />
+    );
+  }
+
+  private renderSuggestions() {
+    const { suggestions } = this;
+
+    if (suggestions.length === 0) {
+      return null;
+    }
+
+    return (
+      <SearchFacetSuggestions
+        options={suggestions}
+        value={this.inputVal.trim()}
+        operator={this.pendingOperator}
+        onPickOperator={(op) => this.setPendingOperator(op)}
+        highlighted={this.highlightedSuggestion}
+        onHighlight={(index) => {
+          this.highlightedSuggestion = index;
+        }}
+        onPick={this.commitFacet}
+      />
+    );
+  }
 
   constructor(props: SearchInputUrlProps & Dependencies) {
     super(props);
@@ -239,10 +620,28 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
   }
 
   render() {
-    const { searchUrlParam, persistentSearchStore, namespaceStore, ...searchInputProps } = this.props;
+    // Every injected dependency has to be pulled out here: whatever is left in
+    // `searchInputProps` is spread onto `Input` and reaches the DOM element, so
+    // a missed one is rendered as an `[object Object]` attribute.
+    const {
+      searchUrlParam,
+      facetsUrlParam,
+      searchOperatorUrlParam,
+      persistentSearchStore,
+      savedSearchesStore,
+      namespaceStore,
+      history,
+      searchFields,
+      ...searchInputProps
+    } = this.props;
+
+    // Only flag a pattern the engine rejects, and only while a regex operator
+    // is armed. A valid pattern matching nothing is a normal empty result.
+    const hasInvalidRegex =
+      isRegexOperator(this.pendingOperator) && this.inputVal !== "" && compileSearchRegex(this.inputVal) === undefined;
 
     return (
-      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+      <div className={styles.wrapper} ref={this.wrapperRef}>
         <SearchInput
           value={this.inputVal}
           onChange={(val, event) => {
@@ -251,6 +650,24 @@ class NonInjectedSearchInputUrl extends React.Component<SearchInputUrlProps & De
           }}
           onClear={this.clear}
           {...searchInputProps}
+          onKeyDown={this.onSearchKeyDown}
+          // Rendered inside the field's own <label>, so the chips read as part
+          // of the search box rather than as controls sitting next to it.
+          contentLeft={this.renderFacets()}
+          className={cssNames(searchInputProps.className, styles.searchInput, {
+            invalidRegex: hasInvalidRegex,
+          })}
+        />
+        {this.renderSuggestions()}
+        {this.renderSavedSearches()}
+        <Icon
+          small
+          material={this.savedSearchesOpen ? "bookmark" : "bookmark_border"}
+          active={this.savedSearchesOpen}
+          onClick={() => {
+            this.savedSearchesOpen = !this.savedSearchesOpen;
+          }}
+          tooltip="Saved searches"
         />
         <Icon
           small
@@ -270,6 +687,10 @@ export const SearchInputUrl = withInjectables<Dependencies, SearchInputUrlProps>
     return {
       ...props,
       searchUrlParam: di.inject(searchUrlPageParamInjectable),
+      facetsUrlParam: di.inject(facetsUrlPageParamInjectable),
+      searchOperatorUrlParam: di.inject(searchOperatorUrlPageParamInjectable),
+      savedSearchesStore: di.inject(savedSearchesStoreInjectable),
+      history: di.inject(historyInjectionToken),
       persistentSearchStore: di.inject(persistentSearchStoreInjectable),
       namespaceStore: canCreateStores ? di.inject(namespaceStoreInjectable) : undefined,
     };

--- a/packages/core/src/renderer/components/input/search-input.scss
+++ b/packages/core/src/renderer/components/input/search-input.scss
@@ -25,6 +25,12 @@
     }
   }
 
+  // Set while the typed regular expression is still incomplete, so the list is
+  // showing everything rather than the pattern's matches.
+  &.invalidRegex > label {
+    box-shadow: 0 0 0 1px var(--colorError);
+  }
+
   &.compact {
     min-width: 0;
 

--- a/packages/core/src/renderer/components/input/search-operator-url-page-param.injectable.ts
+++ b/packages/core/src/renderer/components/input/search-operator-url-page-param.injectable.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getInjectable } from "@ogre-tools/injectable";
+import createPageParamInjectable from "../../navigation/create-page-param.injectable";
+
+/**
+ * The operator applied to the text still being typed in the search box, and to
+ * the next facet committed from it.
+ *
+ * It lives in the URL beside `search` rather than in component state because
+ * both the box and `ItemListLayout` need it, and because a shared link carrying
+ * `search` without its operator would mean something different to whoever
+ * opens it.
+ */
+const searchOperatorUrlPageParamInjectable = getInjectable({
+  id: "search-operator-url-page-param",
+  instantiate: (di) => {
+    const createPageParam = di.inject(createPageParamInjectable);
+
+    return createPageParam({
+      name: "searchOp",
+      defaultValue: "",
+    });
+  },
+});
+
+export default searchOperatorUrlPageParamInjectable;

--- a/packages/core/src/renderer/components/input/search-regex.test.ts
+++ b/packages/core/src/renderer/components/input/search-regex.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { compileSearchRegex } from "./search-regex";
+
+describe("compileSearchRegex", () => {
+  it("compiles a plain pattern", () => {
+    expect(compileSearchRegex("nginx")?.test("my-nginx-pod")).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(compileSearchRegex("NGINX")?.test("my-nginx-pod")).toBe(true);
+  });
+
+  it("keeps character classes usable, which a lowercased source would break", () => {
+    expect(compileSearchRegex("[A-Z]")?.test("Nginx")).toBe(true);
+    expect(compileSearchRegex("^kube-[a-z]+$")?.test("kube-system")).toBe(true);
+    expect(compileSearchRegex("^kube-[a-z]+$")?.test("kube-system-2")).toBe(false);
+  });
+
+  it("supports alternation and anchors", () => {
+    const regex = compileSearchRegex("^(prod|staging)-");
+
+    expect(regex?.test("prod-api")).toBe(true);
+    expect(regex?.test("staging-api")).toBe(true);
+    expect(regex?.test("dev-api")).toBe(false);
+  });
+
+  it("returns undefined for a pattern the engine rejects", () => {
+    expect(compileSearchRegex("(")).toBeUndefined();
+    expect(compileSearchRegex("[a-")).toBeUndefined();
+    expect(compileSearchRegex("a{2,1}")).toBeUndefined();
+  });
+
+  it("returns undefined for every prefix of a pattern that is still being typed", () => {
+    const target = "^(prod|staging)-";
+    const prefixes = Array.from({ length: target.length }, (_, i) => target.slice(0, i + 1));
+    const rejected = prefixes.filter((prefix) => compileSearchRegex(prefix) === undefined);
+
+    // The point is not the exact count but that rejection is routine mid-typing,
+    // so callers must never treat it as an error state.
+    expect(rejected.length).toBeGreaterThan(0);
+    expect(compileSearchRegex(target)).toBeInstanceOf(RegExp);
+  });
+
+  it("is not global, so repeated test() calls do not skip matches", () => {
+    const regex = compileSearchRegex("pod");
+
+    expect(regex?.global).toBe(false);
+    expect(regex?.test("pod-a")).toBe(true);
+    expect(regex?.test("pod-b")).toBe(true);
+    expect(regex?.test("pod-c")).toBe(true);
+  });
+});

--- a/packages/core/src/renderer/components/input/search-regex.ts
+++ b/packages/core/src/renderer/components/input/search-regex.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+/**
+ * Compiles a search query into a case-insensitive regular expression.
+ *
+ * Returns undefined for a pattern the engine rejects. That is not an edge case:
+ * it happens on almost every keystroke while the user types a real pattern
+ * ("(", "(fo", "[a-"), so callers treat it as "no usable filter yet" rather
+ * than as an error.
+ *
+ * The `g` flag is deliberately omitted. `RegExp.test` advances `lastIndex` on a
+ * global regex, so reusing one instance across a list of items would skip
+ * roughly every other match.
+ */
+export function compileSearchRegex(query: string): RegExp | undefined {
+  try {
+    return new RegExp(query, "i");
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/renderer/components/item-object-list/header.tsx
+++ b/packages/core/src/renderer/components/item-object-list/header.tsx
@@ -14,7 +14,13 @@ import { SearchInputUrl } from "../input";
 import type { ItemObject } from "@freelensapp/list-layout";
 import type { IClassName, StrictReactNode } from "@freelensapp/utilities";
 
-import type { HeaderCustomizer, HeaderPlaceholders, ItemListStore, ListLayoutSearchFilter } from "./list-layout";
+import type {
+  HeaderCustomizer,
+  HeaderPlaceholders,
+  ItemListStore,
+  ListLayoutSearchFilter,
+  NamedSearchFilter,
+} from "./list-layout";
 import type { Filter } from "./page-filters/store";
 
 export interface ItemListLayoutHeaderProps<I extends ItemObject, PreLoadStores extends boolean> {
@@ -24,6 +30,9 @@ export interface ItemListLayoutHeaderProps<I extends ItemObject, PreLoadStores e
 
   store: ItemListStore<I, PreLoadStores>;
   searchFilters?: ListLayoutSearchFilter<I>[];
+  searchFields?: NamedSearchFilter<I>[];
+  /** Facets are not `Filter`s, so the info line has to be told about them. */
+  getFacetCount?: () => number;
 
   // header (title, filtering, searching, etc.)
   showHeader?: boolean;
@@ -43,6 +52,8 @@ export class ItemListLayoutHeader<I extends ItemObject, PreLoadStores extends bo
       renderHeaderTitle,
       headerClassName,
       searchFilters = [],
+      searchFields = [],
+      getFacetCount,
       getItems,
       store,
       getFilters,
@@ -57,7 +68,7 @@ export class ItemListLayoutHeader<I extends ItemObject, PreLoadStores extends bo
       const allItemsCount = store.getTotalCount();
       const itemsCount = getItems().length;
 
-      if (getFilters().length > 0) {
+      if (getFilters().length > 0 || (getFacetCount?.() ?? 0) > 0) {
         return (
           <>
             <a onClick={toggleFilters}>Filtered</a>
@@ -86,7 +97,12 @@ export class ItemListLayoutHeader<I extends ItemObject, PreLoadStores extends bo
         {title}
         {info && <div className="info-panel grow shrink-0 basis-0">{info}</div>}
         {filters}
-        {searchFilters.length > 0 && searchProps && <SearchInputUrl {...searchProps} />}
+        {(searchFilters.length > 0 || searchFields.length > 0) && searchProps && (
+          <SearchInputUrl
+            {...searchProps}
+            searchFields={searchFields.filter(({ hidden }) => !hidden).map(({ id, title }) => ({ id, title }))}
+          />
+        )}
       </div>
     );
   }

--- a/packages/core/src/renderer/components/item-object-list/list-layout.tsx
+++ b/packages/core/src/renderer/components/item-object-list/list-layout.tsx
@@ -6,7 +6,7 @@
 
 import "./item-list-layout.scss";
 
-import { cssNames, noop } from "@freelensapp/utilities";
+import { cssNames, isDefined, noop } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import autoBindReact from "auto-bind/react";
 import { groupBy } from "es-toolkit";
@@ -17,6 +17,9 @@ import selectedFilterNamespacesInjectable from "../../../common/k8s-api/selected
 import userPreferencesStateInjectable, {
   type UserPreferencesState,
 } from "../../../features/user-preferences/common/state.injectable";
+import facetsUrlPageParamInjectable from "../input/facets-url-page-param.injectable";
+import { allFieldsId, compileFacet, parseFacetOperator, parseFacets } from "../input/search-facets";
+import searchOperatorUrlPageParamInjectable from "../input/search-operator-url-page-param.injectable";
 import { ItemListLayoutContent } from "./content";
 import { ItemListLayoutFilters } from "./filters";
 import { ItemListLayoutHeader } from "./header";
@@ -29,13 +32,14 @@ import type { ItemObject, TableCellProps } from "@freelensapp/list-layout";
 import type { IClassName, SingleOrMany, StrictReactNode } from "@freelensapp/utilities";
 
 import type { IComputedValue } from "mobx";
-import type { Primitive } from "type-fest";
 
 import type { SubscribableStore } from "../../kube-watch-api/kube-watch-api";
+import type { PageParam } from "../../navigation/page-param";
 import type { StorageLayer } from "../../utils/storage-helper";
 import type { AddRemoveButtonsProps } from "../add-remove-buttons";
 import type { ConfirmDialogParams } from "../confirm-dialog";
 import type { SearchInputUrlProps } from "../input";
+import type { CompiledFacet, SearchFacet } from "../input/search-facets";
 import type { TableProps, TableRowProps, TableSortCallbacks } from "../table";
 import type { PageFiltersStore } from "./page-filters/store";
 
@@ -43,6 +47,29 @@ export type ListLayoutSearchFilter<I extends ItemObject> = (
   item: I,
 ) => SingleOrMany<string | number | undefined | null>;
 export type ListLayoutSearchFilters<I extends ItemObject> = Record<string, ListLayoutSearchFilter<I>>;
+
+/**
+ * A searchable field a view exposes by name, so the search box can offer it as
+ * a facet to combine with others.
+ *
+ * Views that declare only the anonymous {@link ItemListLayoutProps.searchFilters}
+ * keep working unchanged - they simply offer nothing but "All fields".
+ */
+export interface NamedSearchFilter<I extends ItemObject> {
+  /** Stable id; it travels in the URL, so renaming it invalidates saved links. */
+  id: string;
+  /** Label shown in the facet dropdown and on the chip. */
+  title: string;
+  getValue: ListLayoutSearchFilter<I>;
+  /**
+   * Searched by "All fields" but not offered as a facet of its own.
+   *
+   * For fields nobody filters on deliberately, like a uid: dropping them would
+   * silently narrow what a plain query finds, and listing them would clutter
+   * the dropdown.
+   */
+  hidden?: boolean;
+}
 export type ListLayoutItemsFilter<I extends ItemObject> = (items: I[]) => I[];
 export type ListLayoutItemsFilters<I extends ItemObject> = Record<string, ListLayoutItemsFilter<I>>;
 
@@ -51,10 +78,6 @@ export interface HeaderPlaceholders {
   searchProps?: SearchInputUrlProps;
   filters?: StrictReactNode;
   info?: StrictReactNode;
-}
-
-function normalizeText(value: Primitive) {
-  return String(value).toLowerCase();
 }
 
 export type ItemListStore<I extends ItemObject, PreLoadStores extends boolean> = {
@@ -100,6 +123,12 @@ export type ItemListLayoutProps<Item extends ItemObject, PreLoadStores extends b
   preloadStores?: boolean;
   hideFilters?: boolean;
   searchFilters?: ListLayoutSearchFilter<Item>[];
+  /**
+   * Named searchable fields, offered individually in the search box so they can
+   * be combined as facets. When given, these also back the "All fields" facet,
+   * making {@link searchFilters} redundant for the view.
+   */
+  searchFields?: NamedSearchFilter<Item>[];
   filterItems?: ListLayoutItemsFilter<Item>[];
 
   // header (title, filtering, searching, etc.)
@@ -159,6 +188,7 @@ const defaultProps: Partial<ItemListLayoutProps<ItemObject, true>> = {
   preloadStores: true,
   dependentStores: [],
   searchFilters: [],
+  searchFields: [],
   customizeHeader: [],
   filterItems: [],
   hasDetailsView: true,
@@ -177,6 +207,8 @@ interface Dependencies {
   itemListLayoutStorage: StorageLayer<ItemListLayoutStorage>;
   pageFiltersStore: PageFiltersStore;
   userPreferencesState: UserPreferencesState;
+  facetsUrlParam: PageParam<string>;
+  searchOperatorUrlParam: PageParam<string>;
 }
 
 @observer
@@ -238,9 +270,13 @@ class NonInjectedItemListLayout<I extends ItemObject, PreLoadStores extends bool
   // reactions. observableProps keeps the reads reactive across those boundaries.
   get filters() {
     let { activeFilters } = this.observableProps.pageFiltersStore;
-    const { searchFilters = [] } = this.observableProps;
+    const { searchFilters = [], searchFields = [] } = this.observableProps;
 
-    if (searchFilters.length === 0) {
+    // A view with nothing searchable must not carry a search filter left over
+    // from another view. `searchFields` counts too: a fully migrated view
+    // declares only those, and dropping the filter would leave its search box
+    // typing into the void.
+    if (searchFilters.length === 0 && searchFields.length === 0) {
       activeFilters = activeFilters.filter(({ type }) => type !== FilterType.SEARCH);
     }
 
@@ -266,26 +302,131 @@ class NonInjectedItemListLayout<I extends ItemObject, PreLoadStores extends bool
     return <PageFiltersList filters={filters} />;
   }
 
+  /**
+   * The getters one facet reads: a single named field, or every searchable field
+   * of the view for {@link allFieldsId}.
+   *
+   * Resolved once per filter pass, never per item - `searchFields.map(...)` in
+   * the item loop allocates an array for every row on every keystroke.
+   */
+  private gettersFor(field: string): ListLayoutSearchFilter<I>[] {
+    const { searchFields = [], searchFilters = [] } = this.observableProps;
+
+    if (field === allFieldsId) {
+      // A view that names its fields is expected to name all of them, `hidden`
+      // included; unioning both sources instead would compute every shared
+      // field twice per item, and `getSearchFields()` re-stringifies labels.
+      return searchFields.length > 0 ? searchFields.map(({ getValue }) => getValue) : searchFilters;
+    }
+
+    const named = searchFields.find((candidate) => candidate.id === field);
+
+    return named ? [named.getValue] : [];
+  }
+
+  /**
+   * Whether a facet's field is searchable here.
+   *
+   * A search carried in from another view - the linked search does exactly that
+   * - can name a field this one does not have. Such a facet is skipped rather
+   * than applied: with no texts to read, a positive operator would empty the
+   * list and a negative one would filter nothing, so the same chip would either
+   * look broken or lie about being applied depending on its operator. The chip
+   * is shown struck through instead, and is kept so it applies again on a view
+   * that does have the field.
+   */
+  private isFieldAvailable(field: string): boolean {
+    const { searchFields = [] } = this.observableProps;
+
+    return field === allFieldsId || searchFields.some((candidate) => candidate.id === field);
+  }
+
+  /** Facets that actually filter here. */
+  private get applicableFacets(): SearchFacet[] {
+    return parseFacets(this.observableProps.facetsUrlParam.get()).filter((facet) => this.isFieldAvailable(facet.field));
+  }
+
+  /**
+   * Whether any text of any of these getters satisfies the facet.
+   *
+   * Walks the fields one text at a time and returns on the first hit, so a match
+   * on the name never costs the work of stringifying labels.
+   */
+  private anyTextMatches(item: I, getters: ListLayoutSearchFilter<I>[], compiled: CompiledFacet): boolean {
+    for (const getTexts of getters) {
+      const value = getTexts(item);
+
+      if (Array.isArray(value)) {
+        for (const text of value) {
+          if (compiled.test(text)) {
+            return true;
+          }
+        }
+      } else if (compiled.test(value)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private matches(item: I, getters: ListLayoutSearchFilter<I>[], compiled: CompiledFacet): boolean {
+    const found = this.anyTextMatches(item, getters, compiled);
+
+    return compiled.negated ? !found : found;
+  }
+
   private filterCallbacks: ListLayoutItemsFilters<I> = {
     [FilterType.SEARCH]: (items) => {
-      const { searchFilters = [] } = this.observableProps;
+      const { searchFilters = [], searchFields = [] } = this.observableProps;
       const search = this.observableProps.pageFiltersStore.getValues(FilterType.SEARCH)[0] || "";
 
-      if (search && searchFilters.length) {
-        const searchTexts = [search].map(normalizeText);
-
-        return items.filter((item) =>
-          searchFilters.some((getTexts) =>
-            [getTexts(item)]
-              .flat()
-              .map(normalizeText)
-              .some((source) => searchTexts.some((search) => source.includes(search))),
-          ),
-        );
+      if (!search || (searchFilters.length === 0 && searchFields.length === 0)) {
+        return items;
       }
 
-      return items;
+      // The plain search box is the "all fields" facet carrying whichever
+      // operator the box has armed, matched by the same code as the committed
+      // chips. Reading the operator here is what makes picking `=~` re-filter
+      // straight away instead of only once a chip is committed.
+      const compiled = compileFacet({
+        field: allFieldsId,
+        values: [search],
+        op: parseFacetOperator(this.observableProps.searchOperatorUrlParam.get()),
+      });
+
+      if (!compiled) {
+        return items;
+      }
+
+      const getters = this.gettersFor(allFieldsId);
+
+      return items.filter((item) => this.matches(item, getters, compiled));
     },
+  };
+
+  /** AND across facets, OR within each. */
+  private filterByFacets = (items: I[]): I[] => {
+    const facets = this.applicableFacets;
+
+    if (facets.length === 0) {
+      return items;
+    }
+
+    // Compiled and resolved per facet, outside the item loop.
+    const matchers = facets
+      .map((facet) => {
+        const compiled = compileFacet(facet);
+
+        return compiled ? { getters: this.gettersFor(facet.field), compiled } : undefined;
+      })
+      .filter(isDefined);
+
+    if (matchers.length === 0) {
+      return items;
+    }
+
+    return items.filter((item) => matchers.every(({ getters, compiled }) => this.matches(item, getters, compiled)));
   };
 
   get items() {
@@ -302,7 +443,9 @@ class NonInjectedItemListLayout<I extends ItemObject, PreLoadStores extends bool
 
     const items = this.observableProps.getItems();
 
-    return applyFilters(filterItems.concat(this.observableProps.filterItems ?? []), items);
+    // Facets are not driven by `pageFiltersStore`, so their filter is always in
+    // the chain; it returns the list untouched when no chips are set.
+    return applyFilters(filterItems.concat(this.filterByFacets, this.observableProps.filterItems ?? []), items);
   }
 
   render() {
@@ -316,6 +459,13 @@ class NonInjectedItemListLayout<I extends ItemObject, PreLoadStores extends bool
           toggleFilters={this.toggleFilters}
           store={this.props.store}
           searchFilters={this.props.searchFilters}
+          searchFields={this.props.searchFields}
+          // Only the applicable ones: a skipped facet is not narrowing the list,
+          // so counting it would report the view as filtered when it is not.
+          //
+          // observableProps, not this.props: the header calls this from inside
+          // its own render reaction, where mobx-react 9 forbids reading props.
+          getFacetCount={() => this.applicableFacets.length}
           showHeader={this.props.showHeader}
           headerClassName={this.props.headerClassName}
           renderHeaderTitle={
@@ -372,6 +522,8 @@ export const ItemListLayout = withInjectables<Dependencies, ItemListLayoutProps<
       itemListLayoutStorage: di.inject(itemListLayoutStorageInjectable),
       pageFiltersStore: di.inject(pageFiltersStoreInjectable),
       userPreferencesState: di.inject(userPreferencesStateInjectable),
+      facetsUrlParam: di.inject(facetsUrlPageParamInjectable),
+      searchOperatorUrlParam: di.inject(searchOperatorUrlPageParamInjectable),
     }),
   },
 ) as <I extends ItemObject, PreLoadStores extends boolean = true>(

--- a/packages/core/src/renderer/components/item-object-list/search-facets-filtering.test.tsx
+++ b/packages/core/src/renderer/components/item-object-list/search-facets-filtering.test.tsx
@@ -1,0 +1,362 @@
+/**
+ * Copyright (c) Freelens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import "@testing-library/jest-dom/vitest";
+
+import directoryForUserDataInjectable from "../../../common/app-paths/directory-for-user-data/directory-for-user-data.injectable";
+import { getDiForUnitTesting } from "../../getDiForUnitTesting";
+import facetsUrlPageParamInjectable from "../input/facets-url-page-param.injectable";
+import { serializeFacets } from "../input/search-facets";
+import searchOperatorUrlPageParamInjectable from "../input/search-operator-url-page-param.injectable";
+import searchUrlPageParamInjectable from "../input/search-url-page-param.injectable";
+import { renderFor } from "../test-utils/renderFor";
+import { ItemListLayout } from "./list-layout";
+
+import type { ItemObject } from "@freelensapp/list-layout";
+
+import type { DiContainer } from "@ogre-tools/injectable";
+
+import type { FacetOperator, SearchFacet } from "../input/search-facets";
+
+interface TestItem extends ItemObject {
+  namespace: string;
+  status: string;
+  labels: string[];
+}
+
+const item = (name: string, namespace: string, status: string, labels: string[]): TestItem => ({
+  getId: () => name,
+  getName: () => name,
+  namespace,
+  status,
+  labels,
+});
+
+const items = [
+  item("prod-api-7d9f", "default", "Running", ["app=api"]),
+  item("prod-web-2b1c", "kube-system", "Running", ["app=web"]),
+  item("staging-api-4a8e", "default", "Pending", ["app=api"]),
+  item("dev-worker-1f2a", "kube-system", "Failed", ["app=worker"]),
+];
+
+const store = {
+  isLoaded: true,
+  failedLoading: false,
+  getTotalCount: () => items.length,
+  isSelected: () => false,
+  toggleSelection: () => {},
+  isSelectedAll: () => false,
+  toggleSelectionAll: () => {},
+  pickOnlySelected: () => [],
+  removeSelectedItems: async () => {},
+  loadAll: async () => {},
+};
+
+describe("filtering by search facets", () => {
+  let di: DiContainer;
+  let render: ReturnType<typeof renderFor>;
+
+  beforeEach(() => {
+    di = getDiForUnitTesting();
+    di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
+    render = renderFor(di);
+  });
+
+  const setFacets = (facets: SearchFacet[]) => di.inject(facetsUrlPageParamInjectable).set(serializeFacets(facets));
+  const setSearch = (query: string) => di.inject(searchUrlPageParamInjectable).set(query);
+  const setSearchOperator = (op: FacetOperator) => di.inject(searchOperatorUrlPageParamInjectable).set(op);
+
+  const renderList = () =>
+    render(
+      <ItemListLayout<TestItem, false>
+        className="TestItems"
+        store={store}
+        getItems={() => items}
+        preloadStores={false}
+        virtual={false}
+        renderHeaderTitle="Test items"
+        searchFields={[
+          { id: "name", title: "Name", getValue: (i) => i.getName() },
+          { id: "namespace", title: "Namespace", getValue: (i) => i.namespace },
+          { id: "status", title: "Status", getValue: (i) => i.status },
+          { id: "labels", title: "Labels", getValue: (i) => i.labels },
+        ]}
+        renderTableContents={(i) => [i.getName()]}
+      />,
+    );
+
+  const visibleNames = (container: HTMLElement) =>
+    items.map((i) => i.getName()).filter((name) => container.textContent?.includes(name));
+
+  it("shows everything when no facet is set", () => {
+    const { baseElement } = renderList();
+
+    expect(visibleNames(baseElement)).toEqual(items.map((i) => i.getName()));
+  });
+
+  it("restricts a facet to its own field", () => {
+    // "default" is a namespace, never part of a name, so a Name facet must miss.
+    setFacets([{ field: "name", values: ["default"] }]);
+
+    const { baseElement } = renderList();
+
+    expect(visibleNames(baseElement)).toEqual([]);
+  });
+
+  it("matches within the named field", () => {
+    setFacets([{ field: "namespace", values: ["default"] }]);
+
+    const { baseElement } = renderList();
+
+    expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f", "staging-api-4a8e"]);
+  });
+
+  it("ORs several values inside one facet", () => {
+    setFacets([{ field: "status", values: ["Pending", "Failed"] }]);
+
+    const { baseElement } = renderList();
+
+    expect(visibleNames(baseElement)).toEqual(["staging-api-4a8e", "dev-worker-1f2a"]);
+  });
+
+  it("ANDs separate facets", () => {
+    setFacets([
+      { field: "namespace", values: ["default"] },
+      { field: "status", values: ["Running"] },
+    ]);
+
+    const { baseElement } = renderList();
+
+    expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f"]);
+  });
+
+  it("combines three facets", () => {
+    setFacets([
+      { field: "namespace", values: ["default"] },
+      { field: "status", values: ["Running", "Pending"] },
+      { field: "labels", values: ["app=api"] },
+    ]);
+
+    const { baseElement } = renderList();
+
+    expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f", "staging-api-4a8e"]);
+  });
+
+  it("ANDs the plain search box on top of the facets", () => {
+    setFacets([{ field: "namespace", values: ["kube-system"] }]);
+    setSearch("worker");
+
+    const { baseElement } = renderList();
+
+    expect(visibleNames(baseElement)).toEqual(["dev-worker-1f2a"]);
+  });
+
+  describe("a facet naming a field this view does not have", () => {
+    // The linked search carries facets across views, so this is routine rather
+    // than exotic. Applying it would empty the list for a positive operator and
+    // filter nothing for a negative one - the same chip looking broken or
+    // lying depending on its operator. It is skipped instead, and the chip is
+    // struck through so the list is never silently unfiltered.
+    it("is skipped rather than matching nothing", () => {
+      setFacets([{ field: "node", values: ["worker-1"] }]);
+
+      const { baseElement } = renderList();
+
+      expect(visibleNames(baseElement)).toEqual(items.map((i) => i.getName()));
+    });
+
+    it("is skipped for a negative operator too", () => {
+      setFacets([{ field: "node", values: ["worker-1"], op: "notContains" }]);
+
+      const { baseElement } = renderList();
+
+      expect(visibleNames(baseElement)).toEqual(items.map((i) => i.getName()));
+    });
+
+    it("leaves the facets that do apply working", () => {
+      setFacets([
+        { field: "node", values: ["worker-1"] },
+        { field: "namespace", values: ["default"] },
+      ]);
+
+      const { baseElement } = renderList();
+
+      expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f", "staging-api-4a8e"]);
+    });
+  });
+
+  describe("operators", () => {
+    it("filters on an exact value with equals", () => {
+      // "default" is also a substring of nothing else here, so use a status
+      // where contains and equals genuinely differ.
+      setFacets([{ field: "status", values: ["Run"], op: "equals" }]);
+
+      const { baseElement } = renderList();
+
+      expect(visibleNames(baseElement)).toEqual([]);
+    });
+
+    it("matches the full value with equals", () => {
+      setFacets([{ field: "status", values: ["Running"], op: "equals" }]);
+
+      const { baseElement } = renderList();
+
+      expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f", "prod-web-2b1c"]);
+    });
+
+    it("excludes with does-not-contain", () => {
+      setFacets([{ field: "name", values: ["api"], op: "notContains" }]);
+
+      const { baseElement } = renderList();
+
+      expect(visibleNames(baseElement)).toEqual(["prod-web-2b1c", "dev-worker-1f2a"]);
+    });
+
+    it("excludes with not-equals", () => {
+      setFacets([{ field: "namespace", values: ["default"], op: "notEquals" }]);
+
+      const { baseElement } = renderList();
+
+      expect(visibleNames(baseElement)).toEqual(["prod-web-2b1c", "dev-worker-1f2a"]);
+    });
+
+    it("ANDs a positive and a negative facet", () => {
+      setFacets([
+        { field: "status", values: ["Running"], op: "equals" },
+        { field: "name", values: ["web"], op: "notContains" },
+      ]);
+
+      const { baseElement } = renderList();
+
+      expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f"]);
+    });
+
+    it("keeps two operators on the same field as independent filters", () => {
+      setFacets([
+        { field: "name", values: ["prod"], op: "contains" },
+        { field: "name", values: ["web"], op: "notContains" },
+      ]);
+
+      const { baseElement } = renderList();
+
+      expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f"]);
+    });
+
+    it("excludes an item when one of a field's many texts matches a negative", () => {
+      setFacets([{ field: "labels", values: ["app=api"], op: "notContains" }]);
+
+      const { baseElement } = renderList();
+
+      expect(visibleNames(baseElement)).toEqual(["prod-web-2b1c", "dev-worker-1f2a"]);
+    });
+
+    describe("regular expressions", () => {
+      it("honours anchors with matches", () => {
+        setFacets([{ field: "name", values: ["^prod"], op: "matches" }]);
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f", "prod-web-2b1c"]);
+      });
+
+      it("is unanchored unless the pattern says otherwise", () => {
+        setFacets([{ field: "name", values: ["api"], op: "matches" }]);
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f", "staging-api-4a8e"]);
+      });
+
+      it("honours alternation", () => {
+        setFacets([{ field: "name", values: ["^(staging|dev)-"], op: "matches" }]);
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(["staging-api-4a8e", "dev-worker-1f2a"]);
+      });
+
+      it("excludes with notMatches", () => {
+        setFacets([{ field: "name", values: ["^prod"], op: "notMatches" }]);
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(["staging-api-4a8e", "dev-worker-1f2a"]);
+      });
+
+      it("mixes a regex facet with a literal one", () => {
+        setFacets([
+          { field: "name", values: ["-api-"], op: "contains" },
+          { field: "namespace", values: ["^default$"], op: "matches" },
+        ]);
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f", "staging-api-4a8e"]);
+      });
+
+      it("filters nothing while the pattern is still incomplete", () => {
+        setFacets([{ field: "name", values: ["^(prod"], op: "matches" }]);
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(items.map((i) => i.getName()));
+      });
+
+      it("applies character classes, which lowercasing the source would break", () => {
+        setFacets([{ field: "namespace", values: ["^[a-z]+-[a-z]+$"], op: "matches" }]);
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(["prod-web-2b1c", "dev-worker-1f2a"]);
+      });
+    });
+
+    describe("the plain search box", () => {
+      it("is literal by default, so metacharacters match nothing", () => {
+        setSearch("^prod");
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual([]);
+      });
+
+      it("matches as a substring across every field", () => {
+        setSearch("kube-system");
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(["prod-web-2b1c", "dev-worker-1f2a"]);
+      });
+
+      // Picking an operator has to re-filter straight away, not wait for a chip.
+      it("applies the armed operator to the text being typed", () => {
+        setSearch("^prod");
+        setSearchOperator("matches");
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f", "prod-web-2b1c"]);
+      });
+
+      it("applies a negative operator to the text being typed", () => {
+        setSearch("api");
+        setSearchOperator("notContains");
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(["prod-web-2b1c", "dev-worker-1f2a"]);
+      });
+
+      it("falls back to contains for an unknown operator in the param", () => {
+        setSearch("prod-");
+        di.inject(searchOperatorUrlPageParamInjectable).set("startsWith");
+
+        const { baseElement } = renderList();
+
+        expect(visibleNames(baseElement)).toEqual(["prod-api-7d9f", "prod-web-2b1c"]);
+      });
+    });
+  });
+});

--- a/packages/core/src/renderer/components/namespaces/route.tsx
+++ b/packages/core/src/renderer/components/namespaces/route.tsx
@@ -80,7 +80,12 @@ const NonInjectedNamespacesRoute = ({
         [columnId.age]: (namespace) => -namespace.getCreationTimestamp(),
         [columnId.status]: (namespace) => namespace.getStatus(),
       }}
-      searchFilters={[(namespace) => namespace.getSearchFields(), (namespace) => namespace.getStatus()]}
+      searchFields={[
+        { id: "name", title: "Name", getValue: (namespace) => namespace.getName() },
+        { id: "labels", title: "Labels", getValue: (namespace) => namespace.getLabels() },
+        { id: "status", title: "Status", getValue: (namespace) => namespace.getStatus() },
+        { id: "uid", title: "UID", hidden: true, getValue: (namespace) => namespace.getId() },
+      ]}
       renderHeaderTitle="Namespaces"
       renderTableHeader={[
         { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },

--- a/packages/core/src/renderer/components/network-services/services.tsx
+++ b/packages/core/src/renderer/components/network-services/services.tsx
@@ -68,10 +68,15 @@ class NonInjectedServices extends React.Component<Dependencies> {
             [columnId.age]: (service) => -service.getCreationTimestamp(),
             [columnId.status]: (service) => service.getStatus(),
           }}
-          searchFilters={[
-            (service) => service.getSearchFields(),
-            (service) => service.getSelector().join(" "),
-            (service) => service.getPorts().join(" "),
+          searchFields={[
+            { id: "name", title: "Name", getValue: (service) => service.getName() },
+            { id: "namespace", title: "Namespace", getValue: (service) => service.getNs() },
+            { id: "labels", title: "Labels", getValue: (service) => service.getLabels() },
+            { id: "type", title: "Type", getValue: (service) => service.getType() },
+            { id: "selector", title: "Selector", getValue: (service) => service.getSelector() },
+            { id: "ports", title: "Ports", getValue: (service) => service.getPorts().join(" ") },
+            { id: "clusterIp", title: "Cluster IP", getValue: (service) => service.getClusterIp() },
+            { id: "uid", title: "UID", hidden: true, getValue: (service) => service.getId() },
           ]}
           renderHeaderTitle="Services"
           renderTableHeader={[

--- a/packages/core/src/renderer/components/nodes/route.tsx
+++ b/packages/core/src/renderer/components/nodes/route.tsx
@@ -462,16 +462,18 @@ class NonInjectedNodesRoute extends React.Component<Dependencies> {
             [columnId.schedulable]: (node) => (node.isUnschedulable() ? "False" : "True"),
             [columnId.conditions]: (node) => node.getNodeConditionText(),
           }}
-          searchFilters={[
-            (node) => node.getSearchFields(),
-            (node) => node.getRoleLabels(),
-            (node) => node.getKubeletVersion(),
-            (node) => node.getNodeConditionText(),
-            (node) => node.getInternalIP(),
-            (node) => node.getExternalIP(),
-            (node) => getInstanceType(node),
-            (node) => getNodeGroup(node),
-            (node) => getCapacityType(node),
+          searchFields={[
+            { id: "name", title: "Name", getValue: (node) => node.getName() },
+            { id: "labels", title: "Labels", getValue: (node) => node.getLabels() },
+            { id: "roles", title: "Roles", getValue: (node) => node.getRoleLabels() },
+            { id: "conditions", title: "Conditions", getValue: (node) => node.getNodeConditionText() },
+            { id: "kubelet", title: "Kubelet version", getValue: (node) => node.getKubeletVersion() },
+            { id: "internalIp", title: "Internal IP", getValue: (node) => node.getInternalIP() },
+            { id: "externalIp", title: "External IP", getValue: (node) => node.getExternalIP() },
+            { id: "instanceType", title: "Instance type", getValue: (node) => getInstanceType(node) },
+            { id: "nodeGroup", title: "Node group", getValue: (node) => getNodeGroup(node) },
+            { id: "capacityType", title: "Capacity type", getValue: (node) => getCapacityType(node) },
+            { id: "uid", title: "UID", hidden: true, getValue: (node) => node.getId() },
           ]}
           renderHeaderTitle="Nodes"
           renderTableHeader={[

--- a/packages/core/src/renderer/components/workloads-deployments/deployments.tsx
+++ b/packages/core/src/renderer/components/workloads-deployments/deployments.tsx
@@ -71,7 +71,14 @@ class NonInjectedDeployments extends React.Component<Dependencies> {
             [columnId.age]: (deployment) => -deployment.getCreationTimestamp(),
             [columnId.condition]: (deployment) => deployment.getConditionsText(),
           }}
-          searchFilters={[(deployment) => deployment.getSearchFields(), (deployment) => deployment.getConditionsText()]}
+          searchFields={[
+            { id: "name", title: "Name", getValue: (deployment) => deployment.getName() },
+            { id: "namespace", title: "Namespace", getValue: (deployment) => deployment.getNs() },
+            { id: "labels", title: "Labels", getValue: (deployment) => deployment.getLabels() },
+            { id: "selector", title: "Selector", getValue: (deployment) => deployment.getSelectors() },
+            { id: "conditions", title: "Conditions", getValue: (deployment) => deployment.getConditionsText() },
+            { id: "uid", title: "UID", hidden: true, getValue: (deployment) => deployment.getId() },
+          ]}
           renderHeaderTitle="Deployments"
           defaultHiddenTableColumns={[columnId.replicas]}
           renderTableHeader={[

--- a/packages/core/src/renderer/components/workloads-pods/pods.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pods.tsx
@@ -50,11 +50,14 @@ const NonInjectedPods = observer((props: Dependencies) => {
         tableId="workloads_pods"
         isConfigurable
         defaultHiddenTableColumns={["ip", "node", "qos"]}
-        searchFilters={[
-          (pod) => pod.getSearchFields(),
-          (pod) => pod.getStatusMessage(),
-          (pod) => pod.status?.podIP,
-          (pod) => pod.getNodeName(),
+        searchFields={[
+          { id: "name", title: "Name", getValue: (pod) => pod.getName() },
+          { id: "namespace", title: "Namespace", getValue: (pod) => pod.getNs() },
+          { id: "labels", title: "Labels", getValue: (pod) => pod.getLabels() },
+          { id: "status", title: "Status", getValue: (pod) => pod.getStatusMessage() },
+          { id: "ip", title: "IP", getValue: (pod) => pod.status?.podIP },
+          { id: "node", title: "Node", getValue: (pod) => pod.getNodeName() },
+          { id: "uid", title: "UID", hidden: true, getValue: (pod) => pod.getId() },
         ]}
         renderHeaderTitle="Pods"
         renderTableHeader={[]}


### PR DESCRIPTION
Fixes #1536

**Description of changes:**

Search boxes now build **facets**: type text, pick a field from the dropdown, and it
becomes a removable chip inside the field. Values within a facet are OR-ed and
separate facets are AND-ed, which covers the `and` / `or` / `not` combinations the
issue asks for.

<img width="371" height="367" alt="image" src="https://github.com/user-attachments/assets/0c2b66cd-1db4-40f8-b21f-3855658a4156" />

Six operators: `:` contains, `=` equals, `=~` matches regex, `!:` does not contain,
`!=` not equals, `!~` does not match regex. Picking one re-filters immediately;
committing a chip freezes it, so a chip keeps meaning what it meant when it was
added.

The issue suggested Slack's syntax as a possible pattern. This goes with visible
chips instead of modifiers typed into the query, so the active filter is always on
screen and there is no syntax to learn. Happy to revisit if you would rather have the
Slack style.

Named **saved searches** per view, persisted with the user's preferences. Applying one
restores the whole query.

<img width="492" height="157" alt="image" src="https://github.com/user-attachments/assets/985c5b4f-6f90-4f01-8b57-b631fb2190dc" />

Eight views expose named fields: Pods, Deployments, Services, Events, Nodes, Secrets,
Config Maps and Namespaces. Every other view keeps exactly its current behaviour,
offering only "All fields".

**Design notes worth a reviewer's attention:**

A facet naming a field the current view does not have is **skipped and shown struck
through**, not applied. Applying it would empty the list for a positive operator and
filter nothing for a negative one, so the same chip would look broken or lie about
being applied depending on its operator. It is kept, so it applies again on a view
that does have the field - which matters because the linked search carries facets
across views. The label travels with the facet, so the chip still reads properly
where the field is unknown.

<img width="488" height="53" alt="image" src="https://github.com/user-attachments/assets/b72f9c56-8e6a-431e-88dd-d5395a326f61" />

- `search` keeps its meaning; `searchOp` and `facets` are new params beside it, so
  existing links and `searchUrlParam.set(...)` callers (the catalog's label badges,
  for one) behave exactly as before. A malformed `facets` param degrades to "no
  facets" rather than breaking the view.
- Regular expressions are **unanchored**: in a search box `=~ ngin` has to find
  `my-nginx`. Anchor explicitly with `^...$`.
- Negative operators with several values mean "none of them". OR-ing negations would
  be true for almost everything.
- `Input` gains a `contentLeft` prop, symmetric to the existing `contentRight`, so the
  chips render inside the field. It is the only change here touching a shared
  component, and it is purely additive.
- The linked search now carries the whole query rather than just the text. Carrying
  only the text turned a faceted search into a bare query when navigating away and
  back, since routing pushes a path with no query string.

**Testing:**

- 157 new unit tests covering the facet model, the operators, URL round-tripping and
  the filtering through `ItemListLayout`.
- Full core suite green on Linux: 2626 passed, 0 failed.
- `type:check`, `biome check` and `build:di` clean.
