### PR TITLE
Fix TS2883 portability errors in the extensions declaration emit

### DIFF
--- a/packages/core/src/main/catalog-sync-to-renderer/broadcaster.injectable.ts
+++ b/packages/core/src/main/catalog-sync-to-renderer/broadcaster.injectable.ts
@@ -9,11 +9,17 @@ import { debounce } from "es-toolkit/compat";
 import broadcastMessageInjectable from "../../common/ipc/broadcast-message.injectable";
 import { catalogItemsChannel } from "../../common/ipc/catalog";
 
+import type { DebouncedFunc } from "es-toolkit/compat";
+
 import type { CatalogEntity } from "../../common/catalog";
 
+// The return type is annotated explicitly because `debounce` with `leading`
+// infers `DebouncedFuncLeading`, which `es-toolkit/compat` does not export;
+// without the annotation the inferred type is not portable in declaration
+// emit (TS2883). `DebouncedFunc` is exported and is all consumers need.
 const catalogSyncBroadcasterInjectable = getInjectable({
   id: "catalog-sync-broadcaster",
-  instantiate: (di) => {
+  instantiate: (di): DebouncedFunc<(items: CatalogEntity[]) => void> => {
     const broadcastMessage = di.inject(broadcastMessageInjectable);
 
     return debounce(

--- a/packages/random/index.ts
+++ b/packages/random/index.ts
@@ -6,3 +6,5 @@
 
 export { randomFeature } from "./src/feature";
 export { getRandomIdInjectionToken } from "./src/get-random-id.injectable";
+
+export type { GetRandomId } from "./src/get-random-id.injectable";


### PR DESCRIPTION
Blocker 1 of #2363: `tsc -p tsconfig.dts.generated.json` failed with five TS2883 "inferred type ... is likely not portable" errors, so `pnpm --filter @freelensapp/extensions build:dist` never reached the rollup step.

- Export the `GetRandomId` type from `@freelensapp/random`. The four dock injectables infer it from `di.inject(getRandomIdInjectionToken)`; it was declared beside the token but not re-exported from the package entry point, so declaration emit could only name it through a deep node_modules path. This alone clears all four errors.
- Annotate the catalog sync broadcaster with `DebouncedFunc<(items: CatalogEntity[]) => void>`. `debounce(..., { leading: true })` infers `DebouncedFuncLeading`, which `es-toolkit/compat` does not re-export; `DebouncedFunc` is exported and is all consumers use.

Verified:

- `pnpm --filter @freelensapp/extensions build:dist:declarations` exits 0.
- `pnpm type:check` green.
- `biome check` clean on both files.

Blocker 2 (TypeScript 7 removed the JS compiler API, so `rollup-plugin-dts` and `scripts/build-shim.mjs` cannot load) is deliberately not addressed here - see the analysis and recommendation in #2363.

Refs #2363

Generated with [Claude Code](https://claude.ai/code)

| Model: `claude-opus-5[1m]`