### PR TITLE
fix: prevent multiple file/folder dialogs from opening simultaneously

### DIFF
--- a/packages/core/src/features/path-picking-dialog/renderer/pick-paths.injectable.ts
+++ b/packages/core/src/features/path-picking-dialog/renderer/pick-paths.injectable.ts
@@ -16,15 +16,26 @@ const openPathPickingDialogInjectable = getInjectable({
   id: "open-path-picking-dialog",
   instantiate: (di): OpenPathPickingDialog => {
     const requestFromChannel = di.inject(requestFromChannelInjectionToken);
+    let isDialogOpen = false;
 
     return async (options) => {
-      const { onPick, onCancel, ...dialogOptions } = options;
-      const response = await requestFromChannel(openPathPickingDialogChannel, dialogOptions);
+      if (isDialogOpen) {
+        return;
+      }
 
-      if (response.canceled) {
-        await onCancel?.();
-      } else {
-        await onPick?.(response.paths);
+      isDialogOpen = true;
+
+      try {
+        const { onPick, onCancel, ...dialogOptions } = options;
+        const response = await requestFromChannel(openPathPickingDialogChannel, dialogOptions);
+
+        if (response.canceled) {
+          await onCancel?.();
+        } else {
+          await onPick?.(response.paths);
+        }
+      } finally {
+        isDialogOpen = false;
       }
     };
   },

--- a/packages/core/src/renderer/components/path-picker/path-picker.tsx
+++ b/packages/core/src/renderer/components/path-picker/path-picker.tsx
@@ -8,6 +8,7 @@ import { Button } from "@freelensapp/button";
 import { cssNames } from "@freelensapp/utilities";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import { observer } from "mobx-react";
+import React from "react";
 import openPathPickingDialogInjectable from "../../../features/path-picking-dialog/renderer/pick-paths.injectable";
 
 import type { FileFilter, OpenDialogOptions } from "electron";
@@ -36,14 +37,27 @@ interface Dependencies {
 
 const NonInjectedPathPicker = observer((props: PathPickerProps & Dependencies) => {
   const { className, disabled, openPathPickingDialog, ...pickOpts } = props;
+  const [isDialogOpen, setIsDialogOpen] = React.useState(false);
 
   return (
     <Button
       primary
       label={pickOpts.message}
-      disabled={disabled}
+      disabled={disabled || isDialogOpen}
       className={cssNames("PathPicker", className)}
-      onClick={() => void openPathPickingDialog(pickOpts)}
+      onClick={async () => {
+        if (isDialogOpen) {
+          return;
+        }
+
+        setIsDialogOpen(true);
+
+        try {
+          await openPathPickingDialog(pickOpts);
+        } finally {
+          setIsDialogOpen(false);
+        }
+      }}
     />
   );
 });


### PR DESCRIPTION
## Description

Clicking the + button of the Clusters catalog (or any other path picking button) several times in a row opens several native file/folder dialogs at once: the dialog is opened without a parent window, so nothing prevents a second request while the first one is still open.

This PR inherits #2414 by @waterWang and keeps their commit as is: a guard in the `openPathPickingDialog` injectable so that only one dialog can be open at a time, plus a disabled state on the `PathPicker` button while its dialog is open.

A second commit on top of it:

- releases the guard as soon as the native dialog closes, before awaiting `onPick` or `onCancel`, so that a long running `onPick` (for example an extension install) does not silently ignore every other path picking dialog of the application in the meantime;
- adds a unit test for the one dialog at a time behaviour: a second request is ignored while a dialog is open, and a dialog can be opened again as soon as the previous one closes, even if its `onPick` is still running.

## Verification

- The unit test fails on `main` (no guard) and passes with the fix.
- Built app driven with Playwright: three quick clicks on the + button open a single dialog, the button works again once the dialog closes, and the `PathPicker` button in Preferences is disabled only while its dialog is open.
- Biome, Trunk and type check are green locally.

Supersedes #2414

Fixes #1850
